### PR TITLE
fix for non-hexadecimal digit found error in leveldb

### DIFF
--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -150,7 +150,7 @@ class LevelDBBlockchain(Blockchain):
             if self._stored_header_count == 0:
                 headers = []
                 for key, value in self._db.iterator(prefix=DBPrefix.DATA_Block):
-                    dbhash = bytearray(value)[4:]
+                    dbhash = bytearray(value)[8:]
                     headers.append(  Header.FromTrimmedData(binascii.unhexlify(dbhash), 0))
 
                 headers.sort(key=lambda h: h.Index)


### PR DESCRIPTION
Users have reported occasional exceptions with leveldb code reporting `binascii.Error: Non-hexadecimal digit found` when restarting neo-python after a hard exit. This seems to occur in the code block starting with the `if` statement on line 150 of LevelDBBlockchain.py. This code is only executed if the database is opened in a state where it has been initialized with the genesis block but has not downloaded any headers from remote nodes yet.

Line 153 retrieves a value that is prefixed with a `long` encoded as a bytearray, followed by hex-encoded data. The code was treating the `long` as 4 bytes instead of 8 (as it is coded on line 531 when the data is stored), leading to the binascii module trying to decode 4 bytes of non-hexencoded data, leading to the exception.