### PR TITLE
NEP2 Support for KeyPair (fixes #65)

### DIFF
--- a/neo/Cryptography/Helper.py
+++ b/neo/Cryptography/Helper.py
@@ -342,3 +342,13 @@ def base256_encode(n, minwidth=0):  # int/long to byte array
     b.reverse()
 
     return b
+
+
+def xor_bytes(a, b):
+    """ XOR on two bytes objects """
+    assert isinstance(a, bytes)
+    assert isinstance(b, bytes)
+    res = bytearray()
+    for i in range(len(a)):
+        res.append(a[i] ^ b[i])
+    return bytes(res)

--- a/neo/Cryptography/Helper.py
+++ b/neo/Cryptography/Helper.py
@@ -345,9 +345,19 @@ def base256_encode(n, minwidth=0):  # int/long to byte array
 
 
 def xor_bytes(a, b):
-    """ XOR on two bytes objects """
+    """
+    XOR on two bytes objects
+
+    Args:
+        a (bytes): object 1
+        b (bytes): object 2
+
+    Returns:
+        bytes: The XOR result
+    """
     assert isinstance(a, bytes)
     assert isinstance(b, bytes)
+    assert len(a) == len(b)
     res = bytearray()
     for i in range(len(a)):
         res.append(a[i] ^ b[i])

--- a/neo/Cryptography/test_crypto.py
+++ b/neo/Cryptography/test_crypto.py
@@ -1,0 +1,29 @@
+from neo.Utils.NeoTestCase import NeoTestCase
+from neo.Cryptography import Helper
+
+
+class HelperTestCase(NeoTestCase):
+    def test_xor_bytes(self):
+        a = b"12345"
+        b = b"09876"
+        expected_result = b'\x01\x0b\x0b\x03\x03'
+
+        # Should work
+        result = Helper.xor_bytes(a, b)
+        self.assertEqual(result, expected_result)
+
+        # Should not work on inequal length byte objects
+        with self.assertRaises(AssertionError) as context:
+            Helper.xor_bytes(a, b"x")
+
+    def test_base256_encode(self):
+        val = 1234567890
+        res = Helper.base256_encode(val)
+        self.assertEqual(res, bytearray(b'\xd2\x02\x96I'))
+
+    def test_random_key(self):
+        a = Helper.random_key()
+        self.assertEqual(len(a), 64)
+
+        b = Helper.random_key()
+        self.assertNotEqual(a, b)

--- a/neo/Wallets/KeyPair.py
+++ b/neo/Wallets/KeyPair.py
@@ -83,7 +83,13 @@ class KeyPair(object):
     @staticmethod
     def PrivateKeyFromWIF(wif):
         """
-        Build the private key from a WIF key
+        Get the private key from a WIF key
+
+        Args:
+            wif (str): The wif key
+
+        Returns:
+            bytes: The private key
         """
         if wif is None or len(wif) is not 52:
             raise ValueError('Please provide a wif with a length of 52 bytes (LEN: {0:d})'.format(len(wif)))
@@ -105,7 +111,14 @@ class KeyPair(object):
     @staticmethod
     def PrivateKeyFromNEP2(nep2_key, passphrase):
         """
-        Build the private key from a NEP-2 encrypted private key
+        Gets the private key from a NEP-2 encrypted private key
+
+        Args:
+            nep2_key (str): The nep-2 encrypted private key
+            passphrase (str): The password to encrypt the private key with, as unicode string
+
+        Returns:
+            bytes: The private key
         """
         if not nep2_key or len(nep2_key) != 58:
             raise ValueError('Please provide a nep2_key with a length of 58 bytes (LEN: {0:d})'.format(len(nep2_key)))
@@ -147,13 +160,21 @@ class KeyPair(object):
         return private_key
 
     def GetAddress(self):
-        """ Returns the public NEO address for this KeyPair """
+        """
+        Returns the public NEO address for this KeyPair
+
+        Returns:
+            str: The private key
+        """
         contract = Contract.CreateSignatureContract(self.PublicKey)
         return contract.Address
 
     def Export(self):
         """
-        returns the private key in WIF format.
+        Export this KeyPair's private key in WIF format.
+
+        Returns:
+            str: The key in wif format
         """
         data = bytearray(38)
         data[0] = 0x80
@@ -168,7 +189,13 @@ class KeyPair(object):
 
     def ExportNEP2(self, passphrase):
         """
-        returns the encrypted private key in NEP-2 format.
+        Export the encrypted private key in NEP-2 format.
+
+        Args:
+            passphrase (str): The password to encrypt the private key with, as unicode string
+
+        Returns:
+            str: The NEP-2 encrypted private key
         """
         if len(passphrase) < 2:
             raise ValueError("Passphrase must have a minimum of 2 characters")

--- a/neo/Wallets/KeyPair.py
+++ b/neo/Wallets/KeyPair.py
@@ -103,7 +103,7 @@ class KeyPair(object):
         return data[1:33]
 
     @staticmethod
-    def PrivKeyFromNEP2(nep2_key, passphrase):
+    def PrivateKeyFromNEP2(nep2_key, passphrase):
         """
         Build the private key from a NEP-2 encrypted private key
         """

--- a/neo/Wallets/KeyPair.py
+++ b/neo/Wallets/KeyPair.py
@@ -1,7 +1,27 @@
+import hashlib
+import binascii
+import unicodedata
+import base58
+import scrypt
 import bitcoin
+
+from Crypto import Random
+from Crypto.Cipher import AES
+
 from neo.Cryptography.ECCurve import ECDSA
 from neo.Cryptography.Crypto import Crypto
-import base58
+from neo.Cryptography.Helper import xor_bytes
+from neo.SmartContract.Contract import Contract
+
+# NEP-2 constants
+# https://github.com/neo-project/proposals/blob/master/nep-2.mediawiki
+SCRYPT_ITERATIONS = 16384
+SCRYPT_BLOCKSIZE = 8
+SCRYPT_PARALLEL_FACTOR = 8
+SCRYPT_KEY_LEN_BYTES = 64
+
+NEP_HEADER = bytearray([0x01, 0x42])
+NEP_FLAG = bytearray([0xe0])
 
 
 class KeyPair(object):
@@ -62,7 +82,9 @@ class KeyPair(object):
 
     @staticmethod
     def PrivateKeyFromWIF(wif):
-
+        """
+        Build the private key from a WIF key
+        """
         if wif is None or len(wif) is not 52:
             raise ValueError('Please provide a wif with a length of 52 bytes (LEN: {0:d})'.format(len(wif)))
 
@@ -80,8 +102,59 @@ class KeyPair(object):
 
         return data[1:33]
 
-    def Export(self):
+    @staticmethod
+    def PrivKeyFromNEP2(nep2_key, passphrase):
+        """
+        Build the private key from a NEP-2 encrypted private key
+        """
+        if not nep2_key or len(nep2_key) != 58:
+            raise ValueError('Please provide a nep2_key with a length of 58 bytes (LEN: {0:d})'.format(len(nep2_key)))
 
+        ADDRESS_HASH_SIZE = 4
+        ADDRESS_HASH_OFFSET = len(NEP_FLAG) + len(NEP_HEADER)
+
+        try:
+            decoded_key = base58.b58decode_check(nep2_key)
+        except Exception as e:
+            raise ValueError("Invalid nep2_key")
+
+        address_hash = decoded_key[ADDRESS_HASH_OFFSET:ADDRESS_HASH_OFFSET + ADDRESS_HASH_SIZE]
+        encrypted = decoded_key[-32:]
+
+        pwd_normalized = bytes(unicodedata.normalize('NFC', passphrase), 'utf-8')
+        derived = scrypt.hash(pwd_normalized, address_hash,
+                              N=SCRYPT_ITERATIONS,
+                              r=SCRYPT_BLOCKSIZE,
+                              p=SCRYPT_PARALLEL_FACTOR,
+                              buflen=SCRYPT_KEY_LEN_BYTES)
+
+        derived1 = derived[:32]
+        derived2 = derived[32:]
+
+        cipher = AES.new(derived2, AES.MODE_ECB)
+        decrypted = cipher.decrypt(encrypted)
+        private_key = xor_bytes(decrypted, derived1)
+
+        # Now check that the address hashes match. If they don't, the password was wrong.
+        kp_new = KeyPair(priv_key=private_key)
+        kp_new_address = kp_new.GetAddress()
+        kp_new_address_hash_tmp = hashlib.sha256(kp_new_address.encode('utf-8')).digest()
+        kp_new_address_hash_tmp2 = hashlib.sha256(kp_new_address_hash_tmp).digest()
+        kp_new_address_hash = kp_new_address_hash_tmp2[:4]
+        if (kp_new_address_hash != address_hash):
+            raise ValueError("Wrong passphrase")
+
+        return private_key
+
+    def GetAddress(self):
+        """ Returns the public NEO address for this KeyPair """
+        contract = Contract.CreateSignatureContract(self.PublicKey)
+        return contract.Address
+
+    def Export(self):
+        """
+        returns the private key in WIF format.
+        """
         data = bytearray(38)
         data[0] = 0x80
         data[1:33] = self.PrivateKey[0:32]
@@ -92,3 +165,43 @@ class KeyPair(object):
         b58 = base58.b58encode(bytes(data))
 
         return b58
+
+    def ExportNEP2(self, passphrase):
+        """
+        returns the encrypted private key in NEP-2 format.
+        """
+        if len(passphrase) < 2:
+            raise ValueError("Passphrase must have a minimum of 2 characters")
+
+        # Hash address twice, then only use the first 4 bytes
+        address_hash_tmp = hashlib.sha256(self.GetAddress().encode('utf-8')).digest()
+        address_hash_tmp2 = hashlib.sha256(address_hash_tmp).digest()
+        address_hash = address_hash_tmp2[:4]
+
+        # Normalize password and run scrypt over it with the address_hash
+        pwd_normalized = bytes(unicodedata.normalize('NFC', passphrase), 'utf-8')
+        derived = scrypt.hash(pwd_normalized, address_hash,
+                              N=SCRYPT_ITERATIONS,
+                              r=SCRYPT_BLOCKSIZE,
+                              p=SCRYPT_PARALLEL_FACTOR,
+                              buflen=SCRYPT_KEY_LEN_BYTES)
+
+        # Split the scrypt-result into two parts
+        derived1 = derived[:32]
+        derived2 = derived[32:]
+
+        # Run XOR and encrypt the derived parts with AES
+        xor_ed = xor_bytes(bytes(self.PrivateKey), derived1)
+        cipher = AES.new(derived2, AES.MODE_ECB)
+        encrypted = cipher.encrypt(xor_ed)
+
+        # Assemble the final result
+        assembled = bytearray()
+        assembled.extend(NEP_HEADER)
+        assembled.extend(NEP_FLAG)
+        assembled.extend(address_hash)
+        assembled.extend(encrypted)
+
+        # Finally, encode with Base58Check
+        encrypted_key_nep2 = base58.b58encode_check(bytes(assembled))
+        return encrypted_key_nep2

--- a/neo/Wallets/test_KeyPair.py
+++ b/neo/Wallets/test_KeyPair.py
@@ -62,13 +62,13 @@ class PrivateKeyFromWIFTestCase(NeoTestCase):
 class PrivateKeyFromNEP2TestCase(NeoTestCase):
     def test_should_throw_error_on_too_short_nep2_key(self):
         with self.assertRaises(ValueError) as context:
-            KeyPair.PrivKeyFromNEP2('invalid', 'pwd')
+            KeyPair.PrivateKeyFromNEP2('invalid', 'pwd')
 
         self.assertIn('Please provide a nep2_key with a length of 58 bytes', str(context.exception))
 
     def test_should_throw_error_on_invalid_nep2_key(self):
         with self.assertRaises(ValueError) as context:
-            KeyPair.PrivKeyFromNEP2(58 * 'A', 'pwd')
+            KeyPair.PrivateKeyFromNEP2(58 * 'A', 'pwd')
 
         self.assertEqual('Invalid nep2_key', str(context.exception))
 
@@ -76,7 +76,7 @@ class PrivateKeyFromNEP2TestCase(NeoTestCase):
         nep2_key = "6PYVPVe1fQznphjbUxXP9KZJqPMVnVwCx5s5pr5axRJ8uHkMtZg97eT5kL"
         pwd = "TestingOneTwoThree"
         should_equal_private_key = b"cbf4b9f70470856bb4f40f80b87edb90865997ffee6df315ab166d713af433a5"
-        privkey = KeyPair.PrivKeyFromNEP2(nep2_key, pwd)
+        privkey = KeyPair.PrivateKeyFromNEP2(nep2_key, pwd)
         privkey_hex = binascii.hexlify(privkey)
         self.assertEqual(privkey_hex, should_equal_private_key)
 
@@ -84,7 +84,7 @@ class PrivateKeyFromNEP2TestCase(NeoTestCase):
         nep2_key = "6PYVPVe1fQznphjbUxXP9KZJqPMVnVwCx5s5pr5axRJ8uHkMtZg97eT5kL"
         pwd = "invalid-pwd"
         with self.assertRaises(ValueError) as context:
-            KeyPair.PrivKeyFromNEP2(nep2_key, pwd)
+            KeyPair.PrivateKeyFromNEP2(nep2_key, pwd)
 
         self.assertEqual('Wrong passphrase', str(context.exception))
 

--- a/neo/Wallets/test_KeyPair.py
+++ b/neo/Wallets/test_KeyPair.py
@@ -53,3 +53,77 @@ class PrivateKeyFromWIFTestCase(NeoTestCase):
             KeyPair.PrivateKeyFromWIF(encodedFakeWIF)
 
         self.assertEqual('Invalid WIF Checksum!', str(context.exception))
+
+    def test_should_work(self):
+        privkey = KeyPair.PrivateKeyFromWIF("L44B5gGEpqEDRS9vVPz7QT35jcBG2r3CZwSwQ4fCewXAhAhqGVpP")
+        self.assertEqual(binascii.hexlify(privkey), b"cbf4b9f70470856bb4f40f80b87edb90865997ffee6df315ab166d713af433a5")
+
+
+class PrivateKeyFromNEP2TestCase(NeoTestCase):
+    def test_should_throw_error_on_too_short_nep2_key(self):
+        with self.assertRaises(ValueError) as context:
+            KeyPair.PrivKeyFromNEP2('invalid', 'pwd')
+
+        self.assertIn('Please provide a nep2_key with a length of 58 bytes', str(context.exception))
+
+    def test_should_throw_error_on_invalid_nep2_key(self):
+        with self.assertRaises(ValueError) as context:
+            KeyPair.PrivKeyFromNEP2(58 * 'A', 'pwd')
+
+        self.assertEqual('Invalid nep2_key', str(context.exception))
+
+    def test_should_work(self):
+        nep2_key = "6PYVPVe1fQznphjbUxXP9KZJqPMVnVwCx5s5pr5axRJ8uHkMtZg97eT5kL"
+        pwd = "TestingOneTwoThree"
+        should_equal_private_key = b"cbf4b9f70470856bb4f40f80b87edb90865997ffee6df315ab166d713af433a5"
+        privkey = KeyPair.PrivKeyFromNEP2(nep2_key, pwd)
+        privkey_hex = binascii.hexlify(privkey)
+        self.assertEqual(privkey_hex, should_equal_private_key)
+
+    def test_should_throw_error_on_invalid_password(self):
+        nep2_key = "6PYVPVe1fQznphjbUxXP9KZJqPMVnVwCx5s5pr5axRJ8uHkMtZg97eT5kL"
+        pwd = "invalid-pwd"
+        with self.assertRaises(ValueError) as context:
+            KeyPair.PrivKeyFromNEP2(nep2_key, pwd)
+
+        self.assertEqual('Wrong passphrase', str(context.exception))
+
+
+class GetAddressTestCase(NeoTestCase):
+    def test_should_return_valid_address(self):
+        kp = KeyPair(binascii.unhexlify("cbf4b9f70470856bb4f40f80b87edb90865997ffee6df315ab166d713af433a5"))
+        self.assertEqual(kp.GetAddress(), "AStZHy8E6StCqYQbzMqi4poH7YNDHQKxvt")
+
+
+class ExportNEP2TestCase(NeoTestCase):
+    def test_should_throw_error_on_too_short_passphrase(self):
+        kp = KeyPair(binascii.unhexlify("cbf4b9f70470856bb4f40f80b87edb90865997ffee6df315ab166d713af433a5"))
+        with self.assertRaises(ValueError) as context:
+            kp.ExportNEP2("x")
+
+        self.assertIn('Passphrase must have a minimum', str(context.exception))
+
+    def test_should_export_valid_nep2_key(self):
+        kp = KeyPair(binascii.unhexlify("cbf4b9f70470856bb4f40f80b87edb90865997ffee6df315ab166d713af433a5"))
+        nep2_key = kp.ExportNEP2("TestingOneTwoThree")
+        self.assertEqual(nep2_key, "6PYVPVe1fQznphjbUxXP9KZJqPMVnVwCx5s5pr5axRJ8uHkMtZg97eT5kL")
+
+    def test_should_export_valid_nep2_key_with_emoji_pwd(self):
+        pwd = "hellö♥️"
+        privkey = "03eb20a711f93c04459000c62cc235f9e9da82382206b812b07fd2f81779aa42"
+
+        # expected outputs
+        target_address = "AXQUduANGZF4e7wDazVAtyRLHwMounaUMA"
+        target_encrypted_key = "6PYWdv8bP9vbfGsNnjzDawCoXCYpk4rnWG8xTZrvdzx6FjB6jv4H9MM586"
+
+        kp = KeyPair(binascii.unhexlify(privkey))
+        nep2_key = kp.ExportNEP2(pwd)
+        self.assertEqual(nep2_key, target_encrypted_key)
+        self.assertEqual(kp.GetAddress(), target_address)
+
+
+class ExportWIFTestCase(NeoTestCase):
+    def test_should_export_valid_wif_key(self):
+        kp = KeyPair(binascii.unhexlify("cbf4b9f70470856bb4f40f80b87edb90865997ffee6df315ab166d713af433a5"))
+        wif = kp.Export()
+        self.assertEqual(wif, "L44B5gGEpqEDRS9vVPz7QT35jcBG2r3CZwSwQ4fCewXAhAhqGVpP")

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,4 @@ Twisted==17.5.0
 urllib3==1.21.1
 wcwidth==0.1.7
 zope.interface==4.4.2
+scrypt==0.8.0


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

Added NEP2 encrypted key support to KeyPair. See #65

**How did you solve this problem?**

Adding NEP2 encrypted key support to KeyPair. @ixje helped with testing and finalizing the solution.

**How did you make sure your solution works?**

Tests

**Did you add any tests?**

Yes

**Did you check your `pycodestyle`?**

Yes

**Are there any special changes in the code that we should be aware of?**

No

**Are you making a PR to a feature branch or development rather than master?**

development
