### PR TITLE
Feature events localhuman

### DIFF
--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -242,7 +242,6 @@ class Blockchain(object):
 
         return amount_claimed
 
-
     def OnNotify(self, notification):
         #        print("on notifiy %s " % notification)
         self.Notify.on_change(notification)

--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -242,6 +242,7 @@ class Blockchain(object):
 
         return amount_claimed
 
+
     def OnNotify(self, notification):
         #        print("on notifiy %s " % notification)
         self.Notify.on_change(notification)

--- a/neo/EventHub.py
+++ b/neo/EventHub.py
@@ -11,7 +11,7 @@
 #       print("handler1 called with args", args)
 #
 from collections import namedtuple
-
+import pdb
 # pymitter manages the event bus: https://github.com/riga/pymitter#examples
 from pymitter import EventEmitter
 
@@ -21,12 +21,19 @@ events = EventEmitter(wildcard=True)
 # SmartContractEvent has the following properties:
 #
 # - event_type (str)
-# - contract_hash (str)
-# - tx_hash (str)
+# - contract_hash (UInt160)
+# - tx_hash (UInt256)
+# - block_number (int)
 # - event_payload (object[])
+# - execution_success (bool)
 #
 #  `event_payload` is always a list of object, depending on what data types you sent in the smart contract.
-SmartContractEvent = namedtuple("SmartContractEvent", ["event_type", "event_payload", "contract_hash", "block_number", "tx_hash"])
+SmartContractEvent = namedtuple("SmartContractEvent", ["event_type",
+                                                       "event_payload",
+                                                       "contract_hash",
+                                                       "block_number",
+                                                       "tx_hash",
+                                                       "execution_success"])
 
 # Smart contract event types
 SMART_CONTRACT_RUNTIME_NOTIFY = "SMART_CONTRACT_RUNTIME_NOTIFY"  # payload: object[]
@@ -38,16 +45,48 @@ SMART_CONTRACT_EXECUTION_FAIL = "SMART_CONTRACT_EXECUTION_FAIL"
 
 
 # Helper for easier dispatching of events from somewhere in the project
-def dispatch_smart_contract_event(event_type, event_payload, contract_hash, block_number, tx_hash):
-    sc_event = SmartContractEvent(event_type, event_payload, contract_hash, block_number, tx_hash)
+def dispatch_smart_contract_event(event_type,
+                                  event_payload,
+                                  contract_hash,
+                                  block_number,
+                                  tx_hash,
+                                  execution_success=False):
+
+    sc_event = SmartContractEvent(event_type, event_payload, contract_hash, block_number, tx_hash, execution_success)
     events.emit(event_type, sc_event)
 
 
 #
 # These handlers are only for temporary development and testing
 #
-@events.on("*")
-def on_any_event(*args):
-    print("")
-    print("=EVENT:", args)
-    print("")
+#@events.on("*")
+#def on_any_event(*args):
+#    print("")
+#    print("=EVENT:", [str(arg) for arg in args])
+#    print("")
+
+
+@events.on(SMART_CONTRACT_RUNTIME_LOG)
+def on_sc_log(*args):
+    if len(args) > 0 and type(args[0]) is SmartContractEvent:
+        sc_event = args[0]
+        print("[Log] [%s] %s" % (sc_event.contract_hash,sc_event.event_payload))
+
+
+@events.on(SMART_CONTRACT_EXECUTION_SUCCESS)
+def on_execution_succes(*args):
+
+    if len(args) > 0 and type(args[0]) is SmartContractEvent:
+        sc_event = args[0]
+        print("[Execution Success] [%s] %s" % (sc_event.contract_hash,sc_event.event_payload))
+
+
+@events.on(SMART_CONTRACT_EXECUTION_FAIL)
+def on_execution_fail(*args):
+    if len(args) > 0 and type(args[0]) is SmartContractEvent:
+        sc_event = args[0]
+        print("[Execution Fail] [%s] %s" % (sc_event.contract_hash,sc_event.event_payload))
+
+
+        #print("sc event %s %s %s" % (len(args),args, type(args)))
+#    pdb.set_trace()

--- a/neo/EventHub.py
+++ b/neo/EventHub.py
@@ -51,7 +51,7 @@ class SmartContractEvent:
     contract_hash = None
     block_number = None
     tx_hash = None
-    execution_success=None
+    execution_success = None
 
     def __init__(self, event_type, event_payload, contract_hash, block_number, tx_hash, execution_success=False):
         self.event_type = event_type
