### PR TITLE
Fix Wallet.ContainsKey

### DIFF
--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -220,7 +220,7 @@ class Wallet(object):
         Returns:
             bool: True if exists, False otherwise.
         """
-        return self.ContainsKeyHash(Crypto.ToScriptHash(public_key.encode_point(True), unhex=False))
+        return self.ContainsKeyHash(Crypto.ToScriptHash(public_key.encode_point(True), unhex=True))
 
     def ContainsKeyHash(self, public_key_hash):
         """

--- a/neo/Wallets/test_wallet.py
+++ b/neo/Wallets/test_wallet.py
@@ -6,6 +6,8 @@ import binascii
 from neo.Cryptography.Crypto import Crypto
 import hashlib
 
+from neo.Wallets.Wallet import Wallet
+
 
 class WalletTestCase(NeoTestCase):
 
@@ -102,3 +104,15 @@ class WalletTestCase(NeoTestCase):
         sig = Crypto.Sign(self.nmsg, key.PrivateKey, key.PublicKey)
 
         self.assertEqual(sig.hex(), self.neon_sig)
+
+    def test_get_contains_key_should_be_found(self):
+        wallet = Wallet("fakepath", "123", True)
+        wallet.CreateKey()
+        keypair = wallet.GetKeys()[0]
+        self.assertTrue(wallet.ContainsKey(keypair.PublicKey))
+
+    def test_get_contains_key_should_not_be_found(self):
+        wallet = Wallet("fakepath", "123", True)
+        wallet.CreateKey()
+        keypair = KeyPair(priv_key=self.pk)
+        self.assertFalse(wallet.ContainsKey(keypair.PublicKey))


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
Wallet.ContainsKey was not working

**How did you solve this problem?**
Change the `unhex` parameter to match [this](https://github.com/CityOfZion/neo-python/blob/master/neo/Wallets/KeyPair.py#L81)
```self.PublicKeyHash = Crypto.ToScriptHash(self.PublicKey.encode_point(True), unhex=True)```

Because `Wallet._keys` stores that same `PublicKeyHash` (see [here](https://github.com/CityOfZion/neo-python/blob/master/neo/Wallets/Wallet.py#L278))

**How did you make sure your solution works?**
- wrote 2 tests
- ran `python -m unittest discover neo` and did not break anything else.

**Did you add any tests?**
yes

**Are there any special changes in the code that we should be aware of?**
no
