### PR TITLE
adding ability to claim gas from SC address

### DIFF
--- a/neo/Blockchain.py
+++ b/neo/Blockchain.py
@@ -22,7 +22,7 @@ def GetSystemShare():
 
 def GetStateReader():
     from neo.SmartContract.StateReader import StateReader
-    return StateReader.Instance()
+    return StateReader()
 
 
 def GetConsensusAddress(validators):

--- a/neo/SmartContract/ContractParameterContext.py
+++ b/neo/SmartContract/ContractParameterContext.py
@@ -242,7 +242,6 @@ class ContractParametersContext():
 #                logger.info("SCRIPT IS %s " % item.Script)
 
             witness = Witness(
-                #                invocation_script='40fdb984faf0a400b6894c1ce5b317cf894ba3eb89b899cefda2ac307b278418b943534ad298884f9200dc4b7e1dc244db16c62a44a830a860060ec11d3e6e9717',
                 invocation_script=sb.ToArray(),
                 verification_script=vscript
             )

--- a/prompt.py
+++ b/prompt.py
@@ -491,7 +491,7 @@ class PromptInterface(object):
         elif item == 'close':
             self.do_close_wallet()
         elif item == 'claim':
-            ClaimGas(self.Wallet)
+            ClaimGas(self.Wallet, True, arguments[1:])
         elif item == 'rebuild':
             self.Wallet.Rebuild()
             try:


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
Adds ability to claim gas from neo stored in a smart contract address.

Example below, with SC address hash/address of `c5a6485dc64174e1ced6ac041b6b591074f795e4` and `AeYtu9j8RNDBnBnJ3CrM25Ay2rJAxS5Bkq`:

```
> import contract_addr c5a6485dc64174e1ced6ac041b6b591074f795e4 025688442a89eca1aeed82fab8eded62f93432a155b31c25e9dd1d2c5be2136cf6

# another wallet sends neo to AeYtu9j8RNDBnBnJ3CrM25Ay2rJAxS5Bkq

> send neo AeYtu9j8RNDBnBnJ3CrM25Ay2rJAxS5Bkq --from-addr=AeYtu9j8RNDBnBnJ3CrM25Ay2rJAxS5Bkq

> wallet claim --from-addr=AeYtu9j8RNDBnBnJ3CrM25Ay2rJAxS5Bkq

```




**Are there any special changes in the code that we should be aware of?**

No