@@ -87,7 +87,7 @@ def dispatch_smart_contract_event(event_type,
 def on_sc_log(*args):
     if len(args) > 0 and type(args[0]) is SmartContractEvent:
         sc_event = args[0]
-        print("[Log] [%s] %s" % (sc_event.contract_hash,sc_event.event_payload))
+        print("[Log] [%s] %s" % (sc_event.contract_hash, sc_event.event_payload))
 
 
 @events.on(SmartContractEvent.EXECUTION_SUCCESS)
@@ -95,20 +95,19 @@ def on_execution_succes(*args):
 
     if len(args) > 0 and type(args[0]) is SmartContractEvent:
         sc_event = args[0]
-        print("[Execution Success] [%s] %s" % (sc_event.contract_hash,sc_event.event_payload))
+        print("[Execution Success] [%s] %s" % (sc_event.contract_hash, sc_event.event_payload))
 
 
 @events.on(SmartContractEvent.EXECUTION_FAIL)
 def on_execution_fail(*args):
     if len(args) > 0 and type(args[0]) is SmartContractEvent:
         sc_event = args[0]
-        print("[Execution Fail] [Error: %s] %s" % (sc_event.contract_hash,sc_event.event_payload))
+        print("[Execution Fail] [Error: %s] %s" % (sc_event.contract_hash, sc_event.event_payload))
 
 
-
-#@events.on("*")
-#@events.on("*.*")
-#def on_any_event(*args):
+# @events.on("*")
+# @events.on("*.*")
+# def on_any_event(*args):
 #    print("")
 #    print("=EVENT: %s" % args)
 #    print("")

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -31,7 +31,7 @@ import time
 import plyvel
 from autologging import logged
 import binascii
-
+import traceback
 
 @logged
 class LevelDBBlockchain(Blockchain):
@@ -661,21 +661,17 @@ class LevelDBBlockchain(Blockchain):
                         engine.LoadScript(tx.Script, False)
 
                         try:
-                            # drum roll?
                             success = engine.Execute()
-                            print("[neo.Implementations.Blockchains.LevelDBBlockchain.PersistBlock: engine execute] -> Success")
-                            if success:
-                                service.Commit()
+                            service.ExecutionCompleted(engine, success)
 
-                                if len(service.notifications) > 0:
-                                    for n in service.notifications:
-                                        self.OnNotify(n)
-
-                            for item in engine.EvaluationStack.Items:
-                                print("[neo.Implementations.Blockchains.LevelDBBlockchain.PersistBlock: engine execute result] -> %s " % item)
+                            # this will be deprecated in favor of neo.EventHub
+                            if len(service.notifications) > 0:
+                                for n in service.notifications:
+                                    self.OnNotify(n)
 
                         except Exception as e:
-                            print("[neo.Implementations.Blockchains.LevelDBBlockchain.PersistBlock: engine execute result] Could not execute smart contract.  See logs for more details. %s " % e)
+                            service.ExecutionCompleted(engine,False, e)
+
                     else:
 
                         if tx.Type != b'\x00' and tx.Type != 128:
@@ -723,6 +719,7 @@ class LevelDBBlockchain(Blockchain):
                 self.__log.debug("PERSISTING BLOCK %s (cache) %s %s " % (block.Index, len(self._block_cache), end - start))
         except Exception as e:
             print("couldnt persist block %s " % e)
+            traceback.print_stack()
 
     def PersistBlocks(self):
         #        self.__log.debug("PERRRRRSISST:: Hheight, b height, cache: %s/%s %s  --%s %s" % (self.Height, self.HeaderHeight, len(self._block_cache), self.CurrentHeaderHash, self.BlockSearchTries))

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -33,6 +33,7 @@ from autologging import logged
 import binascii
 import traceback
 
+
 @logged
 class LevelDBBlockchain(Blockchain):
 
@@ -670,7 +671,7 @@ class LevelDBBlockchain(Blockchain):
                                     self.OnNotify(n)
 
                         except Exception as e:
-                            service.ExecutionCompleted(engine,False, e)
+                            service.ExecutionCompleted(engine, False, e)
 
                     else:
 

--- a/neo/Implementations/Blockchains/LevelDB/TestLevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/TestLevelDBBlockchain.py
@@ -145,8 +145,8 @@ class TestLevelDBBlockchain(LevelDBBlockchain):
                     # the changes made by the contract to the database
                     try:
                         success = engine.Execute()
-#                        service.ExecutionCompleted(engine, success)
+                        # service.ExecutionCompleted(engine, success)
                         return True
                     except Exception as e:
-#                        service.ExecutionCompleted(self, False, e)
+                        # service.ExecutionCompleted(self, False, e)
                         return False

--- a/neo/Implementations/Blockchains/LevelDB/TestLevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/TestLevelDBBlockchain.py
@@ -145,8 +145,8 @@ class TestLevelDBBlockchain(LevelDBBlockchain):
                     # the changes made by the contract to the database
                     try:
                         success = engine.Execute()
-                        service.ExecutionCompleted(engine, success)
+#                        service.ExecutionCompleted(engine, success)
                         return True
                     except Exception as e:
-                        service.ExecutionCompleted(self, False, e)
+#                        service.ExecutionCompleted(self, False, e)
                         return False

--- a/neo/Implementations/Blockchains/LevelDB/TestLevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/TestLevelDBBlockchain.py
@@ -145,9 +145,8 @@ class TestLevelDBBlockchain(LevelDBBlockchain):
                     # the changes made by the contract to the database
                     try:
                         success = engine.Execute()
-                        if success:
-                            service.Commit()
+                        service.ExecutionCompleted(engine, success)
                         return True
                     except Exception as e:
-                        print("could not execute %s " % e)
+                        service.ExecutionCompleted(self, False, e)
                         return False

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -277,13 +277,15 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None):
         # drum roll?
         success = engine.Execute()
 
