### PR TITLE
fix bugs about binary writer and reader

### DIFF
--- a/neo/IO/BinaryReader.py
+++ b/neo/IO/BinaryReader.py
@@ -139,7 +139,7 @@ class BinaryReader(object):
         items = []
         for i in range(0, 2000):
             data = self.ReadBytes(64)
-            ba = bytearray(binascii.unhexlify(data))
+            ba = bytearray(data)
             ba.reverse()
             items.append(ba.hex().encode('utf-8'))
         return items

--- a/neo/IO/BinaryWriter.py
+++ b/neo/IO/BinaryWriter.py
@@ -121,7 +121,7 @@ class BinaryWriter(object):
             return self.WriteUInt16(value, endian)
 
         elif value <= 0xFFFFFFFF:
-            self.WriteByte(0xfd)
+            self.WriteByte(0xfe)
             return self.WriteUInt32(value, endian)
 
         else:


### PR DESCRIPTION
1.when writing var int to stream, if the INT's byte length is 4,should write 'fe' first, not 'fd'.

2.when converting data from stream to bytearray,don't need unhexlify.
