### PR TITLE
added THROW and THROWIFNOT opcodes to engine

### DIFF
--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -752,6 +752,15 @@ class ExecutionEngine():
 
                 estack.PushT(Struct(items))
 
+            elif opcode == THROW:
+                self._VMState |= VMState.FAULT
+                return
+
+            elif opcode == THROWIFNOT:
+                if estack.Pop().GetBoolean() == False:
+                    self._VMState |= VMState.FAULT
+                    return
+
             else:
 
                 self._VMState |= VMState.FAULT

--- a/neo/VM/OpCode.py
+++ b/neo/VM/OpCode.py
@@ -38,6 +38,11 @@ SYSCALL = b'\x68'
 TAILCALL = b'\x69'
 
 
+# Exceptions
+THROW = b'\xf0'
+THROWIFNOT = b'\xf1'
+
+
 #  Stack
 DUPFROMALTSTACK = b'\x6A'
 TOALTSTACK = b'\x6B' #  Puts the input onto the top of the alt stack. Removes it from the main stack.


### PR DESCRIPTION
Two new opcodes for exception handling were added to neo-vm on Aug 22, causing transactions with multiple invocations in neo-python's implementation to halt execution after the first invocation due to the trailing unknown opcode