+        service.ExecutionCompleted(engine, success)
+
         if success:
 
-            service.TestCommit()
-
+            # this will be removed in favor of neo.EventHub
             if len(service.notifications) > 0:
                 for n in service.notifications:
                     Blockchain.Default().OnNotify(n)
+
 
             consumed = engine.GasConsumed() - Fixed8.FromDecimal(10)
             consumed.value = int(consumed.value)
@@ -305,12 +307,10 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None):
             wallet_tx.Attributes = []
 
             return wallet_tx, net_fee, engine.EvaluationStack.Items, engine.ops_processed
-        else:
-            print("error executing contract.....")
-            return None, None, None, None
 
     except Exception as e:
-        print("COULD NOT EXECUTE %s " % e)
+        service.ExecutionCompleted(engine, False, e)
+ #       print("COULD NOT EXECUTE %s " % e)
 
     return None, None, None, None
 
@@ -455,6 +455,8 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet):
 
             i_success = engine.Execute()
 
+            service.ExecutionCompleted(engine,i_success)
+
             if i_success:
                 service.TestCommit()
 
@@ -482,9 +484,7 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet):
             print("error executing deploy contract.....")
 
     except Exception as e:
-        print("COULD NOT EXECUTE %s " % e)
-        traceback.print_stack()
-        traceback.print_exc()
+        service.ExecutionCompleted(engine, False, e)
 
     return None, [], 0
 

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -372,7 +372,7 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet):
                     contract_state = i
                     break
                 elif type(i) is InteropInterface:
-                    item = i.GetInterface('neo.whatever')
+                    item = i.GetInterface()
                     if type(item) is ContractState:
                         contract_state = item
                         break

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -286,7 +286,6 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None):
                 for n in service.notifications:
                     Blockchain.Default().OnNotify(n)
 
-
             consumed = engine.GasConsumed() - Fixed8.FromDecimal(10)
             consumed.value = int(consumed.value)
 
@@ -310,7 +309,7 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None):
 
     except Exception as e:
         service.ExecutionCompleted(engine, False, e)
- #       print("COULD NOT EXECUTE %s " % e)
+#        print("COULD NOT EXECUTE %s " % e)
 
     return None, None, None, None
 
@@ -455,7 +454,7 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet):
 
             i_success = engine.Execute()
 
-            service.ExecutionCompleted(engine,i_success)
+            service.ExecutionCompleted(engine, i_success)
 
             if i_success:
                 service.TestCommit()

--- a/neo/Prompt/Notify.py
+++ b/neo/Prompt/Notify.py
@@ -7,8 +7,10 @@ from neo.Cryptography.Crypto import Crypto
 
 def SubscribeNotifications():
 
-    Blockchain.Default().Notify.on_change += HandleBlockchainNotification
+# Moving to neo.EventHub
 
+#    Blockchain.Default().Notify.on_change += HandleBlockchainNotification
+    pass
 
 def HandleBlockchainNotification(notification):
 

--- a/neo/Prompt/Notify.py
+++ b/neo/Prompt/Notify.py
@@ -7,10 +7,11 @@ from neo.Cryptography.Crypto import Crypto
 
 def SubscribeNotifications():
 
-# Moving to neo.EventHub
+    # Moving to neo.EventHub
 
-#    Blockchain.Default().Notify.on_change += HandleBlockchainNotification
+    #    Blockchain.Default().Notify.on_change += HandleBlockchainNotification
     pass
