### PR TITLE
setup.py: set python_requires='>=3.4, <3.6'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ reqs = [str(ir.req) for ir in install_reqs]
 
 setup(
     name='neo-python',
+    python_requires='>=3.4, <3.6',
     version='0.4.0',
     description="Python Node and SDK for the NEO blockchain",
     long_description=readme,


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

Minor fix to `setup.py`: set `python_requires='>=3.4, <3.6'`

**How did you solve this problem?**

n/a

**How did you make sure your solution works?**

n/a

**Did you add any tests?**

no

**Are there any special changes in the code that we should be aware of?**

no
