### PR TITLE
close existing wallet before creating new one

### DIFF
--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -43,6 +43,7 @@ class UserWallet(Wallet):
         self.__log.debug("initialized user wallet!! %s " % self)
 
     def BuildDatabase(self):
+        PWDatabase.Destroy()
         PWDatabase.Initialize(self._path)
         db = PWDatabase.ContextDB()
         try:


### PR DESCRIPTION
When using the `create wallet` command, if there is an existing wallet already open it will become permanently corrupted instead of a new database file being created. 

Because the database instance already exists, the code will currently write the new keypair into the existing file and overwrite the master key, causing the wallet to no longer be decryptable and throwing an exception any time it is opened again. 

This change will force any existing wallet database instance to be closed before creating a new one.