### PR TITLE
removed unused keyword "contract" from testinvoke in help output

### DIFF
--- a/prompt.py
+++ b/prompt.py
@@ -109,7 +109,7 @@ class PromptInterface(object):
                 'wallet {verbose}',
                 'wallet rebuild {start block}',
                 'send {assetId or name} {address} {amount}',
-                'testinvoke contract {contract hash} {params}',
+                'testinvoke {contract hash} {params}',
                 'invoke',
                 'cancel',
                 ]


### PR DESCRIPTION
The help for testinvoke had an extra "contract" keyword that didn't reflect the actual command syntax