### PR TITLE
prompt.py: Allow quitting with CTRL-D. Before it threw an exception.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Contracts
 # Distribution / packaging
 .Python
 env/
+.venv*
 build/
 develop-eggs/
 dist/

--- a/prompt.py
+++ b/prompt.py
@@ -693,8 +693,11 @@ class PromptInterface(object):
                                     get_bottom_toolbar_tokens=self.get_bottom_toolbar,
                                     style=self.token_style)
                 except EOFError:
-                    # Control-D pressed
+                    # Control-D pressed: quit
                     return self.quit()
+                except KeyboardInterrupt:
+                    # Control-C pressed: do nothing
+                    continue
 
 
             if self._gathering_password:

--- a/prompt.py
+++ b/prompt.py
@@ -686,12 +686,15 @@ class PromptInterface(object):
                 result = prompt("password> ", is_password=True)
 
             else:
-                result = prompt("neo> ",
-                                completer=self.completer,
-                                history=self.history,
-                                get_bottom_toolbar_tokens=self.get_bottom_toolbar,
-                                style=self.token_style)
-
+                try:
+                    result = prompt("neo> ",
+                                    completer=self.completer,
+                                    history=self.history,
+                                    get_bottom_toolbar_tokens=self.get_bottom_toolbar,
+                                    style=self.token_style)
+                except EOFError:
+                    # Control-D pressed
+                    return self.quit()
 
 
             if self._gathering_password:


### PR DESCRIPTION
When in the prompt users press CTRL + D, it threw an Exception before. Added an exception handler to quit the prompt.

This solution is recommended in the prompt-toolkit example here: https://github.com/jonathanslenders/python-prompt-toolkit/tree/master/examples/tutorial