### PR TITLE
fixture download: improved error handling

### DIFF
--- a/neo/Utils/BlockchainFixtureTestCase.py
+++ b/neo/Utils/BlockchainFixtureTestCase.py
@@ -45,14 +45,13 @@ class BlockchainFixtureTestCase(NeoTestCase):
             tar.extractall()
             tar.close()
         except Exception as e:
-            print("Could not extract tar file %s " % e)
+            raise Exception("Could not extract tar file - %s. You may want need to remove the fixtures file %s manually to fix this." % (e, cls.FIXTURE_FILENAME))
 
-        if os.path.exists(cls.leveldb_testpath()):
-            cls._blockchain = TestLevelDBBlockchain(path=cls.leveldb_testpath())
+        if not os.path.exists(cls.leveldb_testpath()):
+            raise Exception("Error downloading fixtures")
 
-            Blockchain.RegisterBlockchain(cls._blockchain)
-        else:
-            print("Error downloading fixtures")
+        cls._blockchain = TestLevelDBBlockchain(path=cls.leveldb_testpath())
+        Blockchain.RegisterBlockchain(cls._blockchain)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

When the fixture download failed, the partially downloaded fixture file is left over, but the tests cannot run on them and we got many confusing error messages from the tests.

This commit just aborts running the tests if there is a defect fixtures file, and gives a hint on how you might solve it.

**How did you solve this problem?**

Raising an Exception when the fixtures file is corrupt.

**How did you make sure your solution works?**

Manual tests

**Did you add any tests?**

No

**Did you check your `pycodestyle`?**

Yes

**Are there any special changes in the code that we should be aware of?**

No

**Are you making a PR to a feature branch or development rather than master?**

development
