### PR TITLE
Respect address version from settings

### DIFF
--- a/neo/Cryptography/Crypto.py
+++ b/neo/Cryptography/Crypto.py
@@ -10,7 +10,7 @@ from .Helper import *
 from neo.UInt256 import UInt256
 from neo.UInt160 import UInt160
 from neo.Cryptography.ECCurve import EllipticCurve
-
+from neo.Settings import settings
 
 class Crypto(object):
 
@@ -51,7 +51,7 @@ class Crypto(object):
 
     @staticmethod
     def ToAddress(uint160):
-        return hash_to_wallet_address(uint160.Data)
+        return hash_to_wallet_address(uint160.Data, settings.ADDRESS_VERSION)
 
     @staticmethod
     def Sign(message, private_key, public_key):

--- a/neo/Cryptography/Helper.py
+++ b/neo/Cryptography/Helper.py
@@ -18,7 +18,7 @@ import base58
 
 
 def hash_to_wallet_address(ba, address_version=23):
-    sb = bytearray([23]) + ba
+    sb = bytearray([address_version]) + ba
     c256 = bin_dbl_sha256(sb)[0:4]
     outb = sb + bytearray(c256)
     return base58.b58encode(bytes(outb))

--- a/neo/Cryptography/test_crypto.py
+++ b/neo/Cryptography/test_crypto.py
@@ -1,6 +1,9 @@
 from neo.Utils.NeoTestCase import NeoTestCase
+from neo.Cryptography.Crypto import Crypto
 from neo.Cryptography import Helper
+from neo.Settings import settings
 
+from neo.UInt160 import UInt160
 
 class HelperTestCase(NeoTestCase):
     def test_xor_bytes(self):
@@ -27,3 +30,16 @@ class HelperTestCase(NeoTestCase):
 
         b = Helper.random_key()
         self.assertNotEqual(a, b)
+
+    def test_to_address(self):
+        script_hash = UInt160(data=b'B\x11#x\xff\xa3,Le\xd5\x13\xaa5\x06\x89\xdf\xf68\x11T')
+        self.assertEqual(Crypto.ToAddress(script_hash), 'AMoCmy4xaaCnpejTAJkZYTsRz58BLopeeV')
+
+    def test_to_address_alt_version(self):
+        original_version = settings.ADDRESS_VERSION
+        settings.ADDRESS_VERSION = 42
+
+        script_hash = UInt160(data=b'B\x11#x\xff\xa3,Le\xd5\x13\xaa5\x06\x89\xdf\xf68\x11T')
+        self.assertEqual(Crypto.ToAddress(script_hash), 'J1DfV2jS511SMtP6dH5ckr3Nwf26kbFx7s')
+
+        settings.ADDRESS_VERSION = original_version


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

Address version is hard coded to 23, but is intended to be configurable in protocol.json.

I'm working with a neo fork that uses a different address version.

**How did you solve this problem?**

Use `settings.ADDRESS_VERSION` as default address version rather than hard-coded `23`

**How did you make sure your solution works?**

Tests

**Did you add any tests?**

Yep

**Are there any special changes in the code that we should be aware of?**

I also submitted changes to `dev` branch and `neo-python-core`, but I had prepared this initially since the project I'm working on is using the master branch. So here's a backport.