### PR TITLE
Feature nep5 wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ UnitTestChain
 
 Contracts
 
-Wallets
+/Wallets
 
 # Distribution / packaging
 .Python

--- a/neo/Implementations/Wallets/peewee/Models.py
+++ b/neo/Implementations/Wallets/peewee/Models.py
@@ -42,8 +42,15 @@ class Contract(ModelBase):
 
 class Key(ModelBase):
     Id = PrimaryKeyField()
-    Name = CharField(unique=True, )
+    Name = CharField(unique=True)
     Value = CharField()
+
+
+class NEP5Token(ModelBase):
+    ContractHash = CharField(unique=True)
+    Name = CharField()
+    Symbol = CharField()
+    Decimals = IntegerField()
 
 
 class Transaction(ModelBase):

--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -368,14 +368,13 @@ class UserWallet(Wallet):
 
         return result
 
-
     def TokenBalancesForAddress(self, address):
         if len(self._tokens):
             jsn = []
             tokens = list(self._tokens.values())
             for t in tokens:
                 jsn.append(
-                        '[%s] %s : %s' %  (t.ScriptHash.ToString(),t.symbol,t.GetBalance(self,address,as_string=True))
+                    '[%s] %s : %s' % (t.ScriptHash.ToString(), t.symbol, t.GetBalance(self, address, as_string=True))
                 )
             return jsn
 
@@ -423,11 +422,11 @@ class UserWallet(Wallet):
 
         return True, coins_toremove
 
-
     def ToJson(self, verbose=False):
 
         assets = self.GetCoinAssets()
         tokens = list(self._tokens.values())
+        assets = assets + tokens
 
         if Blockchain.Default().Height == 0:
             percent_synced = 0
@@ -464,10 +463,9 @@ class UserWallet(Wallet):
                 watch_total = self.GetBalance(asset, CoinState.WatchOnly).value / Fixed8.D
                 balances.append("[%s]: %s " % (bc_asset.GetName(), total))
                 watch_balances.append("[%s]: %s " % (bc_asset.GetName(), watch_total))
-#            elif type(asset) is WalletNEP5Token:
-#                balance=0
-#                balances.append("[%s]: %s " % (asset.symbol, 0))
-#                watch_balances.append("[%s]: %s " % (asset.symbol, 0))
+            elif type(asset) is WalletNEP5Token:
+                balances.append("[%s]: %s " % (asset.symbol, self.GetBalance(asset)))
+                watch_balances.append("[%s]: %s " % (asset.symbol, self.GetBalance(asset, True)))
 
         tokens = []
         for t in self._tokens.values():

--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -22,8 +22,8 @@ from neo.UInt256 import UInt256
 from .PWDatabase import PWDatabase
 
 from neo.Implementations.Wallets.peewee.Models import Account, Address, Coin, \
-                                                        Contract, Key, Transaction, \
-                                                            TransactionInfo, NEP5Token
+    Contract, Key, Transaction, \
+    TransactionInfo, NEP5Token
 
 from autologging import logged
 import json
@@ -162,8 +162,7 @@ class UserWallet(Wallet):
         else:
             raise Exception("Address already exists in wallet")
 
-
-    def AddNEP5Token(self,token):
+    def AddNEP5Token(self, token):
 
         super(UserWallet, self).AddNEP5Token(token)
 
@@ -174,14 +173,13 @@ class UserWallet(Wallet):
             pass
 
         db_token = NEP5Token.create(
-            ContractHash = token.ScriptHash.ToBytes(),
-            Name = token.name,
-            Symbol = token.symbol,
-            Decimals = token.decimals
+            ContractHash=token.ScriptHash.ToBytes(),
+            Name=token.name,
+            Symbol=token.symbol,
+            Decimals=token.decimals
         )
         db_token.save()
         return True
-
 
     def FindUnspentCoins(self, from_addr=None, use_standard=False, watch_only_val=0):
         return super(UserWallet, self).FindUnspentCoins(from_addr, use_standard, watch_only_val=watch_only_val)

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -140,11 +140,11 @@ def TestInvokeContract(wallet, args, withdrawal_tx=None, parse_params=True):
     contract = BC.GetContract(args[0])
 
     if contract:
-        descripe_contract(contract)
 
         verbose = False
 
         if 'verbose' in args:
+            descripe_contract(contract)
             verbose = True
             args.remove('verbose')
 

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -42,7 +42,7 @@ from neo.UInt160 import UInt160
 
 def InvokeWithdrawTx(wallet, tx, contract_hash):
 
