### PR TITLE
implemented multi-sig capability

### DIFF
--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -327,8 +327,9 @@ class Transaction(Inventory, InventoryMixin):
         return tx
 
     def DeserializeUnsigned(self, reader):
-        if reader.ReadByte() != self.Type:
-            raise Exception('incorrect type')
+        txtype = reader.ReadByte()
+        if txtype != int.from_bytes(self.Type, 'little'):
+            raise Exception('incorrect type {}, wanted {}'.format(txtype, int.from_bytes(self.Type, 'little')))
         self.DeserializeUnsignedWithoutType(reader)
 
     def DeserializeUnsignedWithoutType(self,reader):

--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -355,11 +355,8 @@ class UserWallet(Wallet):
             signature_contract = None
             for ct in self._contracts.values():
                 if ct.PublicKeyHash == k.PublicKeyHash:
-                    signature_contract = ct
-            if signature_contract:
-                addr = signature_contract.Address
-
-                jsn.append( {'Address': addr, 'Public Key': pub.decode('utf-8')})
+                    addr = ct.Address
+                    jsn.append( {'Address': addr, 'Public Key': pub.decode('utf-8')})
 
         return jsn
 

--- a/neo/Prompt/Commands/LoadSmartContract.py
+++ b/neo/Prompt/Commands/LoadSmartContract.py
@@ -217,3 +217,32 @@ def generate_deploy_script(script, name='test', version='test', author='test', e
     script = sb.ToArray()
 
     return script
+
+
+def ImportMultiSigContractAddr(wallet, args):
+
+    if len(args) < 4:
+        print("please specify multisig contract like such: 'import multisig {pubkey in wallet} {minimum # of signatures required} {signing pubkey 1} {signing pubkey 2}...'")
+        return
+
+    if wallet is None:
+        print("please open a wallet")
+        return
+
+    pubkey = get_arg(args, 0)
+    m = get_arg(args, 1)
+    publicKeys = args[2:]
+
+    if publicKeys[1]:
+
+        pubkey_script_hash = Crypto.ToScriptHash(pubkey,unhex=True)
+
+        verification_contract = Contract.CreateMultiSigContract(pubkey_script_hash, int(m), publicKeys)
+
+        address = verification_contract.Address
+
+        wallet.AddContract(verification_contract)
+
+        print("Added multi-sig contract address %s to wallet" % address)
+
+    return 'Hello'

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -104,7 +104,7 @@ def construct_and_send(prompter, wallet, arguments):
 
         else:
             print ("Transaction initiated, but the signature is incomplete")
-            print(context.ToJson())
+            print(json.dumps(context.ToJson()))
             return
 
 

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -99,11 +99,14 @@ def construct_and_send(prompter, wallet, arguments):
             if relayed:
                 print("Relayed Tx: %s " % tx.Hash.ToString())
             else:
+
                 print("Could not relay tx %s " % tx.Hash.ToString())
 
         else:
-            print("Could not sign transaction")
+            print ("Transaction initiated, but the signature is incomplete")
+            print(context.ToJson())
             return
+
 
 
 
@@ -180,3 +183,26 @@ def construct_contract_withdrawal(prompter, wallet, arguments):
 
     if withdraw_constructed_tx is not None:
         return withdraw_constructed_tx
+
+
+def parse_and_sign(prompter, wallet, jsn):
+
+    try:
+        context = ContractParametersContext.FromJson(jsn)
+        if context is None:
+            print("Failed to parse JSON")
+            return
+        #print("Parsed content: {}".format(json.dumps(context.ToJson(), indent=4)))
+        wallet.Sign(context)
+        if context.Completed:
+            print("Signature complete, relay now?")
+            return
+        else:
+            print ("Transaction initiated, but the signature is incomplete")
+            print(context.ToJson())
+            return
+
+    except Exception as e:
+        print("could not send: %s " % e)
+        traceback.print_stack()
+        traceback.print_exc()

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -77,9 +77,17 @@ def construct_and_send(prompter, wallet, arguments):
             return
 
         standard_contract = wallet.GetStandardAddress()
-        data = standard_contract.Data
-        tx.Attributes = [TransactionAttribute(usage=TransactionAttributeUsage.Script,
-                                              data=data)]
+
+        if scripthash_from is not None:
+            signer_contract = wallet.GetContract(scripthash_from)
+        else:
+            signer_contract = wallet.GetContract(standard_contract)
+
+        if signer_contract.IsMultiSigContract == False:
+
+            data = standard_contract.Data
+            tx.Attributes = [TransactionAttribute(usage=TransactionAttributeUsage.Script,
+                                               data=data)]
 
 
         context = ContractParametersContext(tx)

--- a/neo/SmartContract/Contract.py
+++ b/neo/SmartContract/Contract.py
@@ -15,6 +15,7 @@ from neo.SmartContract.ContractParameterType import ContractParameterType
 from neo.Core.VerificationCode import VerificationCode
 from neo.Core.Helper import Helper
 from neo.Cryptography.Helper import *
+from neo.Cryptography.ECCurve import ECDSA
 from autologging import logged
 
 
@@ -68,7 +69,7 @@ class Contract(SerializableMixin, VerificationCode):
     def Type(self):
         if self.IsStandard:
             return ContractType.SignatureContract
-        elif self.IsMultiSigContract():
+        elif self.IsMultiSigContract:
             return ContractType.MultiSigContract
         return ContractType.CustomContract
 
@@ -110,7 +111,7 @@ class Contract(SerializableMixin, VerificationCode):
 
 
     @staticmethod
-    def CreateMultiSigContract(publickKeyHash, m, publicKeys):
+    def CreateMultiSigContract(publicKeyHash, m, publicKeys):
 
         pk = [ECDSA.decode_secp256r1(p).G for p in publicKeys]
         return Contract(Contract.CreateMultiSigRedeemScript(m, pk),

--- a/neo/SmartContract/Contract.py
+++ b/neo/SmartContract/Contract.py
@@ -50,6 +50,20 @@ class Contract(SerializableMixin, VerificationCode):
 
         return True
 
+
+    @property
+    def IsMultiSigContract(self):
+        scp = binascii.unhexlify(self.Script)
+
+        if len(scp) < 37:
+            return False
+
+        if scp[len(scp)-1] != int.from_bytes(CHECKMULTISIG, 'little'):
+            return False
+
+        return True
+
+
     @property
     def Type(self):
         if self.IsStandard:
@@ -73,11 +87,6 @@ class Contract(SerializableMixin, VerificationCode):
         return Contract(redeemScript, parameterList, publicKeyHash)
 
 
-
-    @staticmethod
-    def CreateMultiSigContract(publickKeyHash, m, publicKeys):
-        raise NotImplementedError()
-
     @staticmethod
     def CreateMultiSigRedeemScript(m, publicKeys):
 
@@ -98,6 +107,16 @@ class Contract(SerializableMixin, VerificationCode):
         sb.add(CHECKMULTISIG)
 
         return sb.ToArray()
+
+
+    @staticmethod
+    def CreateMultiSigContract(publickKeyHash, m, publicKeys):
+
+        pk = [ECDSA.decode_secp256r1(p).G for p in publicKeys]
+        return Contract(Contract.CreateMultiSigRedeemScript(m, pk),
+                     bytearray([ContractParameterType.Signature] * 3),
+                     publicKeyHash)
+
 
     @staticmethod
     def CreateSignatureContract(publicKey):
@@ -142,10 +161,6 @@ class Contract(SerializableMixin, VerificationCode):
         writer.WriteUInt160(self.PublicKeyHash)
         writer.WriteVarBytes(self.ParameterList)
         writer.WriteVarBytes(self.Script)
-
-    def IsMultiSigContract(self):
-        #Not implemented
-        return False
 
 
     @staticmethod

--- a/neo/SmartContract/ContractParameterType.py
+++ b/neo/SmartContract/ContractParameterType.py
@@ -40,7 +40,7 @@ def ToName(param_type):
     for item in items:
         name = item[0]
         val = int(item[1])
-        print("name, val %s %s %s" % (name,val, param_type))
+        #print("name, val %s %s %s" % (name,val, param_type))
 
         if val == param_type:
             return name

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -798,9 +798,9 @@ class ExecutionEngine():
         else:
             op = self.CurrentContext.OpReader.ReadByte(do_ord=False)
 
-        opname = ToName(op)
+#        opname = ToName(op)
 #        print("____________________________________________________")
-        print("%02x -> %s" % (int.from_bytes(op,byteorder='little'), opname))
+#        print("%02x -> %s" % (int.from_bytes(op,byteorder='little'), opname))
 #        print("-----------------------------------")
 
         self.ops_processed += 1

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -612,7 +612,7 @@ class ExecutionEngine():
 
                 pubkeys = []
                 for i in range(0, n):
-                    pubkeys[i] = estack.Pop().GetByteArray()
+                    pubkeys.append(estack.Pop().GetByteArray())
 
                 m = estack.Pop().GetBigInteger()
 
@@ -623,7 +623,7 @@ class ExecutionEngine():
                 sigs = []
 
                 for i in range(0, m):
-                    m[i] = estack.Pop().GetByteArray()
+                    sigs.append(estack.Pop().GetByteArray())
 
                 message = self.ScriptContainer.GetMessage()
 
@@ -640,7 +640,7 @@ class ExecutionEngine():
                             i+=1
                         j+=1
 
-                        if m - i > j - n:
+                        if m - i > n - j:
                             fSuccess = False
 
                 except Exception as e:
@@ -798,9 +798,9 @@ class ExecutionEngine():
         else:
             op = self.CurrentContext.OpReader.ReadByte(do_ord=False)
 
-#        opname = ToName(op)
+        opname = ToName(op)
 #        print("____________________________________________________")
-#        print("%02x -> %s" % (int.from_bytes(op,byteorder='little'), opname))
+        print("%02x -> %s" % (int.from_bytes(op,byteorder='little'), opname))
 #        print("-----------------------------------")
 
         self.ops_processed += 1

--- a/prompt.py
+++ b/prompt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 
 import json

--- a/prompt.py
+++ b/prompt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 import json
@@ -794,6 +794,8 @@ class PromptInterface(object):
                             self.show_wallet(arguments)
                         elif command == 'send':
                             self.do_send(arguments)
+                        elif command == 'sign':
+                            self.do_sign(arguments)
                         elif command == 'block':
                             self.show_block(arguments)
                         elif command == 'tx':

--- a/prompt.py
+++ b/prompt.py
@@ -16,7 +16,7 @@ from neo.Network.NodeLeader import NodeLeader
 from neo.Prompt.Commands.Invoke import InvokeContract,TestInvokeContract,test_invoke,InvokeWithdrawTx
 from neo.Prompt.Commands.BuildNRun import BuildAndRun,LoadAndRun
 from neo.Prompt.Commands.LoadSmartContract import LoadContract,GatherContractDetails,ImportContractAddr,ImportMultiSigContractAddr
-from neo.Prompt.Commands.Send import construct_and_send,construct_contract_withdrawal
+from neo.Prompt.Commands.Send import construct_and_send,construct_contract_withdrawal,parse_and_sign
 from neo.Prompt.Commands.Wallet import DeleteAddress,ImportWatchAddr
 from neo.Prompt.Utils import get_arg
 from neo.Prompt.Notify import SubscribeNotifications

--- a/prompt.py
+++ b/prompt.py
@@ -15,7 +15,7 @@ from neo.Wallets.KeyPair import KeyPair
 from neo.Network.NodeLeader import NodeLeader
 from neo.Prompt.Commands.Invoke import InvokeContract,TestInvokeContract,test_invoke,InvokeWithdrawTx
 from neo.Prompt.Commands.BuildNRun import BuildAndRun,LoadAndRun
-from neo.Prompt.Commands.LoadSmartContract import LoadContract,GatherContractDetails,ImportContractAddr
+from neo.Prompt.Commands.LoadSmartContract import LoadContract,GatherContractDetails,ImportContractAddr,ImportMultiSigContractAddr
 from neo.Prompt.Commands.Send import construct_and_send,construct_contract_withdrawal
 from neo.Prompt.Commands.Wallet import DeleteAddress,ImportWatchAddr
 from neo.Prompt.Utils import get_arg
@@ -109,6 +109,7 @@ class PromptInterface(object):
                 'wallet {verbose}',
                 'wallet rebuild {start block}',
                 'send {assetId or name} {address} {amount}',
+                'sign {transaction in JSON format}',
                 'testinvoke {contract hash} {params}',
                 'invoke',
                 'cancel',
@@ -282,6 +283,9 @@ class PromptInterface(object):
             elif item == 'watch_addr':
                 return ImportWatchAddr(self.Wallet, get_arg(arguments,1))
 
+            elif item == 'multisig_addr':
+                return ImportMultiSigContractAddr(self.Wallet, arguments[1:])
+
 
 
         print("please specify something to import")
@@ -384,6 +388,9 @@ class PromptInterface(object):
     def do_send(self, arguments):
         construct_and_send(self, self.Wallet, arguments)
 
+    def do_sign(self, arguments):
+        jsn = get_arg(arguments)
+        parse_and_sign(self, self.Wallet, jsn)
 
     def show_state(self):
         height = Blockchain.Default().Height


### PR DESCRIPTION
This pull request implements multi-signature capability that is compatible with the latest neo-gui, i.e. you can begin a multi-sig transaction in either neo-python or neo-gui, then import and sign/relay the resulting JSON-serialized transaction in either client. 

This should allow people with private networks to claim all the NEO and GAS from the initial contract without having to use Windows at all.