### PR TITLE
Added Wallet.GetSyncedBalances

### DIFF
--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -69,3 +69,8 @@ class UserWalletTestCase(WalletFixtureTestCase):
         self.assertEqual(token.symbol, 'NEP5')
         self.assertEqual(token.decimals, 8)
         self.assertEqual(token.Address, 'AYhE3Svuqdfh1RtzvE8hUhNR7HSpaSDFQg')
+
+    def test_4_get_synced_balances(self):
+        wallet = self.GetWallet1()
+        synced_balances = wallet.GetSyncedBalances()
+        self.assertEqual(len(synced_balances), 2)

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -21,6 +21,7 @@ from neo.Settings import settings
 from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
 from neo.Fixed8 import Fixed8
 from neo.UInt160 import UInt160
+from neo.UInt256 import UInt256
 from neo.Core.Helper import Helper
 
 from itertools import groupby
@@ -1145,6 +1146,25 @@ class Wallet(object):
             success |= res
 
         return success
+
+    def GetSyncedBalances(self):
+        """
+        Returns a list of synced balances. The list looks like this:
+        [('NEO', 100.0), ('NEOGas', 100.0)]
+
+        Returns
+            list: [(asset_name, amount), ...]
+        """
+        assets = self.GetCoinAssets()
+        balances = []
+        for asset in assets:
+            if type(asset) is UInt256:
+                bc_asset = Blockchain.Default().GetAssetState(asset.ToBytes())
+                total = self.GetBalance(asset).value / Fixed8.D
+                balances.append((bc_asset.GetName(), total))
+            elif type(asset) is NEP5Token:
+                balances.append((asset.symbol, self.GetBalance(asset)))
+        return balances
 
     def ToJson(self, verbose=False):
         # abstract


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

Added `Wallet.GetSyncedBalances()` to easily get a list of fully synced balances. External dApps often need a way to know the current wallet balances.

The code is basically reused from the `ToJson()` method.

Any feedback whether it would be better to return an object with asset name as key and balance as value, or keep the list style like now would be appreciated.

**How did you solve this problem?**

n/a

**How did you make sure your solution works?**

Manual and automated tests

**Did you add any tests?**

Yes

**Did you check your `pycodestyle`?**

yes

**Are there any special changes in the code that we should be aware of?**

No

**Are you making a PR to a feature branch or development rather than master?**

development