### PR TITLE
Update prompt hinting/autocomplete

### DIFF
--- a/prompt.py
+++ b/prompt.py
@@ -134,11 +134,12 @@ class PromptInterface(object):
     def get_completer(self):
 
         standard_completions = ['block', 'tx', 'header', 'mem', 'neo', 'gas',
-                                'help', 'state', 'node', 'exit', 'quit',
+                                'help', 'state', 'nodes', 'exit', 'quit',
                                 'config', 'import', 'export', 'open',
                                 'wallet', 'contract', 'asset', 'wif',
                                 'watch_addr', 'contract_addr', 'testinvoke', 'tkn_send',
-                                'tkn_mint', 'tkn_send_from', 'tkn_approve', 'tkn_allowance', ]
+                                'tkn_mint', 'tkn_send_from', 'tkn_approve', 'tkn_allowance', 
+                                'build', ]
 
         if self.Wallet:
             for addr in self.Wallet.Addresses:


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

Inaccurate command availability in command hinting.

**How did you solve this problem?**

* Add a new `build` in prompt hint.
* Rename `node` to `nodes` in prompt hint, as `nodes` seems to be the primary command name, while `node` been the alias (for legacy support?).

**How did you make sure your solution works?**

* Basic smoke test on `prompt.py` against privatenet.

**Did you add any tests?**

Not Applicable.

**Are there any special changes in the code that we should be aware of?**

No.