+
 
 def HandleBlockchainNotification(notification):
 

--- a/neo/Prompt/Notify.py
+++ b/neo/Prompt/Notify.py
@@ -48,7 +48,7 @@ def HandleBlockchainNotification(notification):
 
         else:
 
-            interface = state.GetInterface('t')
+            interface = state.GetInterface()
 
             if interface is not None:
                 hasjson = getattr(interface, 'ToJson', None)

--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -328,5 +328,12 @@ class ApplicationEngine(ExecutionEngine):
         )
 
         engine.LoadScript(script, False)
-        engine.Execute()
+
+        try:
+            success = engine.Execute()
+            service.ExecutionCompleted(engine, success)
+        except Exception as e:
+            service.ExecutionCompleted(engine, False, e)
+
+
         return engine

--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -335,5 +335,4 @@ class ApplicationEngine(ExecutionEngine):
         except Exception as e:
             service.ExecutionCompleted(engine, False, e)
 
-
         return engine

--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -11,10 +11,10 @@ from neo.Cryptography.ECCurve import ECDSA
 from neo.UInt160 import UInt160
 from neo.UInt256 import UInt256
 from neo.Fixed8 import Fixed8
-from neo.VM.InteropService import StackItem,stack_item_to_py
+from neo.VM.InteropService import StackItem, stack_item_to_py
 from neo.SmartContract.StorageContext import StorageContext
 from neo.SmartContract.StateReader import StateReader
-from neo.EventHub import dispatch_smart_contract_event,SmartContractEvent
+from neo.EventHub import dispatch_smart_contract_event, SmartContractEvent
 import sys
 
 from autologging import logged
@@ -83,17 +83,11 @@ class StateMachine(StateReader):
 
         return False
 
-
-
-
-
     def ExecutionCompleted(self, engine, success, error=None):
 
         # commit storages right away
         if success:
             self.Commit()
-
-
 
         height = Blockchain.Default().Height
         tx_hash = engine.ScriptContainer.Hash
@@ -101,9 +95,7 @@ class StateMachine(StateReader):
         # dispatch all notify events, along with the success of the contract execution
         for notify_event_args in self.notifications:
 
-            dispatch_smart_contract_event(SmartContractEvent.RUNTIME_NOTIFY,notify_event_args.State, notify_event_args.ScriptHash.ToString(), height, tx_hash.ToString(), success)
-
-
+            dispatch_smart_contract_event(SmartContractEvent.RUNTIME_NOTIFY, notify_event_args.State, notify_event_args.ScriptHash.ToString(), height, tx_hash.ToString(), success)
 
         # get the first script that was executed
         # this is usually the script that sets up the script to be executed
@@ -113,7 +105,6 @@ class StateMachine(StateReader):
         if len(engine.ExecutedScriptHashes) > 0:
             entry_script = UInt160(data=engine.ExecutedScriptHashes[1])
 
-
         if success:
 
             payload = []
@@ -122,12 +113,11 @@ class StateMachine(StateReader):
                 payload_item = stack_item_to_py(item)
                 payload.append(payload_item)
 
-            dispatch_smart_contract_event(SmartContractEvent.EXECUTION_SUCCESS, payload, entry_script.ToString(),height,tx_hash.ToString(),success)
+            dispatch_smart_contract_event(SmartContractEvent.EXECUTION_SUCCESS, payload, entry_script.ToString(), height, tx_hash.ToString(), success)
 
         else:
 
             dispatch_smart_contract_event(SmartContractEvent.EXECUTION_FAIL, error, entry_script.ToString(), height, tx_hash.ToString(), success)
-
 
     def Commit(self):
         if self._wb is not None:
@@ -136,7 +126,6 @@ class StateMachine(StateReader):
             self._assets.Commit(self._wb, False)
             self._contracts.Commit(self._wb, False)
             self._storages.Commit(self._wb, False)
-
 
     def TestCommit(self):
         # print("test commit items....")

--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -136,7 +136,7 @@ class StateMachine(StateReader):
     def Account_SetVotes(self, engine):
 
         try:
-            account = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AccountState.AccountState')
+            account = engine.EvaluationStack.Pop().GetInterface()
 
             vote_list = engine.EvaluationStack.Pop().GetArray()
         except Exception as e:
@@ -251,7 +251,7 @@ class StateMachine(StateReader):
 
     def Asset_Renew(self, engine):
 
-        current_asset = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AssetState.AssetState')
+        current_asset = engine.EvaluationStack.Pop().GetInterface()
 
         if current_asset is None:
             return False
