### PR TITLE
Fix WriteVarInt of ScriptBuilder

### DIFF
--- a/neo/VM/ScriptBuilder.py
+++ b/neo/VM/ScriptBuilder.py
@@ -46,7 +46,7 @@ class ScriptBuilder(object):
             return self.WriteUInt16(value, endian)
 
         elif value <= 0xFFFFFFFF:
-            self.WriteByte(0xfd)
+            self.WriteByte(0xfe)
             return self.WriteUInt32(value, endian)
 
         else:


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
 wrong byte written for var int.

**How did you solve this problem?**
correct the byte written

**How did you make sure your solution works?**
common sense, issue was discussed before for the `BinaryWriter` class

**Did you add any tests?**
no

**Are there any special changes in the code that we should be aware of?**
no
