### PR TITLE
Not enough values to unpack (expected 4, got 2)

### DIFF
--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -234,12 +234,12 @@ def test_invoke(script, wallet, outputs):
 #            tx.Gas = Fixed8.One()
 #            tx.Attributes = []
 #            return tx, []
-            return None,[]
+            return None,None, None, None
 
     except Exception as e:
         print("COULD NOT EXECUTE %s " % e)
 
-    return None,[]
+    return None,None, None, None
 
 
 


### PR DESCRIPTION
When contract test invoke is not successful, got error message ValueError: not enough values to unpack (expected 4, got 2)