@@ -409,7 +409,7 @@ class StateMachine(StateReader):
 
     def Contract_GetStorageContext(self, engine):
 
-        contract = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.ContractState.ContractState')
+        contract = engine.EvaluationStack.Pop().GetInterface()
 
         self.__log.debug("CONTRACT Get storage context %s " % contract)
         if contract.ScriptHash.ToBytes() in self._contracts_created:
@@ -445,7 +445,7 @@ class StateMachine(StateReader):
         context = None
         try:
             item = engine.EvaluationStack.Pop()
-            context = item.GetInterface('neo.SmartContract.StorageContext.StorageContext')
+            context = item.GetInterface()
             shash = context.ScriptHash
         except Exception as e:
             print("could not get storage context %s " % e)
@@ -489,7 +489,7 @@ class StateMachine(StateReader):
         context = None
         try:
 
-            context = engine.EvaluationStack.Pop().GetInterface('neo.SmartContract.StorageContext.StorageContext')
+            context = engine.EvaluationStack.Pop().GetInterface()
         except Exception as e:
             self.__log.debug("Storage Context Not found on stack")
             return False
@@ -524,7 +524,7 @@ class StateMachine(StateReader):
 
     def Storage_Delete(self, engine):
 
-        context = engine.EvaluationStack.Pop().GetInterface('neo.SmartContract.StorageContext.StorageContext')
+        context = engine.EvaluationStack.Pop().GetInterface()
 
         if not self.CheckStorageContext(context):
             return False

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -379,7 +379,7 @@ class StateReader(InteropService):
 
     def Header_GetHash(self, engine):
 
-        header = engine.EvaluationStack.Pop().GetInterface('neo.Core.BlockBase.BlockBase')
+        header = engine.EvaluationStack.Pop().GetInterface()
         if header is None:
             return False
         engine.EvaluationStack.PushT(header.Hash.ToArray())
@@ -387,7 +387,7 @@ class StateReader(InteropService):
 
     def Header_GetVersion(self, engine):
 
-        header = engine.EvaluationStack.Pop().GetInterface('neo.Core.BlockBase.BlockBase')
+        header = engine.EvaluationStack.Pop().GetInterface()
         if header is None:
             return False
         engine.EvaluationStack.PushT(header.Version)
@@ -395,7 +395,7 @@ class StateReader(InteropService):
 
     def Header_GetPrevHash(self, engine):
 
-        header = engine.EvaluationStack.Pop().GetInterface('neo.Core.BlockBase.BlockBase')
+        header = engine.EvaluationStack.Pop().GetInterface()
         if header is None:
             return False
         engine.EvaluationStack.PushT(header.PrevHash.ToArray())
@@ -403,7 +403,7 @@ class StateReader(InteropService):
 
     def Header_GetMerkleRoot(self, engine):
 
-        header = engine.EvaluationStack.Pop().GetInterface('neo.Core.BlockBase.BlockBase')
+        header = engine.EvaluationStack.Pop().GetInterface()
         if header is None:
             return False
         engine.EvaluationStack.PushT(header.MerkleRoot.ToArray())
@@ -411,7 +411,7 @@ class StateReader(InteropService):
 
     def Header_GetTimestamp(self, engine):
 
-        header = engine.EvaluationStack.Pop().GetInterface('neo.Core.BlockBase.BlockBase')
+        header = engine.EvaluationStack.Pop().GetInterface()
         if header is None:
             return False
         engine.EvaluationStack.PushT(header.Timestamp)
@@ -420,7 +420,7 @@ class StateReader(InteropService):
 
     def Header_GetConsensusData(self, engine):
 
-        header = engine.EvaluationStack.Pop().GetInterface('neo.Core.BlockBase.BlockBase')
+        header = engine.EvaluationStack.Pop().GetInterface()
         if header is None:
             return False
         engine.EvaluationStack.PushT(header.ConsensusData)
@@ -428,7 +428,7 @@ class StateReader(InteropService):
 
     def Header_GetNextConsensus(self, engine):
 
-        header = engine.EvaluationStack.Pop().GetInterface('neo.Core.BlockBase.BlockBase')
+        header = engine.EvaluationStack.Pop().GetInterface()
         if header is None:
             return False
         engine.EvaluationStack.PushT(header.NextConsensus.ToArray())
@@ -436,7 +436,7 @@ class StateReader(InteropService):
 
     def Block_GetTransactionCount(self, engine):
 
-        block = engine.EvaluationStack.Pop().GetInterface('neo.Core.Block.Block')
+        block = engine.EvaluationStack.Pop().GetInterface()
         if block is None:
             return False
         engine.EvaluationStack.PushT(len(block.Transactions))