-    print("withdraw tx 1 %s " % json.dumps(tx.ToJson(), indent=4))
+    #    print("withdraw tx 1 %s " % json.dumps(tx.ToJson(), indent=4))
 
     requestor_contract = wallet.GetDefaultContract()
     tx.Attributes = [
@@ -70,13 +70,10 @@ def InvokeWithdrawTx(wallet, tx, contract_hash):
         verification_contract = Contract.Create(reedeem_script, param_list, requestor_contract.PublicKeyHash)
 
         address = verification_contract.Address
-        print("address is.... %s " % address)
         withdraw_verification = verification_contract
 
     context = ContractParametersContext(tx)
     wallet.Sign(context)
-
-    print("withdraw tx 2 %s " % json.dumps(tx.ToJson(), indent=4))
 
     context.Add(withdraw_verification, 0, 0)
 
@@ -84,7 +81,7 @@ def InvokeWithdrawTx(wallet, tx, contract_hash):
 
         tx.scripts = context.GetScripts()
 
-        print("withdraw tx 3 %s " % json.dumps(tx.ToJson(), indent=4))
+        print("withdraw tx %s " % json.dumps(tx.ToJson(), indent=4))
 
         wallet.SaveTransaction(tx)
 

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -1,17 +1,19 @@
-from prompt_toolkit import prompt
-import traceback
-
 from neo.Core.Blockchain import Blockchain
-from neo.Fixed8 import Fixed8
 from neo.Core.TX.Transaction import TransactionOutput, ContractTransaction
 from neo.Core.TX.InvocationTransaction import InvocationTransaction
+from neo.Core.TX.TransactionAttribute import TransactionAttribute, TransactionAttributeUsage
 from neo.SmartContract.ContractParameterContext import ContractParametersContext
 from neo.Network.NodeLeader import NodeLeader
-from neo.Prompt.Utils import parse_param, get_arg, get_from_addr
+from neo.Prompt.Utils import get_arg, get_from_addr,get_asset_id
+from neo.Prompt.Commands.Invoke import InvokeContract
 from neo.Wallets.Coin import CoinState
+from neo.Wallets.NEP5Token import NEP5Token
+from neo.UInt256 import UInt256
+from neo.Fixed8 import Fixed8
+
 import json
-from neo.Core.TX.TransactionAttribute import TransactionAttribute, TransactionAttributeUsage
-import pdb
+from prompt_toolkit import prompt
+import traceback
 
 
 def construct_and_send(prompter, wallet, arguments):
@@ -29,14 +31,7 @@ def construct_and_send(prompter, wallet, arguments):
         address_to = get_arg(arguments, 1)
         amount = get_arg(arguments, 2)
 
-        assetId = None
-
-        if to_send.lower() == 'neo':
-            assetId = Blockchain.Default().SystemShare().Hash
-        elif to_send.lower() == 'gas':
-            assetId = Blockchain.Default().SystemCoin().Hash
-        elif Blockchain.Default().GetAssetState(to_send):
-            assetId = Blockchain.Default().GetAssetState(to_send).AssetId
+        assetId = get_asset_id(wallet, to_send)
 
         scripthash_to = wallet.ToScriptHash(address_to)
         if scripthash_to is None:
@@ -48,18 +43,25 @@ def construct_and_send(prompter, wallet, arguments):
         if from_address is not None:
             scripthash_from = wallet.ToScriptHash(from_address)
 
+
+        # if this is a token, we will use a different
+        # transfer mechanism
+        if type(assetId) is NEP5Token:
+            return do_token_transfer(assetId, wallet, from_address, address_to, amount)
+
+
+
         f8amount = Fixed8.TryParse(amount)
         if f8amount is None:
             print("invalid amount format")
             return
 
-        if f8amount.value % pow(10, 8 - Blockchain.Default().GetAssetState(assetId.ToBytes()).Precision) != 0:
+        if type(assetId) is UInt256 and f8amount.value % pow(10, 8 - Blockchain.Default().GetAssetState(assetId.ToBytes()).Precision) != 0:
             print("incorrect amount precision")
             return
 
         fee = Fixed8.Zero()
-        if get_arg(arguments, 3):
-            fee = Fixed8.TryParse(get_arg(arguments, 3))
+
 
         output = TransactionOutput(AssetId=assetId, Value=f8amount, script_hash=scripthash_to)
         tx = ContractTransaction(outputs=[output])
@@ -133,14 +135,7 @@ def construct_contract_withdrawal(prompter, wallet, arguments):
     to_address = get_arg(arguments, 2)
     amount = get_arg(arguments, 3)
 
-    assetId = None
-
-    if to_send.lower() == 'neo':
-        assetId = Blockchain.Default().SystemShare().Hash
-    elif to_send.lower() == 'gas':
-        assetId = Blockchain.Default().SystemCoin().Hash
-    elif Blockchain.Default().GetAssetState(to_send):
-        assetId = Blockchain.Default().GetAssetState(to_send).AssetId
+    assetId = get_asset_id(wallet, to_send)
 
     scripthash_to = wallet.ToScriptHash(to_address)
     if scripthash_to is None:
@@ -225,3 +220,36 @@ def parse_and_sign(prompter, wallet, jsn):
         print("could not send: %s " % e)
         traceback.print_stack()
         traceback.print_exc()
+
+
+
+
+def do_token_transfer(token, wallet,from_address,to_address,amount_str):
+    if from_address is None:
+        print("Please specify --from-addr={addr} to send NEP5 tokens")
+        return
+
+
+    precision_mult = pow(10, token.decimals)
+
+    amount = float(amount_str) * precision_mult
+
+    tx, fee, results = token.Transfer(wallet, from_address, to_address, amount)
+
+    if tx is not None and results is not None and len(results) > 0:
+
+        if results[0].GetBigInteger() == 1:
+            print("\n-----------------------------------------------------------")
+            print("Will transfer %s %s from %s to %s" % (amount_str, token.symbol, from_address, to_address))
+            print("Transfer fee: %s " % (fee.value / Fixed8.D))
+            print("-------------------------------------------------------------\n")
+
+            passwd = prompt("[Password]> ", is_password=True)
+
+            if not wallet.ValidatePassword(passwd):
+                print("incorrect password")
+                return
+
+            InvokeContract(wallet,tx,fee)
+        else:
+            print("could not transfer tokens")

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -4,8 +4,8 @@ from neo.Core.TX.InvocationTransaction import InvocationTransaction
 from neo.Core.TX.TransactionAttribute import TransactionAttribute, TransactionAttributeUsage
 from neo.SmartContract.ContractParameterContext import ContractParametersContext
 from neo.Network.NodeLeader import NodeLeader
-from neo.Prompt.Utils import get_arg, get_from_addr,get_asset_id
-from neo.Prompt.Commands.Invoke import InvokeContract
+from neo.Prompt.Utils import get_arg, get_from_addr, get_asset_id
+from neo.Prompt.Commands.Tokens import do_token_transfer, amount_from_string
 from neo.Wallets.Coin import CoinState
 from neo.Wallets.NEP5Token import NEP5Token
 from neo.UInt256 import UInt256
@@ -43,13 +43,10 @@ def construct_and_send(prompter, wallet, arguments):
         if from_address is not None:
             scripthash_from = wallet.ToScriptHash(from_address)
 
-
         # if this is a token, we will use a different
         # transfer mechanism
         if type(assetId) is NEP5Token:
-            return do_token_transfer(assetId, wallet, from_address, address_to, amount)
-
-
+            return do_token_transfer(assetId, wallet, from_address, address_to, amount_from_string(assetId, amount))
 
         f8amount = Fixed8.TryParse(amount)
         if f8amount is None:
@@ -61,7 +58,6 @@ def construct_and_send(prompter, wallet, arguments):
             return
 
         fee = Fixed8.Zero()
-
 
         output = TransactionOutput(AssetId=assetId, Value=f8amount, script_hash=scripthash_to)
         tx = ContractTransaction(outputs=[output])
@@ -220,36 +216,3 @@ def parse_and_sign(prompter, wallet, jsn):
         print("could not send: %s " % e)
         traceback.print_stack()
         traceback.print_exc()
-
-
-
-
-def do_token_transfer(token, wallet,from_address,to_address,amount_str):
-    if from_address is None:
-        print("Please specify --from-addr={addr} to send NEP5 tokens")
-        return
-
-
-    precision_mult = pow(10, token.decimals)
-
-    amount = float(amount_str) * precision_mult
-
-    tx, fee, results = token.Transfer(wallet, from_address, to_address, amount)
-
-    if tx is not None and results is not None and len(results) > 0:
-
-        if results[0].GetBigInteger() == 1:
-            print("\n-----------------------------------------------------------")
-            print("Will transfer %s %s from %s to %s" % (amount_str, token.symbol, from_address, to_address))
-            print("Transfer fee: %s " % (fee.value / Fixed8.D))
-            print("-------------------------------------------------------------\n")
-
-            passwd = prompt("[Password]> ", is_password=True)
-
-            if not wallet.ValidatePassword(passwd):
-                print("incorrect password")
-                return
-
-            InvokeContract(wallet,tx,fee)
-        else:
-            print("could not transfer tokens")

--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -1,0 +1,89 @@
+from neo.Prompt.Commands.Invoke import InvokeContract
+from neo.Prompt.Utils import get_asset_id
+from neo.Fixed8 import Fixed8
+from prompt_toolkit import prompt
+from decimal import Decimal
+import json
+
+
+def token_send(wallet, args):
+
+    token = get_asset_id(wallet, args[0])
+    send_from = args[1]
+    send_to = args[2]
+    amount = amount_from_string(token, args[3])
+
+    return do_token_transfer(token, wallet, send_from, send_to, amount)
+
+
+def token_send_from(wallet, args):
+    token = get_asset_id(wallet, args[0])
+    send_from = args[1]
+    send_to = args[2]
+    amount = amount_from_string(token, args[3])
+
+    raise NotImplementedError()
+
+
+def token_approve_allowance(wallet, args):
+    token = get_asset_id(wallet, args[0])
+    send_from = args[1]
+    send_to = args[2]
+    amount = amount_from_string(token, args[3])
+
+    raise NotImplementedError()
+
+
+def token_get_allowance(wallet, args):
+    token = get_asset_id(wallet, args[0])
+    allowance_from = args[1]
+    allowance_to = args[2]
+
+    raise NotImplementedError()
+
+
+def do_token_transfer(token, wallet, from_address, to_address, amount):
+    if from_address is None:
+        print("Please specify --from-addr={addr} to send NEP5 tokens")
+        return
+
+    tx, fee, results = token.Transfer(wallet, from_address, to_address, amount)
+
+    if tx is not None and results is not None and len(results) > 0:
+
+        if results[0].GetBigInteger() == 1:
+            print("\n-----------------------------------------------------------")
+            print("Will transfer %s %s from %s to %s" % (string_from_amount(token, amount), token.symbol, from_address, to_address))
+            print("Transfer fee: %s " % (fee.value / Fixed8.D))
+            print("-------------------------------------------------------------\n")
+
+            passwd = prompt("[Password]> ", is_password=True)
+
+            if not wallet.ValidatePassword(passwd):
+                print("incorrect password")
+                return
+
+            InvokeContract(wallet, tx, fee)
+        else:
+            print("could not transfer tokens.")
+    else:
+
+        print("could not transfer tokens")
+
+
+def amount_from_string(token, amount_str):
+
+    precision_mult = pow(10, token.decimals)
+    amount = float(amount_str) * precision_mult
+
+    return int(amount)
+
+
+def string_from_amount(token, amount):
+
+    precision_mult = pow(10, token.decimals)
+    amount = Decimal(amount) / Decimal(precision_mult)
+    formatter_str = '.%sf' % token.decimals
+    amount_str = format(amount, formatter_str)
+
+    return amount_str

--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -8,6 +8,10 @@ import json
 
 def token_send(wallet, args):
 
+    if len(args) != 4:
+        print("please provide a token symbol, from address, to address, and amount")
+        return
+
     token = get_asset_id(wallet, args[0])
     send_from = args[1]
     send_to = args[2]
@@ -17,32 +21,103 @@ def token_send(wallet, args):
 
 
 def token_send_from(wallet, args):
+    if len(args) != 4:
+        print("please provide a token symbol, from address, to address, and amount")
+        return
+
     token = get_asset_id(wallet, args[0])
     send_from = args[1]
     send_to = args[2]
     amount = amount_from_string(token, args[3])
 
-    raise NotImplementedError()
+    allowance = token_get_allowance(wallet, args[:-1], verbose=False)
+
+    if allowance and allowance >= amount:
+
+        tx, fee, results = token.TransferFrom(wallet, send_from, send_to, amount)
+
+        if tx is not None and results is not None and len(results) > 0:
+
+            if results[0].GetBigInteger() == 1:
+                print("\n-----------------------------------------------------------")
+                print("Transfer of %s %s from %s to %s" % (
+                    string_from_amount(token, amount), token.symbol, send_from, send_to))
+                print("Transfer fee: %s " % (fee.value / Fixed8.D))
+                print("-------------------------------------------------------------\n")
+
+                passwd = prompt("[Password]> ", is_password=True)
+
+                if not wallet.ValidatePassword(passwd):
+                    print("incorrect password")
+                    return
+
+                return InvokeContract(wallet, tx, fee)
+
+        print("Could not send tokens")
+    else:
+
+        print("Requestest transfer from is greater than allowance")
 
 
 def token_approve_allowance(wallet, args):
+
+    if len(args) != 4:
+        print("please provide a token symbol, from address, to address, and amount")
+        return
+
     token = get_asset_id(wallet, args[0])
-    send_from = args[1]
-    send_to = args[2]
+    approve_from = args[1]
+    approve_to = args[2]
     amount = amount_from_string(token, args[3])
 
-    raise NotImplementedError()
+    tx, fee, results = token.Approve(wallet, approve_from, approve_to, amount)
+
+    if tx is not None and results is not None and len(results) > 0:
+
+        if results[0].GetBigInteger() == 1:
+            print("\n-----------------------------------------------------------")
+            print("Approve allowance of %s %s from %s to %s" % (string_from_amount(token, amount), token.symbol, approve_from, approve_to))
+            print("Transfer fee: %s " % (fee.value / Fixed8.D))
+            print("-------------------------------------------------------------\n")
+
+            passwd = prompt("[Password]> ", is_password=True)
+
+            if not wallet.ValidatePassword(passwd):
+                print("incorrect password")
+                return
+
+            return InvokeContract(wallet, tx, fee)
+
+    print("could not transfer tokens")
 
 
-def token_get_allowance(wallet, args):
+def token_get_allowance(wallet, args, verbose=False):
+
+    if len(args) != 3:
+        print("please provide a token symbol, from address, to address")
+        return
+
     token = get_asset_id(wallet, args[0])
     allowance_from = args[1]
     allowance_to = args[2]
 
-    raise NotImplementedError()
+    tx, fee, results = token.Allowance(wallet, allowance_from, allowance_to)
+
+    if tx is not None and results is not None and len(results) > 0:
+        allowance = results[0].GetBigInteger()
+        if verbose:
+            print("%s allowance for %s from %s : %s " % (token.symbol, allowance_to, allowance_from, allowance))
+
+        return allowance
+    else:
+        if verbose:
+            print("Could not get allowance for token %s " % token.symbol)
+
+    return 0
 
 
 def do_token_transfer(token, wallet, from_address, to_address, amount):
+
     if from_address is None:
         print("Please specify --from-addr={addr} to send NEP5 tokens")
         return
@@ -63,12 +138,9 @@ def do_token_transfer(token, wallet, from_address, to_address, amount):
                 print("incorrect password")
                 return
 
-            InvokeContract(wallet, tx, fee)
-        else:
-            print("could not transfer tokens.")
-    else:
+            return InvokeContract(wallet, tx, fee)
 
-        print("could not transfer tokens")
+    print("could not transfer tokens")
 
 
 def amount_from_string(token, amount_str):

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -3,6 +3,7 @@ from neo.Wallets.NEP5Token import NEP5Token
 import binascii
 import json
 
+
 def DeleteAddress(prompter, wallet, addr):
 
     scripthash = wallet.ToScriptHash(addr)
@@ -39,7 +40,7 @@ def ImportToken(wallet, contract_hash):
 
     if contract:
         hex_script = binascii.hexlify(contract.Code.Script)
-        token = NEP5Token(script= hex_script)
+        token = NEP5Token(script=hex_script)
 
         result = token.Query(wallet)
 
@@ -52,6 +53,3 @@ def ImportToken(wallet, contract_hash):
         else:
 
             print("Could not import token")
-
-
-

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -1,4 +1,7 @@
-
+from neo.Core.Blockchain import Blockchain
+from neo.Wallets.NEP5Token import NEP5Token
+import binascii
+import json
 
 def DeleteAddress(prompter, wallet, addr):
 
@@ -21,8 +24,34 @@ def ImportWatchAddr(wallet, addr):
 
     script_hash = wallet.ToScriptHash(addr)
 
-    print("will import watch address %s %s " % (addr, script_hash))
-
     result = wallet.AddWatchOnly(script_hash)
 
     print("result %s " % result)
+
+
+def ImportToken(wallet, contract_hash):
+
+    if wallet is None:
+        print("please open a wallet")
+        return False
+
+    contract = Blockchain.Default().GetContract(contract_hash)
+
+    if contract:
+        hex_script = binascii.hexlify(contract.Code.Script)
+        token = NEP5Token(script= hex_script)
+
+        result = token.Query(wallet)
+
+        if result:
+
+            print("queried token %s " % json.dumps(token.ToJson(), indent=4))
+
+            wallet.AddNEP5Token(token)
+
+        else:
+
+            print("Could not import token")
+
+
+

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -46,9 +46,9 @@ def ImportToken(wallet, contract_hash):
 
         if result:
 
-            print("queried token %s " % json.dumps(token.ToJson(), indent=4))
 
             wallet.AddNEP5Token(token)
+            print("added token %s " % json.dumps(token.ToJson(), indent=4))
 
         else:
 

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -46,7 +46,6 @@ def ImportToken(wallet, contract_hash):
 
         if result:
 
-
             wallet.AddNEP5Token(token)
             print("added token %s " % json.dumps(token.ToJson(), indent=4))
 

--- a/neo/Prompt/Commands/Withdraw.py
+++ b/neo/Prompt/Commands/Withdraw.py
@@ -141,7 +141,7 @@ def construct_contract_withdrawal_request(wallet, arguments, fee=Fixed8.FromDeci
     to_address = get_arg(arguments, 2)
     amount = get_arg(arguments, 3)
 
-    assetId = get_asset_id(to_send)
+    assetId = get_asset_id(wallet,to_send)
 
     f8amount = get_asset_amount(amount, assetId)
 
@@ -179,7 +179,7 @@ def construct_contract_withdrawal_request(wallet, arguments, fee=Fixed8.FromDeci
 def construct_withdrawal_tx(wallet, args):
 
     from_address = get_arg(args, 0)
-    assetId = get_asset_id(get_arg(args, 1))
+    assetId = get_asset_id(wallet,get_arg(args, 1))
     to_address = get_arg(args, 2)
     f8amount = get_asset_amount(get_arg(args, 3), assetId)
 

--- a/neo/Prompt/Commands/Withdraw.py
+++ b/neo/Prompt/Commands/Withdraw.py
@@ -141,7 +141,7 @@ def construct_contract_withdrawal_request(wallet, arguments, fee=Fixed8.FromDeci
     to_address = get_arg(arguments, 2)
     amount = get_arg(arguments, 3)
 
-    assetId = get_asset_id(wallet,to_send)
+    assetId = get_asset_id(wallet, to_send)
 
     f8amount = get_asset_amount(amount, assetId)
 
@@ -179,7 +179,7 @@ def construct_contract_withdrawal_request(wallet, arguments, fee=Fixed8.FromDeci
 def construct_withdrawal_tx(wallet, args):
 
     from_address = get_arg(args, 0)
-    assetId = get_asset_id(wallet,get_arg(args, 1))
+    assetId = get_asset_id(wallet, get_arg(args, 1))
     to_address = get_arg(args, 2)
     f8amount = get_asset_amount(get_arg(args, 3), assetId)
 

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -36,8 +36,15 @@ def get_asset_attachments(params):
     return params, neo_to_attach, gas_to_attach
 
 
-def get_asset_id(asset_str):
+def get_asset_id(wallet, asset_str):
     assetId = None
+
+    # check to see if this is a token
+    for token in wallet.GetTokens().values():
+        if asset_str == token.symbol:
+            return token
+        elif asset_str == token.ScriptHash.ToString():
+            return token
 
     if asset_str.lower() == 'neo':
         assetId = Blockchain.Default().SystemShare().Hash
@@ -47,7 +54,6 @@ def get_asset_id(asset_str):
         assetId = Blockchain.Default().GetAssetState(asset_str).AssetId
 
     return assetId
-
 
 def get_asset_amount(amount, assetId):
 

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -55,6 +55,7 @@ def get_asset_id(wallet, asset_str):
 
     return assetId
 
+
 def get_asset_amount(amount, assetId):
 
     f8amount = Fixed8.TryParse(amount)

--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -11,8 +11,9 @@ from autologging import logged
 from neo.Implementations.Blockchains.LevelDB.DBPrefix import DBPrefix
 from neo.Implementations.Blockchains.LevelDB.DBCollection import DBCollection
 from neo.Implementations.Blockchains.LevelDB.CachedScriptTable import CachedScriptTable
-from neo.Core.State import ContractState,AssetState,AccountState,ValidatorState,StorageItem
+from neo.Core.State import ContractState, AssetState, AccountState, ValidatorState, StorageItem
 from neo.SmartContract import TriggerType
+
 
 @logged
 class ApplicationEngine(ExecutionEngine):
@@ -297,8 +298,6 @@ class ApplicationEngine(ExecutionEngine):
             return 100
 
         return 1
-
-
 
     @staticmethod
     def Run(script, container=None):

--- a/neo/VM/ScriptBuilder.py
+++ b/neo/VM/ScriptBuilder.py
@@ -106,7 +106,7 @@ class ScriptBuilder(object):
             elif data > 0 and data <= 16:
                 return self.add(int.from_bytes(PUSH1, 'little') - 1 + data)
             else:
-                return self.push( binascii.hexlify( data.ToByteArray()))
+                return self.push(binascii.hexlify(data.ToByteArray()))
         else:
             if not type(data) == bytearray:
                 buf = binascii.unhexlify(data)

--- a/neo/VM/ScriptBuilder.py
+++ b/neo/VM/ScriptBuilder.py
@@ -106,7 +106,7 @@ class ScriptBuilder(object):
             elif data > 0 and data <= 16:
                 return self.add(int.from_bytes(PUSH1, 'little') - 1 + data)
             else:
-                return self.push(binascii.hexlify(base256_encode(data)))
+                return self.push( binascii.hexlify( data.ToByteArray()))
         else:
             if not type(data) == bytearray:
                 buf = binascii.unhexlify(data)

--- a/neo/Wallets/NEP5Token.py
+++ b/neo/Wallets/NEP5Token.py
@@ -1,0 +1,130 @@
+from neo.Core.VerificationCode import VerificationCode
+from neo.Cryptography.Crypto import Crypto
+from neo.Prompt.Commands.Invoke import TestInvokeContract
+from neo.Prompt.Utils import parse_param
+from neo.UInt160 import UInt160
+import binascii
+from decimal import getcontext, Decimal
+
+
+class NEP5Token(VerificationCode):
+
+    name = None
+    symbol = None
+    decimals = None
+
+    _address = None
+
+    def __init__(self, script=None):
+
+        param_list = bytearray(b'\x07\x10')
+        super(NEP5Token, self).__init__(script=script, param_list=param_list)
+
+    def SetScriptHash(self, script_hash):
+        self._scriptHash = script_hash
+
+    @staticmethod
+    def FromDBInstance(db_token):
+        hash_ar = bytearray(binascii.unhexlify(db_token.ContractHash))
+        hash_ar.reverse()
+        hash = UInt160(data=hash_ar)
+        token = NEP5Token(script=None)
+        token.SetScriptHash(hash)
+        token.name = db_token.Name
+        token.symbol = db_token.Symbol
+        token.decimals = db_token.Decimals
+        return token
+
+    @property
+    def Address(self):
+        if self._address is None:
+            self._address = Crypto.ToAddress(self.ScriptHash)
+        return self._address
+
+    def Query(self, wallet):
+
+        if self.name is not None:
+            # don't query twice
+            return
+
+        invoke_args = [self.ScriptHash.ToString(), parse_param('name'), []]
+        invoke_args2 = [self.ScriptHash.ToString(), parse_param('symbol'), []]
+        invoke_args3 = [self.ScriptHash.ToString(), parse_param('decimals'), []]
+        tx, fee, nameResults, num_ops = TestInvokeContract(wallet, invoke_args, None, False)
+        tx, fee, symbolResults, num_ops = TestInvokeContract(wallet, invoke_args2, None, False)
+        tx, fee, decimalResults, num_ops = TestInvokeContract(wallet, invoke_args3, None, False)
+
+        try:
+
+            self.name = nameResults[0].GetString()
+            self.symbol = symbolResults[0].GetString()
+            self.decimals = decimalResults[0].GetBigInteger()
+            return True
+        except Exception as e:
+            print("could not query token %s " % e)
+
+        return False
+
+    def GetBalance(self, wallet, address, as_string=False):
+
+        if type(address) is UInt160:
+            address = Crypto.ToAddress(address)
+
+        invoke_args = [self.ScriptHash.ToString(), parse_param('balanceOf'), [parse_param(address)]]
+        tx, fee, balanceResults, num_ops = TestInvokeContract(wallet, invoke_args, None, False)
+
+        try:
+            val = balanceResults[0].GetBigInteger()
+            precision_divisor = pow(10, self.decimals)
+            balance = Decimal(val) / Decimal(precision_divisor)
+            if as_string:
+                formatter_str = '.%sf' % self.decimals
+                balance_str = format(balance, formatter_str)
+                return balance_str
+            return balance
+        except Exception as e:
+            print("could not get balance: %s " % e)
+        return 0
+
+    def Transfer(self, wallet, from_addr, to_addr, amount):
+
+        invoke_args = [self.ScriptHash.ToString(), 'transfer',
+                       [parse_param(from_addr), parse_param(to_addr), parse_param(amount)]]
+
+        tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True)
+
+        return tx, fee, results
+
+    def TransferFrom(self, wallet, from_addr, to_addr, amount):
+        invoke_args = [self.ScriptHash.ToString(), 'transferFrom',
+                       [parse_param(from_addr), parse_param(to_addr), parse_param(amount)]]
+
+        tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True)
+
+        return tx, fee, results
+
+    def Allowance(self, wallet, owner_addr, requestor_addr):
+        invoke_args = [self.ScriptHash.ToString(), 'allowance',
+                       [parse_param(owner_addr), parse_param(requestor_addr), parse_param(0)]]
+
+        tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True)
+
+        return tx, fee, results
+
+    def Approve(self, wallet, owner_addr, requestor_addr, amount):
+        invoke_args = [self.ScriptHash.ToString(), 'approve',
+                       [parse_param(owner_addr), parse_param(requestor_addr), parse_param(amount)]]
+
+        tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True)
+
+        return tx, fee, results
+
+    def ToJson(self):
+        jsn = {
+            'name': self.name,
+            'symbol': self.symbol,
+            'decimals': self.decimals,
+            'script_hash': self.ScriptHash.ToString(),
+            'contract address': self.Address
+        }
+        return jsn

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -40,7 +40,7 @@ class Wallet(object):
     _master_key = None
     _keys = {}  # holds keypairs
     _contracts = {}  # holds Contracts
-    _tokens = {} # holds references to NEP5 tokens
+    _tokens = {}  # holds references to NEP5 tokens
     _watch_only = []  # holds set of hashes
     _coins = {}  # holds Coin References
 

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -40,7 +40,7 @@ class Wallet(object):
     _master_key = None
     _keys = {}  # holds keypairs
     _contracts = {}  # holds Contracts
-
+    _tokens = {} # holds references to NEP5 tokens
     _watch_only = []  # holds set of hashes
     _coins = {}  # holds Coin References
 
@@ -110,6 +110,7 @@ class Wallet(object):
             self._keys = self.LoadKeyPairs()
             self._contracts = self.LoadContracts()
             self._watch_only = self.LoadWatchOnly()
+            self._tokens = self.LoadNEP5Tokens()
             self._coins = self.LoadCoins()
             try:
                 h = int(self.LoadStoredData('Height'))
@@ -142,6 +143,12 @@ class Wallet(object):
             return
 
         self._watch_only.append(script_hash)
+
+    def AddNEP5Token(self, token):
+        if token.ScriptHash.ToBytes() in self._tokens.keys():
+            print("Token already in wallet")
+            return
+        self._tokens[token.ScriptHash.ToBytes()] = token
 
     def ChangePassword(self, password_old, password_new):
         if not self.ValidatePassword(password_old):
@@ -329,6 +336,10 @@ class Wallet(object):
         pass
 
     def LoadCoins(self):
+        # abstract
+        pass
+
+    def LoadNEP5Tokens(self):
         # abstract
         pass
 

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -301,6 +301,11 @@ class Wallet(object):
     def GetAvailable(self, asset_id):
         raise NotImplementedError()
 
+
+    def GetNEP5TokenBalance(self, token, address):
+        balance = token.GetBalance(self, address)
+        return balance
+
     def GetBalance(self, asset_id, watch_only=0):
         total = Fixed8(0)
         for coin in self.GetCoins():

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -303,6 +303,9 @@ class Wallet(object):
     def GetAvailable(self, asset_id):
         raise NotImplementedError()
 
+    def GetTokens(self):
+        return self._tokens
+
     def GetTokenBalance(self, token, watch_only=0):
         total = Decimal(0)
 

--- a/prompt.py
+++ b/prompt.py
@@ -411,7 +411,7 @@ class PromptInterface(object):
         elif item == 'tkn_approve':
             token_approve_allowance(self.Wallet, arguments[1:])
         elif item == 'tkn_allowance':
-            token_get_allowance(self.Wallet, arguments[1:])
+            token_get_allowance(self.Wallet, arguments[1:], verbose=True)
 
     def do_send(self, arguments):
         construct_and_send(self, self.Wallet, arguments)

--- a/prompt.py
+++ b/prompt.py
@@ -20,7 +20,7 @@ from neo.Prompt.Commands.BuildNRun import BuildAndRun, LoadAndRun
 from neo.Prompt.Commands.Withdraw import RequestWithdraw, RedeemWithdraw
 from neo.Prompt.Commands.LoadSmartContract import LoadContract, GatherContractDetails, ImportContractAddr, ImportMultiSigContractAddr
 from neo.Prompt.Commands.Send import construct_and_send, parse_and_sign
-from neo.Prompt.Commands.Wallet import DeleteAddress, ImportWatchAddr,ImportToken
+from neo.Prompt.Commands.Wallet import DeleteAddress, ImportWatchAddr, ImportToken
 from neo.Prompt.Utils import get_arg
 from neo.Prompt.Notify import SubscribeNotifications
 from neo.Settings import settings

--- a/prompt.py
+++ b/prompt.py
@@ -20,7 +20,7 @@ from neo.Prompt.Commands.BuildNRun import BuildAndRun, LoadAndRun
 from neo.Prompt.Commands.Withdraw import RequestWithdraw, RedeemWithdraw
 from neo.Prompt.Commands.LoadSmartContract import LoadContract, GatherContractDetails, ImportContractAddr, ImportMultiSigContractAddr
 from neo.Prompt.Commands.Send import construct_and_send, parse_and_sign
-from neo.Prompt.Commands.Wallet import DeleteAddress, ImportWatchAddr
+from neo.Prompt.Commands.Wallet import DeleteAddress, ImportWatchAddr,ImportToken
 from neo.Prompt.Utils import get_arg
 from neo.Prompt.Notify import SubscribeNotifications
 from neo.Settings import settings
@@ -305,6 +305,9 @@ class PromptInterface(object):
 
             elif item == 'multisig_addr':
                 return ImportMultiSigContractAddr(self.Wallet, arguments[1:])
+
+            elif item == 'token':
+                return ImportToken(self.Wallet, get_arg(arguments, 1))
 
         print("please specify something to import")
         return

--- a/protocol.testnet.json
+++ b/protocol.testnet.json
@@ -9,7 +9,7 @@
         ],
         "VersionName": "/NEO-PYTHON:2.3.4/",
         "WsPort": 20334,
