### PR TITLE
fix for bytearray slice end calculation for SUBSTR opcode

### DIFF
--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -328,7 +328,7 @@ class ExecutionEngine():
                     return
 
                 x = estack.Pop().GetByteArray()
-                estack.PushT( x[index:count])
+                estack.PushT( x[index:count+index])
 
             elif opcode == LEFT:
 


### PR DESCRIPTION
Fix to get correct return from SUBSTR opcode (bytearray slice operation needed start:end instead of start:length)