### PR TITLE
Settings which are dynamically configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 ## Getting started
 
-You will need to install the libleveldb library. Install [Python 3.5](https://www.python.org/downloads/release/python-354/) to make sure you don't run into any issues with your version of Python being different than the current maintainer's version. Note that Python 3.6 is not currently supported due to incompatibilities with the byteplay module. 
+You will need to install the libleveldb library. Install [Python 3.5](https://www.python.org/downloads/release/python-354/) to make sure you don't run into any issues with your version of Python being different than the current maintainer's version. Note that Python 3.6 is not currently supported due to incompatibilities with the byteplay module.
 
 We have published a Youtube [video](https://youtu.be/oy6Z_zd42-4) to help get you started with this library. There are other videos under the [CityOfZion](https://www.youtube.com/channel/UCzlQUNLrRa8qJkz40G91iJg) Youtube channel.
 
@@ -65,7 +65,7 @@ apt-get -s install libleveldb-dev
 
 This is a bit more tricky...
 
-``` 
+```
 yum -y install development tools python35 python35-devel python35-pip readline-devel leveldb-devel libffi-devel
 ```
 
@@ -192,6 +192,20 @@ send { ASSET_ID } { ADDRESS } { AMOUNT }
 
 
 #### Extra notes
+
+To run the prompt on mainnet, you can use the cli argument `-m`:
+
+```
+$ python prompt.py -h
+usage: prompt.py [-h] [-m] [-c CONFIG]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -m, --mainnet         use MainNet instead of the default TestNet
+  -c CONFIG, --config CONFIG
+                        Use a specific config file
+```
+
 On OSX, if you would like to run the process in the background, even when your computer is sleeping, you can use the built in `caffeinate` command
 
 ```

--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -11,7 +11,7 @@ from neo.VM.OpCode import *
 from neo.Core.State.SpentCoinState import SpentCoinState
 from neo.Core.Helper import Helper
 from neo.SmartContract.Contract import Contract
-from neo import Settings
+from neo.Settings import settings
 from neo.Cryptography.Crypto import *
 from neo.Cryptography.Helper import *
 from collections import Counter
@@ -60,8 +60,8 @@ class Blockchain(object):
     @staticmethod
     def StandbyValidators():
         if len(Blockchain.__validators) < 1:
-            vlist = Settings.STANDBY_VALIDATORS
-            for pkey in Settings.STANDBY_VALIDATORS:
+            vlist = settings.STANDBY_VALIDATORS
+            for pkey in settings.STANDBY_VALIDATORS:
                 Blockchain.__validators.append( ECDSA.decode_secp256r1(pkey).G)
 
         return Blockchain.__validators

--- a/neo/Core/Helper.py
+++ b/neo/Core/Helper.py
@@ -7,7 +7,7 @@ from neo.VM.ScriptBuilder import ScriptBuilder
 from neo.SmartContract.ApplicationEngine import ApplicationEngine
 from neo.Fixed8 import Fixed8
 from neo.SmartContract import TriggerType
-from neo import Settings
+from neo.Settings import settings
 from base58 import b58decode
 import pdb
 class Helper(object):
@@ -51,7 +51,7 @@ class Helper(object):
 
         retVal = ms.ToArray()
         StreamManager.ReleaseStream(ms)
-        
+
         return retVal
 
 
@@ -60,7 +60,7 @@ class Helper(object):
         data = b58decode(address)
         if len(data) != 25:
             raise ValueError('Not correct Address, wrong length.')
-        if data[0] != Settings.ADDRESS_VERSION:
+        if data[0] != settings.ADDRESS_VERSION:
             raise ValueError('Not correct Coin Version')
 
         checksum = Crypto.Default().Hash256(data[:21])[:4]

--- a/neo/Core/TX/EnrollmentTransaction.py
+++ b/neo/Core/TX/EnrollmentTransaction.py
@@ -4,7 +4,7 @@ from neo.Core.TX.Transaction import Transaction,TransactionType
 import sys
 import binascii
 from neo.Cryptography.ECCurve import EllipticCurve,ECDSA
-from neo import Settings
+from neo.Settings import settings
 from neo.Fixed8 import Fixed8
 
 class EnrollmentTransaction(Transaction):
@@ -21,7 +21,7 @@ class EnrollmentTransaction(Transaction):
         return self.Size() + sys.getsizeof(int)
 
     def SystemFee(self):
-        return Fixed8( int(Settings.ENROLLMENT_TX_FEE))
+        return Fixed8( int(settings.ENROLLMENT_TX_FEE))
 
     def DeserializeExclusiveData(self, reader):
         if self.Version is not 0:

--- a/neo/Core/TX/IssueTransaction.py
+++ b/neo/Core/TX/IssueTransaction.py
@@ -8,7 +8,7 @@ Usage:
 from neo.Core.TX.Transaction import Transaction,TransactionType
 
 import random
-from neo import Settings
+from neo.Settings import settings
 from neo.Fixed8 import Fixed8
 
 
@@ -22,7 +22,7 @@ class IssueTransaction(Transaction):
         self.Type = TransactionType.IssueTransaction  # 0x40
 
     def SystemFee(self):
-        return Fixed8( int(Settings.ISSUE_TX_FEE))
+        return Fixed8(int(settings.ISSUE_TX_FEE))
 
 
     def GetScriptHashesForVerifying(self):

--- a/neo/Core/TX/PublishTransaction.py
+++ b/neo/Core/TX/PublishTransaction.py
@@ -4,7 +4,7 @@ from neo.Core.TX.Transaction import Transaction,TransactionType
 import sys
 from neo.Core.FunctionCode import FunctionCode
 import binascii
-from neo import Settings
+from neo.Settings import settings
 from neo.Fixed8 import Fixed8
 
 class PublishTransaction(Transaction):
@@ -24,7 +24,7 @@ class PublishTransaction(Transaction):
         self.Type = TransactionType.PublishTransaction
 
     def SystemFee(self):
-        return Fixed8(int(Settings.PUBLISH_TX_FEE))
+        return Fixed8(int(settings.PUBLISH_TX_FEE))
 
     def DeserializeExclusiveData(self, reader):
         if self.Version > 1:

--- a/neo/Core/TX/RegisterTransaction.py
+++ b/neo/Core/TX/RegisterTransaction.py
@@ -16,7 +16,7 @@ from neo.Cryptography.Helper import hash_to_wallet_address
 from neo.Cryptography.Crypto import Crypto
 from neo.Cryptography.ECCurve import EllipticCurve,ECDSA
 
-from neo import Settings
+from neo.Settings import settings
 from neo.Fixed8 import Fixed8
 
 
@@ -76,7 +76,7 @@ In English:
 
 
     def SystemFee(self):
-        return Fixed8(int(Settings.REGISTER_TX_FEE))
+        return Fixed8(int(settings.REGISTER_TX_FEE))
 
     def GetScriptHashesForVerifying(self):
         """Get ScriptHash From SignatureContract"""

--- a/neo/Core/test_genesis_block.py
+++ b/neo/Core/test_genesis_block.py
@@ -8,7 +8,7 @@ from neo.Core.Blockchain import Blockchain
 from neo.Core.Helper import Helper
 from neo.Core.Witness import Witness
 from neo.VM.OpCode import *
-from neo import Settings
+from neo.Settings import settings
 from neo.Cryptography.Crypto import Crypto
 from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
 import shutil
@@ -78,7 +78,7 @@ class GenesisBlockTestCase(VerifiableTestCase):
 
         script = Contract.CreateMultiSigRedeemScript(int(len(Blockchain.StandbyValidators()) / 2) + 1, Blockchain.StandbyValidators())
 
-        if Settings.MAGIC == 1953787457:
+        if settings.MAGIC == 1953787457:
             self.assertEqual(script, self.contractraw)
             out = Crypto.ToScriptHash(script)
 
@@ -125,7 +125,7 @@ class GenesisBlockTestCase(VerifiableTestCase):
 
 #        rd = block.RawData()
 
-        if Settings.MAGIC == 1953787457:
+        if settings.MAGIC == 1953787457:
             self.assertEqual(block.MerkleRoot.ToBytes(), self.testnet_genesis_merkle)
             self.assertEqual(txhashes, self.test_genesis_tx_hashes)
             self.assertEqual(block.RawData(), self.testnet_genesis_raw)

--- a/neo/Implementations/Blockchains/LevelDB/test_level_db.py
+++ b/neo/Implementations/Blockchains/LevelDB/test_level_db.py
@@ -5,7 +5,7 @@ from neo.Core.Header import Header
 from neo.IO.Helper import Helper
 import shutil
 import binascii
-from neo import Settings
+from neo.Settings import settings
 
 class LevelDBTest(NeoTestCase):
 
@@ -56,7 +56,7 @@ class LevelDBTest(NeoTestCase):
         block_one = Helper.AsSerializableWithType(hexdata,'neo.Core.Block.Block')
         header = block_one.Header
 
-        if Settings.MAGIC == 1953787457:
+        if settings.MAGIC == 1953787457:
             self.assertEqual(self._blockchain.CurrentHeaderHash, b'b3181718ef6167105b70920e4a8fbbd0a0a56aacf460d70e10ba6fa1668f1fef')
         else:
             self.assertEqual(self._blockchain.CurrentHeaderHash, b'd42561e3d30e15be6400b6df2f328e02d2bf6354c41dce433bc57687c82144bf')
@@ -93,4 +93,4 @@ class LevelDBTest(NeoTestCase):
 
 
         #test contains block functions
-#        self.assertTrue( self._blockchain.ContainsBlock(block_one_again.Index))
+#        self.assertTrue(self._blockchain.ContainsBlock(block_one_again.Index))

--- a/neo/Neo.py
+++ b/neo/Neo.py
@@ -1,7 +1,7 @@
 from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
 from neo.Implementations.Wallets.peewee.UserWallet import UserWallet
 from neo.Core.Blockchain import Blockchain
-from neo import Settings
+from neo.Settings import settings
 from neo.Network.LocalNode import LocalNode
 
 class CLI(object):
@@ -14,7 +14,7 @@ class CLI(object):
 
     def __init__(self):
 
-        self._blockchain = LevelDBBlockchain( Settings.LEVELDB_PATH )
+        self._blockchain = LevelDBBlockchain( settings.LEVELDB_PATH )
         Blockchain.RegisterBlockchain(self._blockchain)
         self._localnode = LocalNode()
         self._localnode.Start(20333, 20334)

--- a/neo/Network/Message.py
+++ b/neo/Network/Message.py
@@ -2,7 +2,7 @@ from neo.IO.Mixins import SerializableMixin
 from neo.IO.BinaryReader import BinaryReader
 from neo.IO.BinaryWriter import BinaryWriter
 from neo.IO.MemoryStream import MemoryStream,StreamManager
-from neo import Settings
+from neo.Settings import settings
 from neo.Core.Helper import Helper
 from neo.Cryptography.Helper import *
 import ctypes
@@ -35,7 +35,7 @@ class Message(SerializableMixin):
     def __init__(self, command=None, payload = None, print_payload=False):
 
         self.Command = command
-        self.Magic = Settings.MAGIC
+        self.Magic = settings.MAGIC
 
         if payload is None:
             payload = bytearray()

--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -24,7 +24,7 @@ from .InventoryType import InventoryType
 
 import random
 
-from neo import Settings
+from neo.Settings import settings
 
 @logged
 class NeoNode(Protocol):
@@ -274,7 +274,7 @@ class NeoNode(Protocol):
         self.SendSerializedMessage(m)
 
     def SendVersion(self):
-        m = Message("version", VersionPayload(Settings.NODE_PORT, self.remote_nodeid, Settings.VERSION_NAME))
+        m = Message("version", VersionPayload(settings.NODE_PORT, self.remote_nodeid, settings.VERSION_NAME))
         self.SendSerializedMessage(m)
 
 

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -4,7 +4,7 @@ from neo.Core.Blockchain import Blockchain as BC
 from neo.Core.TX.Transaction import Transaction
 from neo.Core.TX.MinerTransaction import MinerTransaction
 from neo.Network.NeoNode import NeoNode
-from neo import Settings
+from neo.Settings import settings
 
 
 from autologging import logged
@@ -63,7 +63,7 @@ class NodeLeader():
     def Start(self):
         # start up endpoints
         start_delay=0
-        for bootstrap in Settings.SEED_LIST:
+        for bootstrap in settings.SEED_LIST:
             host, port = bootstrap.split(":")
             self.ADDRS.append('%s:%s' % (host,port))
             reactor.callLater( start_delay, self.SetupConnection,host, port)

--- a/neo/Network/Payloads/test_payloads.py
+++ b/neo/Network/Payloads/test_payloads.py
@@ -6,7 +6,7 @@ from neo.IO.Helper import Helper as IOHelper
 from neo.IO.BinaryWriter import BinaryWriter
 from neo.IO.BinaryReader import BinaryReader
 from neo.IO.MemoryStream import MemoryStream,StreamManager
-from neo import Settings
+from neo.Settings import settings
 from neo.Core.Helper import Helper
 import random
 import binascii
@@ -79,7 +79,7 @@ class PayloadTestCase(NeoTestCase):
 
         self.assertEqual(dm.Command, 'version')
 
-        self.assertEqual(dm.Magic, Settings.MAGIC)
+        self.assertEqual(dm.Magic, settings.MAGIC)
 
         checksum = Message.GetChecksum(dm.Payload)
 

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -1,32 +1,77 @@
-
+"""
+The settings are dynamically configurable, for instance to set them depending on CLI arguments.
+By default these are the testnet settings, but you can reconfigure them by calling the `setup(..)`
+method.
+"""
 import json
 
+class SettingsHolder:
+    """
+    This class holds all the settings. Needs to be setup with one of the
+    `setup` methdos before using it.
+    """
+    MAGIC = None
+    ADDRESS_VERSION = None
+    STANDBY_VALIDATORS = None
+    SEED_LIST = None
 
-with open('protocol.testnet.json') as data_file:
+    ENROLLMENT_TX_FEE = None
+    ISSUE_TX_FEE = None
+    PUBLISH_TX_FEE = None
+    REGISTER_TX_FEE = None
 
-    data = json.load(data_file)
+    LEVELDB_PATH = None
+    NODE_PORT = None
+    WS_PORT = None
+    URI_PREFIX = None
+    VERSION_NAME = None
 
-config = data['ProtocolConfiguration']
+    # Helpers
+    @property
+    def is_mainnet(self):
+        """ Returns True if settings point to MainNet """
+        return self.NODE_PORT == 10333
 
+    @property
+    def is_testnet(self):
+        """ Returns True if settings point to TestNet """
+        return self.NODE_PORT == 20333
 
-MAGIC = config['Magic']
-ADDRESS_VERSION = config['AddressVersion']
-STANDBY_VALIDATORS = config['StandbyValidators']
-SEED_LIST = config['SeedList']
+    # Setup methods
+    def setup(self, config_file):
+        """ Load settings from a JSON config file """
+        with open(config_file) as data_file:
+            data = json.load(data_file)
 
-fees = config['SystemFee']
+        config = data['ProtocolConfiguration']
+        self.MAGIC = config['Magic']
+        self.ADDRESS_VERSION = config['AddressVersion']
+        self.STANDBY_VALIDATORS = config['StandbyValidators']
+        self.SEED_LIST = config['SeedList']
 
-ENROLLMENT_TX_FEE = fees['EnrollmentTransaction']
-ISSUE_TX_FEE = fees['IssueTransaction']
-PUBLISH_TX_FEE = fees['PublishTransaction']
-REGISTER_TX_FEE = fees['RegisterTransaction']
+        fees = config['SystemFee']
+        self.ENROLLMENT_TX_FEE = fees['EnrollmentTransaction']
+        self.ISSUE_TX_FEE = fees['IssueTransaction']
+        self.PUBLISH_TX_FEE = fees['PublishTransaction']
+        self.REGISTER_TX_FEE = fees['RegisterTransaction']
 
+        config = data['ApplicationConfiguration']
+        self.LEVELDB_PATH= config['DataDirectoryPath']
+        self.NODE_PORT = int(config['NodePort'])
+        self.WS_PORT = config['WsPort']
+        self.URI_PREFIX = config['UriPrefix']
+        self.VERSION_NAME = config['VersionName']
 
+    def setup_mainnet(self):
+        """ Load settings from the mainnet JSON config file """
+        self.setup('protocol.mainnet.json')
 
-config = data['ApplicationConfiguration']
+    def setup_testnet(self):
+        """ Load settings from the testnet JSON config file """
+        self.setup('protocol.testnet.json')
 
-LEVELDB_PATH= config['DataDirectoryPath']
-NODE_PORT = int(config['NodePort'])
-WS_PORT = config['WsPort']
-URI_PREFIX = config['UriPrefix']
-VERSION_NAME = config['VersionName']
+# Settings instance used by external modules
+settings = SettingsHolder()
+
+# Load testnet settings as default
+settings.setup_testnet()

--- a/neo/Utils/VerifiableTestCase.py
+++ b/neo/Utils/VerifiableTestCase.py
@@ -7,7 +7,6 @@ from neo.Core.Blockchain import Blockchain
 from neo.Core.Helper import Helper
 from neo.Core.Witness import Witness
 from neo.VM.OpCode import *
-from neo import Settings
 from neo.Cryptography.Crypto import Crypto
 from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
 import shutil

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -15,11 +15,10 @@ from neo.Cryptography.Crypto import Crypto
 from neo.Wallets.AddressState import AddressState
 from neo.Wallets.Coin import Coin
 from neo.Wallets.KeyPair import KeyPair
-from neo import Settings
+from neo.Settings import settings
 from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
 from autologging import logged
 import hashlib
-from neo import Settings
 from threading import Thread
 from threading import Lock
 import traceback
@@ -38,7 +37,7 @@ class Wallet(object):
 
 
 
-    AddressVersion = Settings.ADDRESS_VERSION
+    AddressVersion = None
 
     _path = ''
     _iv = None
@@ -72,7 +71,7 @@ class Wallet(object):
 
     """docstring for Wallet"""
     def __init__(self, path, passwordKey, create):
-
+        self.AddressVersion = settings.ADDRESS_VERSION
         self._path = path
 
         if create:
@@ -83,7 +82,7 @@ class Wallet(object):
             self._coins = {}
 
             if Blockchain.Default() is None:
-                self._indexedDB= LevelDBBlockchain(Settings.LEVELDB_PATH)
+                self._indexedDB= LevelDBBlockchain(settings.LEVELDB_PATH)
                 Blockchain.RegisterBlockchain(self._indexedDB)
             else:
                 self._indexedDB = Blockchain.Default()

--- a/neo/test_settings.py
+++ b/neo/test_settings.py
@@ -1,0 +1,23 @@
+from neo.Utils.NeoTestCase import NeoTestCase
+from neo.Settings import SettingsHolder
+
+class SettingsTestCase(NeoTestCase):
+    def test_settings(self):
+        _settings = SettingsHolder()
+
+        # Validate initial state
+        self.assertEqual(_settings.MAGIC, None)
+        self.assertEqual(_settings.ADDRESS_VERSION, None)
+        self.assertEqual(_settings.STANDBY_VALIDATORS, None)
+        self.assertEqual(_settings.is_mainnet, False)
+        self.assertEqual(_settings.is_testnet, False)
+
+        # Validate correct mainnet state
+        _settings.setup_mainnet()
+        self.assertEqual(_settings.is_mainnet, True)
+        self.assertEqual(_settings.is_testnet, False)
+
+        # Validate correct testnet state
+        _settings.setup_testnet()
+        self.assertEqual(_settings.is_mainnet, False)
+        self.assertEqual(_settings.is_testnet, True)

--- a/node.py
+++ b/node.py
@@ -17,10 +17,10 @@ from twisted.internet import reactor, task
 
 from neo.Core.Blockchain import Blockchain
 from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
-from neo import Settings
+from neo.Settings import settings
 
 
-blockchain = LevelDBBlockchain(Settings.LEVELDB_PATH)
+blockchain = LevelDBBlockchain(settings.LEVELDB_PATH)
 Blockchain.RegisterBlockchain(blockchain)
 
 

--- a/prompt.py
+++ b/prompt.py
@@ -5,6 +5,7 @@ import json
 import logging
 import datetime
 import os
+import argparse
 from neo.IO.MemoryStream import StreamManager
 import resource
 
@@ -21,7 +22,7 @@ from neo.Prompt.Commands.Send import construct_and_send,construct_contract_withd
 from neo.Prompt.Commands.Wallet import DeleteAddress,ImportWatchAddr
 from neo.Prompt.Utils import get_arg
 from neo.Prompt.Notify import SubscribeNotifications
-from neo import Settings
+from neo.Settings import settings
 from neo.Fixed8 import Fixed8
 import traceback
 
@@ -45,9 +46,6 @@ logging.basicConfig(
      format="%(asctime)s %(levelname)s:%(name)s:%(funcName)s:%(message)s")
 
 
-blockchain = LevelDBBlockchain(Settings.LEVELDB_PATH)
-Blockchain.RegisterBlockchain(blockchain)
-SubscribeNotifications()
 
 
 import csv
@@ -126,13 +124,17 @@ class PromptInterface(object):
 
     history = FileHistory('.prompt.py.history')
 
-    start_height = Blockchain.Default().Height
-    start_dt = datetime.datetime.utcnow()
+    start_height = None
+    start_dt = None
+
+    def __init__(self):
+        self.start_height = Blockchain.Default().Height
+        self.start_dt = datetime.datetime.utcnow()
 
 
     def get_bottom_toolbar(self, cli=None):
         out = []
-        net = "[MainNet]" if Settings.NODE_PORT == 10333 else "[TestNet]"
+        net = "[MainNet]" if settings.is_mainnet else "[TestNet]"
         try:
             out =[(Token.Command, '%s Progress: ' % net),
                     (Token.Number, str(Blockchain.Default().Height)),
@@ -895,10 +897,32 @@ class PromptInterface(object):
                     traceback.print_exc()
 
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--mainnet", action="store_true", default=False, help="use MainNet instead of the default TestNet")
+    parser.add_argument("-c", "--config", action="store", help="Use a specific config file")
+    args = parser.parse_args()
+
+    if args.mainnet and args.config:
+        print("Cannot use bot --config and --mainnet parameters, please use only one.")
+        exit(1)
+
+    # Setup depending on command line arguments. By default, the testnet settings are already loaded.
+    if args.config:
+        settings.setup(args.config)
+    elif args.mainnet:
+        settings.setup_mainnet()
+
+    # Instantiate the blockchain and subscribe to notifications
+    blockchain = LevelDBBlockchain(settings.LEVELDB_PATH)
+    Blockchain.RegisterBlockchain(blockchain)
+    SubscribeNotifications()
+
+    # Start the prompt interface
     cli = PromptInterface()
 
+    # Run
     reactor.suggestThreadPoolSize(15)
     reactor.callInThread(cli.run)
     NodeLeader.Instance().Start()


### PR DESCRIPTION
Allows to switch between mainnet and testnet with cli arguments. Might also be useful for further settings in the future.

Several files were touched, but mainly just the import changed from `from neo import Settings` to `from neo.Settings import settings`. The real changes are using a class in [Settings.py](https://github.com/metachris/neo-python/blob/c9585355cfe275bc2aa528e01dd8f28ac6b53880/neo/Settings.py), and adding cli args to [prompt.py](https://github.com/metachris/neo-python/commit/c9585355cfe275bc2aa528e01dd8f28ac6b53880#diff-51c9e721b63b4d4727f5d7f5423a5017).