### PR TITLE
UIntBase: __eq__ bugfix, tests and cleanup

### DIFF
--- a/neo/UInt160.py
+++ b/neo/UInt160.py
@@ -1,34 +1,22 @@
 from neo.UIntBase import UIntBase
 
 class UInt160(UIntBase):
-
-
-
-
     def __init__(self, data=None):
-
         super(UInt160, self).__init__(num_bytes=20, data=data)
 
-
-
-
-
     def CompareTo(self, other):
-
         x = self.ToArray()
         y = other.ToArray()
 
         length = len(x)
 
         for i in range(length-1, 0, -1):
-
             if x[i] > y[i]:
                 return 1
             if x[i] < y[i]:
                 return -1
 
         return 0
-
 
     def __lt__(self, other):
         return self.CompareTo(other) < 0

--- a/neo/UInt256.py
+++ b/neo/UInt256.py
@@ -3,17 +3,10 @@ from neo.UIntBase import UIntBase
 import binascii
 
 class UInt256(UIntBase):
-
-
-
     def __init__(self, data=None):
-
         super(UInt256, self).__init__(num_bytes=32, data=data)
 
-
-
     def Serialize(self, writer):
-
         writer.WriteBytes(self.Data)
 
     def Deserialize(self, reader):

--- a/neo/UIntBase.py
+++ b/neo/UIntBase.py
@@ -2,10 +2,7 @@ from neo.IO.Mixins import SerializableMixin
 import binascii
 
 class UIntBase(SerializableMixin):
-
-
     Data = bytearray()
-
     __hash = None
 
     def __init__(self, num_bytes, data=None):
@@ -26,14 +23,13 @@ class UIntBase(SerializableMixin):
                 raise Exception("Invalid format")
 
         self.__hash = self.GetHashCode()
+
     @property
     def Size(self):
         return len(self.Data)
 
     def GetHashCode(self):
-
         return int.from_bytes(self.Data[:4], 'little')
-
 
     def Serialize(self, writer):
         writer.WriteBytes(self.Data)
@@ -44,7 +40,6 @@ class UIntBase(SerializableMixin):
 
     def ToArray(self):
         return self.Data
-
 
     def ToString(self):
         db = bytearray(self.Data)
@@ -57,11 +52,11 @@ class UIntBase(SerializableMixin):
     def ToBytes(self):
         return bytes(self.ToString(), encoding='utf-8')
 
-
     def __eq__(self, other):
         if other is None:
             return False
-        if( type(self) != type(self)):
+
+        if type(other) != type(self):
             return False
 
         if other is self:
@@ -69,7 +64,6 @@ class UIntBase(SerializableMixin):
 
         if self.Data == other.Data:
             return True
-
 
     def __hash__(self):
         return self.__hash


### PR DESCRIPTION
* Fixed an error in `UIntBase.__eq__`, where it compares `type(self)` to `type(self)`: https://github.com/CityOfZion/neo-python/blob/905775fa5abb7efd1fa6877188eb09410bbebdc0/neo/UIntBase.py#L64
* Added tests for full coverage of `UIntBase`
* Minor cleanup: mostly removal of extra empty lines