### PR TITLE
correct wallet output for script_hash and address

### DIFF
--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -28,7 +28,6 @@ import json
 
 
 class UserWallet(Wallet):
-
     Version = None
 
     __dbaccount = None
@@ -292,7 +291,6 @@ class UserWallet(Wallet):
         ctr = {}
 
         for ct in Contract.select():
-
             data = binascii.unhexlify(ct.RawData)
             contract = Helper.AsSerializableWithType(data, 'neo.SmartContract.Contract.Contract')
             ctr[contract.ScriptHash.ToBytes()] = contract
@@ -498,7 +496,6 @@ class UserWallet(Wallet):
 
             address = c.Address
             if address.ScriptHash == todelete:
-
                 c.delete_instance()
                 address.delete_instance()
 
@@ -540,7 +537,8 @@ class UserWallet(Wallet):
                     has_watch_addr = True
             else:
                 token_balances = self.TokenBalancesForAddress(addr_str)
-                json = {'script_hash': addr_str, 'tokens': token_balances}
+                script_hash = binascii.hexlify(addr.ScriptHash)
+                json = {'address': addr_str, 'script_hash': script_hash.decode('utf8'), 'tokens': token_balances}
                 addresses.append(json)
 
         balances = []


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
the `wallet` command output showed the Address of a wallet in the `script_hash` key instead of the actual scripthash (see below)

```
"addresses": [
        {
            "votes": [],
            "script_hash": "AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y",
            "version": 0,
```
**How did you solve this problem?**
as discussed added both `script_hash` and `address` as key/value pairs

**How did you make sure your solution works?**
run the test suite + manual testing
 
**Did you add any tests?**
no

**Are there any special changes in the code that we should be aware of?**
no