### PR TITLE
 Fix LevelDBBlockchain.GetBlockHash, add tests + docstrings for affected methods.

### DIFF
--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -549,7 +549,7 @@ class LevelDBBlockchain(Blockchain):
 
             if header.Index - 1 >= len(self._header_index) + count:
                 logger.info(
-                    "header in greater than header index length: %s %s " % (header.Index, len(self._header_index)))
+                    "header is greater than header index length: %s %s " % (header.Index, len(self._header_index)))
                 break
 
             if header.Index < count + len(self._header_index):

--- a/neo/Implementations/Blockchains/LevelDB/test_LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/test_LevelDBBlockchain.py
@@ -1,0 +1,36 @@
+from neo.Utils.BlockchainFixtureTestCase import BlockchainFixtureTestCase
+
+
+class LevelDBBlockchainTest(BlockchainFixtureTestCase):
+    @classmethod
+    def leveldb_testpath(self):
+        return './fixtures/test_chain'
+
+    def test_01_initial_setup(self):
+        self.assertEqual(self._blockchain.Height, 756619)
+
+    def test_02_GetBlockHash(self):
+        # test requested block height exceeding blockchain current_height
+        result = self._blockchain.GetBlockHash(800000)
+        self.assertEqual(result, None)
+
+        # test header index length mismatch
+        # save index to restore later
+        saved = self._blockchain._header_index
+        self._blockchain._header_index = self._blockchain._header_index[:10]
+        result = self._blockchain.GetBlockHash(100)
+        self.assertEqual(result, None)
+        self._blockchain._header_index = saved
+
+        # finally test correct retrieval
+        result = self._blockchain.GetBlockHash(100)
+        self.assertEqual(result, self._blockchain._header_index[100])
+
+    def test_03_GetBlockByHeight(self):
+        # test correct retrieval
+        block = self._blockchain.GetBlockByHeight(100)
+        self.assertEqual(block.GetHashCode().ToString(), self._blockchain.GetBlockHash(100).decode('utf-8'))
+
+        # and also a invalid retrieval
+        block = self._blockchain.GetBlockByHeight(800000)
+        self.assertEqual(block, None)


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
`LevelDBBlockchain.GetBlockHash()` returned invalid values on check failures causing [GetBlock()](https://github.com/CityOfZion/neo-python/blob/aff3e6ca415b45ccb4f6bff9350a60a40e54538a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py#L508) and [GetBlockByHeight()](https://github.com/CityOfZion/neo-python/blob/aff3e6ca415b45ccb4f6bff9350a60a40e54538a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py#L490) (who rely on the return values) to behave incorrectly.

It now matches the [C# implementation](https://github.com/neo-project/neo/blob/8e1e4f2b91e75c11d35cff3e2607a5fcbf0747ab/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.cs#L206) as well 

- It also addresses a typo in `AddHeaders()`.

**How did you solve this problem?**
Correct the return values from `bool` to `None`

**How did you make sure your solution works?**
wrote test cases

**Did you add any tests?**
yes

**Are there any special changes in the code that we should be aware of?**
no