@@ -444,7 +444,7 @@ class StateReader(InteropService):
 
     def Block_GetTransactions(self, engine):
 
-        block = engine.EvaluationStack.Pop().GetInterface('neo.Core.Block.Block')
+        block = engine.EvaluationStack.Pop().GetInterface()
         if block is None:
             return False
 
@@ -454,7 +454,7 @@ class StateReader(InteropService):
 
     def Block_GetTransaction(self, engine):
 
-        block = engine.EvaluationStack.Pop().GetInterface('neo.Core.Block.Block')
+        block = engine.EvaluationStack.Pop().GetInterface()
         index = engine.EvaluationStack.Pop().GetBigInteger()
 
         if block is None or index < 0 or index > len(block.Transactions):
@@ -466,7 +466,7 @@ class StateReader(InteropService):
 
     def Transaction_GetHash(self, engine):
 
-        tx = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.Transaction.Transaction')
+        tx = engine.EvaluationStack.Pop().GetInterface()
         if tx is None:
             return False
 
@@ -475,7 +475,7 @@ class StateReader(InteropService):
 
     def Transaction_GetType(self, engine):
 
-        tx = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.Transaction.Transaction')
+        tx = engine.EvaluationStack.Pop().GetInterface()
         if tx is None:
             return False
 
@@ -485,7 +485,7 @@ class StateReader(InteropService):
 
     def Transaction_GetAttributes(self, engine):
 
-        tx = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.Transaction.Transaction')
+        tx = engine.EvaluationStack.Pop().GetInterface()
         if tx is None:
             return False
 
@@ -495,7 +495,7 @@ class StateReader(InteropService):
 
     def Transaction_GetInputs(self, engine):
 
-        tx = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.Transaction.Transaction')
+        tx = engine.EvaluationStack.Pop().GetInterface()
         if tx is None:
             return False
 
@@ -505,7 +505,7 @@ class StateReader(InteropService):
 
     def Transaction_GetOutputs(self, engine):
 
-        tx = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.Transaction.Transaction')
+        tx = engine.EvaluationStack.Pop().GetInterface()
 
         if tx is None:
             return False
@@ -520,7 +520,7 @@ class StateReader(InteropService):
 
     def Transaction_GetReferences(self, engine):
 
-        tx = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.Transaction.Transaction')
+        tx = engine.EvaluationStack.Pop().GetInterface()
 
         if tx is None:
             return False
@@ -532,7 +532,7 @@ class StateReader(InteropService):
 
     def Attribute_GetUsage(self, engine):
 
-        attr = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.TransactionAttribute.TransactionAttribute')
+        attr = engine.EvaluationStack.Pop().GetInterface()
         if attr is None:
             return False
         engine.EvaluationStack.PushT(attr.Usage)
@@ -540,7 +540,7 @@ class StateReader(InteropService):
 
     def Attribute_GetData(self, engine):
 
-        attr = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.TransactionAttribute.TransactionAttribute')
+        attr = engine.EvaluationStack.Pop().GetInterface()
         if attr is None:
             return False
         engine.EvaluationStack.PushT(attr.Data)
@@ -548,7 +548,7 @@ class StateReader(InteropService):
 
     def Input_GetHash(self, engine):
 
-        input = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.Transaction.TransactionInput')
+        input = engine.EvaluationStack.Pop().GetInterface()
         if input is None:
             return False
         engine.EvaluationStack.PushT(input.PrevHash.ToArray())
@@ -556,7 +556,7 @@ class StateReader(InteropService):
 
     def Input_GetIndex(self, engine):
 
-        input = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.Transaction.TransactionInput')
+        input = engine.EvaluationStack.Pop().GetInterface()
         if input is None:
             return False
 
@@ -565,7 +565,7 @@ class StateReader(InteropService):
 
     def Output_GetAssetId(self, engine):
 
-        output = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.Transaction.TransactionOutput')
+        output = engine.EvaluationStack.Pop().GetInterface()
 
         if output is None:
             return False
@@ -575,7 +575,7 @@ class StateReader(InteropService):
 
     def Output_GetValue(self, engine):
 
-        output = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.Transaction.TransactionOutput')
+        output = engine.EvaluationStack.Pop().GetInterface()
         if output is None:
             return False
 
@@ -584,7 +584,7 @@ class StateReader(InteropService):
 
     def Output_GetScriptHash(self, engine):
 
-        output = engine.EvaluationStack.Pop().GetInterface('neo.Core.TX.Transaction.TransactionOutput')
+        output = engine.EvaluationStack.Pop().GetInterface()
 
         if output is None:
             return False
