### PR TITLE
fix for multi-sig context returning complete after one signature

### DIFF
--- a/contrib/privnet-claimall.py
+++ b/contrib/privnet-claimall.py
@@ -14,13 +14,17 @@ python3 privnet-claimall.py {address to receive all 100000000 NEO}
 
 """
 
+import os
 import sys
-sys.path.append("..")
 import json
 import time
 import datetime
-import os
-os.chdir('../')
+
+if os.getcwd().endswith("/contrib"):
+    os.chdir('../')  # use config and Chains folder from main directory
+
+sys.path.append(os.getcwd())
+
 from neo.Implementations.Wallets.peewee.UserWallet import UserWallet
 from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
 from neo.Wallets.KeyPair import KeyPair
@@ -97,7 +101,7 @@ class PrivnetClaimall(object):
             print("insufficient funds, were funds already moved from multi-sig contract?")
             return None
 
-        context = ContractParametersContext(tx)
+        context = ContractParametersContext(tx, isMultiSig=True)
         wallet.Sign(context)
 
         if context.Completed:

--- a/neo/SmartContract/ContractParameterContext.py
+++ b/neo/SmartContract/ContractParameterContext.py
@@ -272,7 +272,7 @@ class ContractParametersContext():
         return jsn
 
 
-    def FromJson(jsn):
+    def FromJson(jsn, isMultiSig=True):
         try:
             parsed = json.loads(jsn)
             if parsed['type'] == 'Neo.Core.ContractTransaction':
@@ -280,7 +280,7 @@ class ContractParametersContext():
                 ms = MemoryStream(binascii.unhexlify(parsed['hex']))
                 r = BinaryReader(ms)
                 verifiable.DeserializeUnsigned(r)
-                context = ContractParametersContext(verifiable)
+                context = ContractParametersContext(verifiable, isMultiSig=isMultiSig)
                 for key, value in parsed['items'].items():
                     if "0x" in key:
                         key = key[2:]


### PR DESCRIPTION
The added check for self.isMultiSig under ContractParametersContext broke the privnet-claimall script since I wasn't passing isMultiSig=True when creating the context. This fix addresses that and also an issue finding the module paths when running the script from inside the contrib directory.