### PR TITLE
fix Pop() order in Block_GetTransaction and Account_GetBalance

### DIFF
--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -440,8 +440,8 @@ class StateReader(InteropService):
 
     def Block_GetTransaction(self, engine):
 
-        block = engine.EvaluationStack.Pop().GetInterface('neo.Core.Block.Block')
         index = engine.EvaluationStack.Pop().GetBigInteger()
+        block = engine.EvaluationStack.Pop().GetInterface('neo.Core.Block.Block')
 
         if block is None or index < 0 or index > len(block.Transactions):
             return False
@@ -597,8 +597,8 @@ class StateReader(InteropService):
 
     def Account_GetBalance(self, engine):
 
-        account = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AccountState.AccountState')
         assetId = UInt256( data=engine.EvaluationStack.Pop().GetByteArray())
+        account = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AccountState.AccountState')
 
         if account is None:
             return False


### PR DESCRIPTION
Block_GetTransaction and Account_GetBalance both pop their arguments off the stack in the wrong order. This is also a problem in the core Neo code, and I have submitted PR #83 in that repository to fix the issue there as well.