### PR TITLE
Feature vm additions

### DIFF
--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -750,7 +750,6 @@ class ExecutionEngine():
             elif opcode == APPEND:
                 newItem = estack.Pop()
 
-
                 if type(newItem) is Struct:
                     newItem = newItem.Clone()
 
@@ -763,7 +762,6 @@ class ExecutionEngine():
                 arr = arrItem.GetArray()
 
                 arr.append(newItem)
-
 
             elif opcode == REVERSE:
 

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -747,6 +747,32 @@ class ExecutionEngine():
 
                 estack.PushT(Struct(items))
 
+            elif opcode == APPEND:
+                newItem = estack.Pop()
+
+
+                if type(newItem) is Struct:
+                    newItem = newItem.Clone()
+
+                arrItem = estack.Pop()
+
+                if not arrItem.IsArray:
+                    self._VMState |= VMState.FAULT
+                    return
+
+                arr = arrItem.GetArray()
+
+                arr.append(newItem)
+
+
+            elif opcode == REVERSE:
+
+                arrItem = estack.Pop()
+                if not arrItem.IsArray:
+                    self._VMState |= VMState.FAULT
+                    return
+                arrItem.GetArray().reverse()
+
             elif opcode == THROW:
                 self._VMState |= VMState.FAULT
                 return

--- a/neo/VM/OpCode.py
+++ b/neo/VM/OpCode.py
@@ -199,7 +199,8 @@ PICKITEM = b'\xC3'
 SETITEM = b'\xC4'
 NEWARRAY = b'\xC5'  # 用作引用類型
 NEWSTRUCT = b'\xC6'  # 用作值類型
-
+APPEND = b'\xC8'
+REVERSE = b'\xC9'
 
 import sys
 import importlib


### PR DESCRIPTION
Implementing new VM Opcodes recently introduced to the C# VM in this issue:
https://github.com/neo-project/neo/issues/117

This goes along with neo-boa commit https://github.com/CityOfZion/neo-boa/commit/0bb91e754ed575c6a528ff0c469d3ac713eb4085, which provides compiler support for these OpCodes

So... now we can do this in a smart contract:
```
m = [1, 2, 4]
m.reverse()

m.append(8)

Notify(m) # this will output [4,2,1,8]
```
