### PR TITLE
prompt: create wallet with file error should not continue

### DIFF
--- a/prompt.py
+++ b/prompt.py
@@ -232,6 +232,7 @@ class PromptInterface(object):
             self.Wallet = UserWallet.Create(path=path, password=passwd)
         except Exception as e:
             print("Exception creating wallet: %s " % e)
+            return
 
         contract = self.Wallet.GetDefaultContract()
         key = self.Wallet.GetKey(contract.PublicKeyHash)


### PR DESCRIPTION
If there is a file-error when creating a wallet, the code should not continue