### PR TITLE
Added Wallet.GetAssetAmount(asset_symbol)

### DIFF
--- a/neo/Implementations/Wallets/peewee/test_user_wallet.py
+++ b/neo/Implementations/Wallets/peewee/test_user_wallet.py
@@ -145,3 +145,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
         wallet.AddNEP5Token(token)
 
         self.assertEqual(len(wallet.GetTokens()), 1)
+
+        # Test for a working `wallet.GetAssetAmount(..)` response
+        gas_amount = wallet.GetAssetAmount("NEOGas")
+        self.assertEqual(gas_amount, 100.0)

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -1183,6 +1183,25 @@ class Wallet(object):
                 balances.append((asset.symbol, self.GetBalance(asset)))
         return balances
 
+    def GetAssetAmount(self, asset_symbol):
+        """
+        Return the amount of an asset in this wallets synced balances
+
+        Usage:
+
+            gas_amount = wallet.GetAssetAmount("NEOGas")
+
+        Returns:
+            None: if asset not in this wallet's synced balances
+            float: the amount of the asset in this wallet's synced balances
+        """
+        synced_balances = self.GetSyncedBalances()
+        for balance in synced_balances:
+            asset, amount = balance
+            if asset == asset_symbol:
+                return amount
+        return None
+
     def ToJson(self, verbose=False):
         # abstract
         pass

--- a/neo/Wallets/test_wallet.py
+++ b/neo/Wallets/test_wallet.py
@@ -1,10 +1,13 @@
+import binascii
+import hashlib
+from tempfile import NamedTemporaryFile
+
+from neo.Wallets.Wallet import Wallet
 from neo.Utils.NeoTestCase import NeoTestCase
 from neo.Wallets.KeyPair import KeyPair
 from neo.UInt160 import UInt160
 from neo.SmartContract.Contract import Contract
-import binascii
 from neo.Cryptography.Crypto import Crypto
-import hashlib
 
 
 class WalletTestCase(NeoTestCase):
@@ -102,3 +105,10 @@ class WalletTestCase(NeoTestCase):
         sig = Crypto.Sign(self.nmsg, key.PrivateKey, key.PublicKey)
 
         self.assertEqual(sig.hex(), self.neon_sig)
+
+    def test_wallet_getassetamount(self):
+        with NamedTemporaryFile() as wallet_file:
+            wallet = Wallet(path=wallet_file.name, passwordKey="test", create=True)
+            wallet.CreateKey()
+            gas_amount = wallet.GetAssetAmount("NEOGas")
+            self.assertIsNone(gas_amount)


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

Added `Wallet.GetAssetAmount(asset_symbol)`, which returns the amount of this asset in this wallet's synced balances.

It's often needed for dapps to query whether a wallet has a certain balance, for instance `NEOGas`. 

Not sure if you want this to be part of `Wallet`, but I thought it might be a good place to start. We could also give it a different name, I started with `GetAssetAmount` because it seemed in tune with the other method names. Should we name it `GetAsset` or something else?

**How did you solve this problem?**

implemented it

**How did you make sure your solution works?**

Testing

**Did you add any tests?**

Yes

**Are there any special changes in the code that we should be aware of?**

No