@@ -594,7 +594,7 @@ class StateReader(InteropService):
 
     def Account_GetScriptHash(self, engine):
 
-        account = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AccountState.AccountState')
+        account = engine.EvaluationStack.Pop().GetInterface()
         if account is None:
             return False
         engine.EvaluationStack.PushT(account.ScriptHash.ToArray())
@@ -602,7 +602,7 @@ class StateReader(InteropService):
 
     def Account_GetVotes(self, engine):
 
-        account = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AccountState.AccountState')
+        account = engine.EvaluationStack.Pop().GetInterface()
         if account is None:
             return False
 
@@ -612,7 +612,7 @@ class StateReader(InteropService):
 
     def Account_GetBalance(self, engine):
 
-        account = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AccountState.AccountState')
+        account = engine.EvaluationStack.Pop().GetInterface()
         assetId = UInt256(data=engine.EvaluationStack.Pop().GetByteArray())
 
         if account is None:
@@ -623,7 +623,7 @@ class StateReader(InteropService):
 
     def Asset_GetAssetId(self, engine):
 
-        asset = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AssetState.AssetState')
+        asset = engine.EvaluationStack.Pop().GetInterface()
         if asset is None:
             return False
         engine.EvaluationStack.PushT(asset.AssetId.ToArray())
@@ -631,7 +631,7 @@ class StateReader(InteropService):
 
     def Asset_GetAssetType(self, engine):
 
-        asset = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AssetState.AssetState')
+        asset = engine.EvaluationStack.Pop().GetInterface()
         if asset is None:
             return False
         engine.EvaluationStack.PushT(asset.AssetType)
@@ -639,7 +639,7 @@ class StateReader(InteropService):
 
     def Asset_GetAmount(self, engine):
 
-        asset = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AssetState.AssetState')
+        asset = engine.EvaluationStack.Pop().GetInterface()
         if asset is None:
             return False
         engine.EvaluationStack.PushT(asset.Amount.GetData())
@@ -647,7 +647,7 @@ class StateReader(InteropService):
 
     def Asset_GetAvailable(self, engine):
 
-        asset = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AssetState.AssetState')
+        asset = engine.EvaluationStack.Pop().GetInterface()
         if asset is None:
             return False
         engine.EvaluationStack.PushT(asset.Available.GetData())
@@ -655,7 +655,7 @@ class StateReader(InteropService):
 
     def Asset_GetPrecision(self, engine):
 
-        asset = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AssetState.AssetState')
+        asset = engine.EvaluationStack.Pop().GetInterface()
         if asset is None:
             return False
         engine.EvaluationStack.PushT(asset.Precision)
@@ -663,7 +663,7 @@ class StateReader(InteropService):
 
     def Asset_GetOwner(self, engine):
 
-        asset = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AssetState.AssetState')
+        asset = engine.EvaluationStack.Pop().GetInterface()
         if asset is None:
             return False
         engine.EvaluationStack.PushT(asset.Owner.EncodePoint(True))
@@ -671,7 +671,7 @@ class StateReader(InteropService):
 
     def Asset_GetAdmin(self, engine):
 
-        asset = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AssetState.AssetState')
+        asset = engine.EvaluationStack.Pop().GetInterface()
         if asset is None:
             return False
         engine.EvaluationStack.PushT(asset.Admin.ToArray())
@@ -679,7 +679,7 @@ class StateReader(InteropService):
 
     def Asset_GetIssuer(self, engine):
 
-        asset = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.AssetState.AssetState')
+        asset = engine.EvaluationStack.Pop().GetInterface()
         if asset is None:
             return False
         engine.EvaluationStack.PushT(asset.Issuer.ToArray())
@@ -687,7 +687,7 @@ class StateReader(InteropService):
 
     def Contract_GetScript(self, engine):
 
-        contract = engine.EvaluationStack.Pop().GetInterface('neo.Core.State.ContractState.ContractState')
+        contract = engine.EvaluationStack.Pop().GetInterface()
         if contract is None:
             return False
         engine.EvaluationStack.PushT(contract.Code.Script)
@@ -707,7 +707,7 @@ class StateReader(InteropService):
         context = None
         try:
             item = engine.EvaluationStack.Pop()
-            context = item.GetInterface('neo.SmartContract.StorageContext.StorageContext')
+            context = item.GetInterface()
             shash = context.ScriptHash
         except Exception as e:
             print("could not get storage context %s " % e)

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -217,7 +217,6 @@ class StateReader(InteropService):
 #                                      Blockchain.Default().Height,
 #                                      engine.ScriptContainer.Hash)
 
