### PR TITLE
Clarify config error message

### DIFF
--- a/prompt.py
+++ b/prompt.py
@@ -735,7 +735,8 @@ class PromptInterface(object):
                 print("cannot configure log.  Please specify on or off")
 
         else:
-            print("Invalid config target: %s", what)
+            print("cannot configure %s", what)
+            print("Try 'config sc-events on|off' or 'config debug on|off'")
 
     def parse_result(self, result):
         if len(result):

--- a/prompt.py
+++ b/prompt.py
@@ -31,8 +31,10 @@ from neo.Prompt.Commands.Invoke import InvokeContract, TestInvokeContract, test_
 from neo.Prompt.Commands.LoadSmartContract import LoadContract, GatherContractDetails, ImportContractAddr, \
     ImportMultiSigContractAddr
 from neo.Prompt.Commands.Send import construct_and_send, parse_and_sign
-from neo.Prompt.Commands.Tokens import token_approve_allowance, token_get_allowance, token_send, token_send_from, token_mint, token_crowdsale_register
-from neo.Prompt.Commands.Wallet import DeleteAddress, ImportWatchAddr, ImportToken, ClaimGas, DeleteToken, AddAlias, ShowUnspentCoins
+from neo.Prompt.Commands.Tokens import token_approve_allowance, token_get_allowance, token_send, token_send_from, \
+    token_mint, token_crowdsale_register
+from neo.Prompt.Commands.Wallet import DeleteAddress, ImportWatchAddr, ImportToken, ClaimGas, DeleteToken, AddAlias, \
+    ShowUnspentCoins
 from neo.Prompt.Utils import get_arg
 from neo.Settings import settings, DIR_PROJECT_ROOT
 from neo.UserPreferences import preferences
@@ -40,7 +42,7 @@ from neo.Wallets.KeyPair import KeyPair
 
 # Logfile settings & setup
 LOGFILE_FN = os.path.join(DIR_PROJECT_ROOT, 'prompt.log')
-LOGFILE_MAX_BYTES = 5e7   # 50 MB
+LOGFILE_MAX_BYTES = 5e7  # 50 MB
 LOGFILE_BACKUP_COUNT = 3  # 3 logfiles history
 settings.set_logfile(LOGFILE_FN, LOGFILE_MAX_BYTES, LOGFILE_BACKUP_COUNT)
 
@@ -49,7 +51,6 @@ FILENAME_PROMPT_HISTORY = os.path.join(DIR_PROJECT_ROOT, '.prompt.py.history')
 
 
 class PromptInterface(object):
-
     go_on = True
 
     _walletdb_loop = None
@@ -520,14 +521,14 @@ class PromptInterface(object):
             try:
                 tx, height = Blockchain.Default().GetTransaction(item)
                 if height > -1:
-
                     bjson = json.dumps(tx.ToJson(), indent=4)
                     tokens = [(Token.Command, bjson)]
                     print_tokens(tokens, self.token_style)
                     print('\n')
             except Exception as e:
                 print("Could not find transaction with id %s " % item)
-                print("Please specify a tx hash like 'db55b4d97cf99db6826967ef4318c2993852dff3e79ec446103f141c716227f6'")
+                print(
+                    "Please specify a tx hash like 'db55b4d97cf99db6826967ef4318c2993852dff3e79ec446103f141c716227f6'")
         else:
             print("please specify a tx hash")
 
@@ -618,13 +619,15 @@ class PromptInterface(object):
             tx, fee, results, num_ops = TestInvokeContract(self.Wallet, args)
 
             if tx is not None and results is not None:
-                print("\n-------------------------------------------------------------------------------------------------------------------------------------")
+                print(
+                    "\n-------------------------------------------------------------------------------------------------------------------------------------")
                 print("Test invoke successful")
                 print("Total operations: %s " % num_ops)
                 print("Results %s " % [str(item) for item in results])
                 print("Invoke TX gas cost: %s " % (tx.Gas.value / Fixed8.D))
                 print("Invoke TX Fee: %s " % (fee.value / Fixed8.D))
-                print("-------------------------------------------------------------------------------------------------------------------------------------\n")
+                print(
+                    "-------------------------------------------------------------------------------------------------------------------------------------\n")
                 print("Enter your password to continue and invoke on the network\n")
 
                 passwd = prompt("[password]> ", is_password=True)
@@ -657,13 +660,15 @@ class PromptInterface(object):
                 tx, fee, results, num_ops = test_invoke(contract_script, self.Wallet, [])
 
                 if tx is not None and results is not None:
-                    print("\n-------------------------------------------------------------------------------------------------------------------------------------")
+                    print(
+                        "\n-------------------------------------------------------------------------------------------------------------------------------------")
                     print("Test deploy invoke successful")
                     print("Total operations executed: %s " % num_ops)
                     print("Results %s " % [str(item) for item in results])
                     print("Deploy Invoke TX gas cost: %s " % (tx.Gas.value / Fixed8.D))
                     print("Deploy Invoke TX Fee: %s " % (fee.value / Fixed8.D))
-                    print("-------------------------------------------------------------------------------------------------------------------------------------\n")
+                    print(
+                        "-------------------------------------------------------------------------------------------------------------------------------------\n")
                     print("Enter your password to continue and deploy this contract")
 
                     passwd = prompt("[password]> ", is_password=True)
@@ -730,8 +735,7 @@ class PromptInterface(object):
                 print("cannot configure log.  Please specify on or off")
 
         else:
-            print("cannot configure %s " % what)
-            print("Try 'config log on/off'")
+            print("Invalid config target: %s", what)
 
     def parse_result(self, result):
         if len(result):
@@ -841,7 +845,8 @@ def main():
                         help="Use PrivNet instead of the default TestNet")
     parser.add_argument("-c", "--config", action="store", help="Use a specific config file")
     parser.add_argument("-t", "--set-default-theme", dest="theme",
-                        choices=["dark", "light"], help="Set the default theme to be loaded from the config file. Default: 'dark'")
+                        choices=["dark", "light"],
+                        help="Set the default theme to be loaded from the config file. Default: 'dark'")
     parser.add_argument('--version', action='version',
                         version='neo-python v{version}'.format(version=__version__))
 


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
Currently when you try to configure an non existing event type, or simply mistype it you'll get a partially confusing error message.

> neo> config sc-evnt on
cannot configure sc-evnt
Try 'config log on/off'
neo> config log on
cannot configure log
Try 'config log on/off'

The "cannot configure <type>" message makes sense, but the one following that suggests you can type `config log on` or `config log off` which you cannot.

**How did you solve this problem?**
I changed the error message to:
`print("Invalid config target: %s", what)`

I believe that without giving a suggestion on what to do next, users will likely try `help` first and see the list of available config commands.
**How did you make sure your solution works?**
ran unit tests. no errors

**Did you add any tests?**
no

**Are there any special changes in the code that we should be aware of?**
no
