### PR TITLE
Added protocol.privnet.json

### DIFF
--- a/protocol.privnet.json
+++ b/protocol.privnet.json
@@ -29,6 +29,21 @@
     "UriPrefix": [ "http://*:20332" ],
     "SslCert": "",
     "SslCertPassword": "",
-    "VersionName":"/NEO-PYTHON:2.3.4/"
-  }
+    "VersionName":"/NEO-PYTHON:2.3.4/",
+    "theme": "dark",
+    "themes": {
+        "dark": {
+            "Command": "#ff0066",
+            "Default": "#00ee00",
+            "Neo": "#0000ee",
+            "Number": "#ffffff"
+        },
+        "light": {
+            "Command": "#ff0066",
+            "Default": "#008800",
+            "Neo": "#0000ee",
+            "Number": "#000000"
+        }
+    }
+   }
 }

--- a/protocol.privnet.json
+++ b/protocol.privnet.json
@@ -1,0 +1,34 @@
+{
+  "ProtocolConfiguration": {
+    "Magic": 56753,
+    "AddressVersion": 23,
+    "StandbyValidators": [
+        "02b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2",
+        "02103a7f7dd016558597f7960d27c516a4394fd968b9e65155eb4b013e4040406e",
+        "03d90c07df63e690ce77912e10ab51acc944b66860237b608c4f8f8309e71ee699",
+        "02a7bc55fe8684e0119768d104ba30795bdcc86619e864add26156723ed185cd62"
+    ],
+    "SeedList": [
+        "127.0.0.1:20333",
+        "127.0.0.1:20334",
+        "127.0.0.1:20335",
+        "127.0.0.1:20336"
+    ],
+    "SystemFee": {
+        "EnrollmentTransaction": 1000,
+        "IssueTransaction": 500,
+        "PublishTransaction": 500,
+        "RegisterTransaction": 10000
+    }
+  },
+
+  "ApplicationConfiguration": {
+    "DataDirectoryPath": "./Chains/privnet",
+    "NodePort": 20333,
+    "WsPort": 20334,
+    "UriPrefix": [ "http://*:20332" ],
+    "SslCert": "",
+    "SslCertPassword": "",
+    "VersionName":"/NEO-PYTHON:2.3.4/"
+  }
+}


### PR DESCRIPTION
Added a `protocol.privnet.json`. Not sure if you want, but I guessed its useful to possibly a large enough part of the user-base to warrant a third file besides mainnet and testnet configs. Any thoughts?