-
         # this will bubble up to where the script was initially run
 
         args = NotifyEventArgs(

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -30,7 +30,11 @@ class ExecutionEngine():
     _EvaluationStack = None
     _AltStack = None
 
+    _ExecutedScriptHashes = None
+
     ops_processed = 0
+
+
 
     @property
     def ScriptContainer(self):
@@ -70,6 +74,11 @@ class ExecutionEngine():
     def EntryContext(self):
         return self.InvocationStack.Peek(self.InvocationStack.Count - 1)
 
+
+    @property
+    def ExecutedScriptHashes(self):
+        return self._ExecutedScriptHashes
+
     def __init__(self, container=None, crypto=None, table=None, service=None):
         self._ScriptContainer = container
         self._Crypto = crypto
@@ -79,7 +88,7 @@ class ExecutionEngine():
         self._InvocationStack = RandomAccessStack(name='Invocation')
         self._EvaluationStack = RandomAccessStack(name='Evaluation')
         self._AltStack = RandomAccessStack(name='Alt')
-
+        self._ExecutedScriptHashes = []
         self.ops_processed = 0
 
     def AddBreakPoint(self, position):
@@ -757,6 +766,8 @@ class ExecutionEngine():
 
         context = ExecutionContext(self, script, push_only)
         self._InvocationStack.PushT(context)
+
+        self._ExecutedScriptHashes.append(context.ScriptHash())
 
     def RemoveBreakPoint(self, position):
 

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -34,8 +34,6 @@ class ExecutionEngine():
 
     ops_processed = 0
 
-
-
     @property
     def ScriptContainer(self):
         return self._ScriptContainer
@@ -73,7 +71,6 @@ class ExecutionEngine():
     @property
     def EntryContext(self):
         return self.InvocationStack.Peek(self.InvocationStack.Count - 1)
-
 
     @property
     def ExecutedScriptHashes(self):

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -358,5 +358,8 @@ def stack_item_to_py(stack_item):
     elif isinstance(stack_item, InteropInterface):
         return stack_item.GetInterface()
 
+    elif isinstance(stack_item, Struct):
+        return stack_item.GetArray()
+
     else:
         raise ValueError('Not supported')

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -33,9 +33,7 @@ class StackItem(EquatableMixin):
     def GetArray(self):
         raise Exception('Not supported')
 
-    def GetInterface(self, t):
-        self.__log.debug("You may need to push %s  using FromInterface " % t)
-#        raise Exception('Not Supported')
+    def GetInterface(self):
         return None
 
     def GetString(self):
@@ -236,7 +234,7 @@ class InteropInterface(StackItem):
 #        print("calling frame %s " % sys._getframe(2))
         raise Exception("Not supported- Cant get byte array for item %s %s " % (type(self), self._object))
 
-    def GetInterface(self, t):
+    def GetInterface(self):
         return self._object
 
     def __str__(self):
@@ -356,6 +354,9 @@ def stack_item_to_py(stack_item):
 
     elif isinstance(stack_item, ByteArray):
         return stack_item.GetBigInteger()
+
+    elif isinstance(stack_item, InteropInterface):
+        return stack_item.GetInterface()
 
     else:
         raise ValueError('Not supported')

--- a/neo/Wallets/NEP5Token.py
+++ b/neo/Wallets/NEP5Token.py
@@ -5,7 +5,7 @@ from neo.Prompt.Utils import parse_param
 from neo.UInt160 import UInt160
 import binascii
 from decimal import getcontext, Decimal
-
+import traceback
 
 class NEP5Token(VerificationCode):
 
@@ -84,6 +84,8 @@ class NEP5Token(VerificationCode):
             return balance
         except Exception as e:
             print("could not get balance: %s " % e)
+            traceback.print_stack()
+
         return 0
 
     def Transfer(self, wallet, from_addr, to_addr, amount):

--- a/neo/Wallets/NEP5Token.py
+++ b/neo/Wallets/NEP5Token.py
@@ -7,6 +7,7 @@ import binascii
 from decimal import getcontext, Decimal
 import traceback
 
+
 class NEP5Token(VerificationCode):
 
     name = None


### PR DESCRIPTION
- Added `execution_success` to `SmartContractEvent`, so that `Notify` events can have this context for when they are being processed
- Moved dispatch of `Notify` to occur after execution of the contract, and include the `execution_success` in the event

Notes: Ideally, when dispatching the events we'd be passing around `UInt160` or `UInt256` for tx hash or for contract hashes, that way any service consuming the events will have a flexible data type to use