### PR TITLE
Updated Storage.Put() GAS calculation

### DIFF
--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -301,7 +301,7 @@ class ApplicationEngine(ExecutionEngine):
             l1 = len(self.EvaluationStack.Peek(1).GetByteArray())
             l2 = len(self.EvaluationStack.Peek(2).GetByteArray())
 
-            return int(((l1 + l2 - 1) / 1024 + 1) * 1000)
+            return int(((l1 + l2 - 1) * 1000) / 1024)
 
         elif api == "Neo.Storage.Delete":
             return 100


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
Storage.Put() currently overcharges by setting a default GAS fee of 1 (compared to the documented system fees of 1 GAS per KB).

**How did you solve this problem?**
Proposed an updated formula for GAS calculation.

**How did you make sure your solution works?**
Logged new return value to ensure `(1024 bytes x 1000) / 1024 == 1000`

**Did you add any tests?**
Not yet. PR & solution up for discussion.

**Are there any special changes in the code that we should be aware of?**
N/A

There seems to be a similar code for the C# engine: https://github.com/neo-project/neo/blob/f6b2c8a556b2cad17f1180faabb6a42fcd16a019/neo/SmartContract/ApplicationEngine.cs#L255

I cannot confirm they have the same issue but it seems likely by the code. I haven't written any tests for this, I've had a look at the current tests but it isn't immediately clear to me how I would go about it other than confirming the formula.

I'm also not entirely sure that the `-1` is necessary either, `l1` and `l2` directly correlate to the number of bytes being stored e.g. `PUT(ctx, "abc", "defghi")` mean `l1 = 3` `l2 = 6`
