### PR TITLE
NeoNode bugfix: maximum recursion depth (fixes #59)

### DIFF
--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -164,7 +164,7 @@ class NeoNode(Protocol):
 
         # Finally, after a message has been fully deserialized and propagated,
         # check if another message can be extracted with the current buffer:
-        if len(self.buffer_in) > 24:
+        if len(self.buffer_in) >= 24:
             self.CheckDataReceived()
 
     def MessageReceived(self, m):

--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -167,7 +167,6 @@ class NeoNode(Protocol):
         if len(self.buffer_in) > 24:
             self.CheckDataReceived()
 
-
     def MessageReceived(self, m):
 
         #        self.Log("Messagereceived and processed ...: %s " % m.Command)


### PR DESCRIPTION
Do not merge yet, long-running tests are currently in progress.

Edit: Several instances of this code (on mainnet and testnet) have been running for about 8 hours now without problems. I'll leave it running overnight and report back tomorrow morning.

It may be easier to get an overview of the changes by looking at the updated `CheckDataReceived` method: https://github.com/metachris/neo-python/blob/2d5023732ef219f6ecd30b50e4f1d2e5f22b5db8/neo/Network/NeoNode.py#L107

**What current issue(s) does this address?, or what feature is it adding?**

NeoNode ran into an issue which caused the maximum recursion depth do be reached (`Could not check message data maximum recursion depth exceeded while calling a Python object`). See #59 

**How did you solve this problem?**

The reason was a ping-pong style recursion buildup between `NeoNode.CheckDataReceived` and `NeoNode.CheckMessageData`. This commit reduced the complexity of the code and avoids this recursion buildup.

**How did you make sure your solution works?**

Currently being tested, by leaving prompt.py run on several machines. One is syncing the whole mainnet from scratch, the other one just normal operations. Final results should be available in a few hours.

**Did you add any tests?**

No

**Did you check your `pycodestyle`?**

Yes

**Are there any special changes in the code that we should be aware of?**

No

**Are you making a PR to a feature branch or development rather than master?**

development
