### PR TITLE
Allow address generation to respect address version from settings

### DIFF
--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -10,6 +10,7 @@ import json
 import os
 import logging
 from json.decoder import JSONDecodeError
+from neocore.Cryptography import Helper
 
 import logzero
 
@@ -107,6 +108,8 @@ class SettingsHolder:
         self.URI_PREFIX = config['UriPrefix']
         self.VERSION_NAME = config['VersionName']
         self.BOOTSTRAP_FILE = config['BootstrapFile']
+
+        Helper.ADDRESS_VERSION = self.ADDRESS_VERSION
 
         if 'DebugStorage' in config:
             self.USE_DEBUG_STORAGE = config['DebugStorage']


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

Address version is hard coded to 23, but is intended to be configurable in protocol.json.

**How did you solve this problem?**

See CityOfZion/neo-python-core#31

**How did you make sure your solution works?**

**Did you add any tests?**

Not sure if needed here, see tests in CityOfZion/neo-python-core#31

**Are there any special changes in the code that we should be aware of?**