-        "theme": "light",
+        "theme": "dark",
         "themes": {
             "dark": {
                 "Command": "#ff0066",


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
Adds wallet support for interacting with NEP5 compliant tokens.

To use, add the script hash of an NEP5 compliant token: 
`import token f8d448b227991cf07cb96a6f9c0322437f1599b9`
 
The balance and details of the token will now appear when using the `wallet` command, along with token details such as this.  The `symbol` listed below will be used in following commands.

```
"tokens": [
        {
            "symbol": "NEP5",
            "decimals": 8,
            "contract address": "AYhE3Svuqdfh1RtzvE8hUhNR7HSpaSDFQg",
            "name": "NEP5 Standard",
            "script_hash": "f8d448b227991cf07cb96a6f9c0322437f1599b9"
        }
    ]
```


To send tokens from your address:
`wallet tkn_send {TOKEN_SYMBOL} {FROM_ADDR} {TO_ADDR} {AMOUNT}`

The NEP5 methods `transferFrom`, `approve`, and `allowance` are currently listed as optional in the specification, but it is strongly encouraged for token creators to implement them.  With this change set the following methods can be used for tokens that implement these methods:

-`wallet tkn_send_from  {TOKEN_SYMBOL} {FROM_ADDR} {TO_ADDR} {AMOUNT}`
-`wallet tkn_approve  {TOKEN_SYMBOL} {OWNER_ADDR} {REQ_ADDR} {AMOUNT}`
-`wallet tkn_allowance  {TOKEN_SYMBOL} {OWNER_ADDR} {REQ_ADDR}`


