### PR TITLE
Fix comments to show correct location for privnet-claim-neo-and-gas.py

### DIFF
--- a/scripts/privnet-claim-neo-and-gas.py
+++ b/scripts/privnet-claim-neo-and-gas.py
@@ -15,11 +15,11 @@ The output of the script is two things:
 
 Run it like this:
 
-    python3 contrib/privnet-claim-neo-and-gas.py
+    python3 scripts/privnet-claim-neo-and-gas.py
 
 There are several parameters you can configure with cli args. Take a look at the help:
 
-    python3 contrib/privnet-claim-neo-and-gas.py -h
+    python3 scripts/privnet-claim-neo-and-gas.py -h
 
 This script takes several minutes to complete. Be patient!
 """


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
Incorrect path in comments for `privnet-claim-neo-and-gas.py`

**How did you solve this problem?**
Updated comment

**How did you make sure your solution works?**
Just a comment

**Did you add any tests?**
N/a

**Are there any special changes in the code that we should be aware of?**
Nope
