### PR TITLE
Add warning message for invalid wallet parameter

### DIFF
--- a/prompt.py
+++ b/prompt.py
@@ -437,6 +437,8 @@ class PromptInterface(object):
                 AddAlias(self.Wallet, arguments[1], arguments[2])
             else:
                 print("Please supply an address and title")
+        else:
+            print("wallet: '{}' is an invalid parameter".format(item))
 
     def do_send(self, arguments):
         construct_and_send(self, self.Wallet, arguments)


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

Display an error message indicating invalid parameter(s) for `wallet` command.

**How did you solve this problem?**

By checking adding a catch all for `item` matching and print out a console message.

Example:

```
neo> wallet sync
wallet: 'sync' is an invalid parameter
```

**How did you make sure your solution works?**

Basic smoke test on prompt.py against privatenet.

**Did you add any tests?**

Not Applicable.

**Are there any special changes in the code that we should be aware of?**

No.
