### PR TITLE
Dockerfile with Python client and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get -y install git python3-dev python3-pip libleveldb-dev
+
+RUN git clone https://github.com/CityOfZion/neo-python.git
+
+WORKDIR neo-python
+
+RUN pip3 install -r requirements.txt
+
+CMD python3 prompt.py


### PR DESCRIPTION
Using this file, the client can be set up more easily. Having Docker installed, it is just "docker build . -t neo-python" from the main directory of the repository and "docker run -it neo-python" to start the client.