### PR TITLE
Logging: configure through settings, enable (rotating) logfile

### DIFF
--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -8,9 +8,9 @@ reconfigure them by calling the `setup(..)` methods.
 """
 import json
 import os
-import sys
-import logging
 from json.decoder import JSONDecodeError
+
+import logzero
 
 # Create am absolute references to the project root folder. Used for
 # specifying the various filenames.
@@ -53,6 +53,12 @@ class SettingsHolder:
     BOOTSTRAP_FILE = None
 
     ALL_FEES = None
+
+    # Logging settings
+    log_smart_contract_events = True
+    logfile = None
+    logfile_max_bytes = None
+    logfile_backup_count = None
 
     # Helpers
     @property
@@ -115,9 +121,25 @@ class SettingsHolder:
         """ Load settings from the privnet JSON config file """
         self.setup(FILENAME_SETTINGS_PRIVNET)
 
+    def log_smart_contract_events(self, is_enabled=True):
+        self.log_smart_contract_events = is_enabled
+
+    def logfile(self, fn, max_bytes=0, backup_count=0):
+        """
+        Setup logging to a (rotating) logfile.
+
+        Args:
+            fn (str): Logfile. If fn is None, disable file logging
+            max_bytes (int): Maximum number of bytes per logfile. If used together with backup_count,
+                             logfile will be rotated when it reaches this amount of bytes.
+            backup_count (int): Number of rotated logfiles to keep
+        """
+        logzero.logfile(fn, maxBytes=max_bytes, backupCount=backup_count)
+
 
 # Settings instance used by external modules
 settings = SettingsHolder()
 
 # Load testnet settings as default
 settings.setup_testnet()
+settings.logfile("/tmp/test.log")

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ greenlet==0.4.12
 hyperlink==17.3.0
 idna==2.5
 incremental==17.5.0
+logzero==1.3.1
 memory-profiler==0.47
 mmh3==2.4
 mock==2.0.0


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

Flexible logging in general, and smart-contract events in particular, with configuration through `neo.Settings`. Implements [logzero](https://logzero.readthedocs.io/en/latest/#example-usage) to simplify logging from anywhere in the project.

In Settings you can now:
* enable/disable logging smart contract events with `settings.log_smart_contract_events(..)`
* Setup a (rotating) logfile with `settings.logfile(..)`

Anywhere in the code you can do `from logzero import logger` and then use it like `logger.info(..)`, `logger.debug(..)`, `logger.exception(..)`, etc. If a logfile was setup through the settings, all those log statements will also be written to the logfile.

Note: with this approach, we could replace the various `print` and `self.__log` statements with `logger.xxx(..)` calls, and it would automatically be printed correctly (and potentially with color support, if we want this) and written to a previously configured logfile.

**How did you solve this problem?**

Added logging setup to neo.Settings, added SC logs to EventHub and implemented logzero.

**How did you make sure your solution works?**

Manual testing

**Did you add any tests?**

No

**Did you check your `pycodestyle`?**

Yes

**Are there any special changes in the code that we should be aware of?**

No

**Are you making a PR to a feature branch or development rather than master?**

feature-events
