### PR TITLE
Improved prompt user-input parser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to this project following the ``0.4.0`` release will be docu
 [0.4.7-dev] work in progress
 ----------------------------
 
-- ...
+- implement a more robust CLI command parser
 
 [0.4.6] 2018-01-24
 ------------------

--- a/neo/Prompt/InputParser.py
+++ b/neo/Prompt/InputParser.py
@@ -1,0 +1,11 @@
+from pyparsing import ZeroOrMore, Regex
+
+
+class InputParser(object):
+    parser = ZeroOrMore(Regex(r'\[[^]]*\]') | Regex(r'"[^"]*"') | Regex(r'\'[^\']*\'') | Regex(r'[^ ]+'))
+
+    def parse_input(self, user_input):
+        if len(user_input):
+            command_parts = self.parser.parseString(user_input)
+            return command_parts[0], command_parts[1:]
+        return None, None

--- a/neo/Prompt/test_input_parser.py
+++ b/neo/Prompt/test_input_parser.py
@@ -6,41 +6,41 @@ class TestInputParser(TestCase):
     input_parser = InputParser()
 
     def test_simple_whitespace_separation(self):
-        command, arguments = self.input_parser.parse_input('this is a simple test')
-        self.assertEqual(command, 'this')
-        self.assertEqual(arguments, ['is', 'a', 'simple', 'test'])
+        command, arguments = self.input_parser.parse_input("this is a simple test")
+        self.assertEqual(command, "this")
+        self.assertEqual(arguments, ["is", "a", "simple", "test"])
 
     def test_keeping_double_quoted_strings_together(self):
-        command, arguments = self.input_parser.parse_input('this "is a simple" test')
-        self.assertEqual(command, 'this')
-        self.assertEqual(arguments, ['"is a simple"', 'test'])
+        command, arguments = self.input_parser.parse_input("this \"is a simple\" test")
+        self.assertEqual(command, "this")
+        self.assertEqual(arguments, ["\"is a simple\"", "test"])
 
     def test_keeping_single_quoted_strings_together(self):
-        command, arguments = self.input_parser.parse_input('this \'is a simple\' test')
-        self.assertEqual(command, 'this')
-        self.assertEqual(arguments, ['\'is a simple\'', 'test'])
+        command, arguments = self.input_parser.parse_input("this 'is a simple' test")
+        self.assertEqual(command, "this")
+        self.assertEqual(arguments, ["'is a simple'", "test"])
 
     def test_keeping_bracket_elements_together(self):
-        command, arguments = self.input_parser.parse_input('this [is a simple] test')
-        self.assertEqual(command, 'this')
-        self.assertEqual(arguments, ['[is a simple]', 'test'])
+        command, arguments = self.input_parser.parse_input("this [is a simple] test")
+        self.assertEqual(command, "this")
+        self.assertEqual(arguments, ["[is a simple]", "test"])
 
     def test_keeping_brackets_and_strings_together(self):
-        command, arguments = self.input_parser.parse_input('this [is \'a simple\'] test')
-        self.assertEqual(command, 'this')
-        self.assertEqual(arguments, ['[is \'a simple\']', 'test'])
+        command, arguments = self.input_parser.parse_input("this [is \"a simple\"] test")
+        self.assertEqual(command, "this")
+        self.assertEqual(arguments, ["[is \"a simple\"]", "test"])
 
     def test_unmatched_brackets(self):
-        command, arguments = self.input_parser.parse_input('this [is \'a simple\' test')
-        self.assertEqual(command, 'this')
-        self.assertEqual(arguments, ['[is', '\'a simple\'', 'test'])
+        command, arguments = self.input_parser.parse_input("this [is \"a simple\" test")
+        self.assertEqual(command, "this")
+        self.assertEqual(arguments, ["[is", "\"a simple\"", "test"])
 
     def test_unmatched_single_quotes(self):
-        command, arguments = self.input_parser.parse_input('this is \'a simple test')
-        self.assertEqual(command, 'this')
-        self.assertEqual(arguments, ['is', '\'a', 'simple', 'test'])
+        command, arguments = self.input_parser.parse_input("this is 'a simple test")
+        self.assertEqual(command, "this")
+        self.assertEqual(arguments, ["is", "'a", "simple", "test"])
 
     def test_unmatched_double_quotes(self):
-        command, arguments = self.input_parser.parse_input('this is "a simple test')
-        self.assertEqual(command, 'this')
-        self.assertEqual(arguments, ['is', '"a', 'simple', 'test'])
+        command, arguments = self.input_parser.parse_input("this is \"a simple test")
+        self.assertEqual(command, "this")
+        self.assertEqual(arguments, ["is", "\"a", "simple", "test"])

--- a/neo/Prompt/test_input_parser.py
+++ b/neo/Prompt/test_input_parser.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+from neo.Prompt.InputParser import InputParser
+
+
+class TestInputParser(TestCase):
+    input_parser = InputParser()
+
+    def test_simple_whitespace_separation(self):
+        command, arguments = self.input_parser.parse_input('this is a simple test')
+        self.assertEqual(command, 'this')
+        self.assertEqual(arguments, ['is', 'a', 'simple', 'test'])
+
+    def test_keeping_double_quoted_strings_together(self):
+        command, arguments = self.input_parser.parse_input('this "is a simple" test')
+        self.assertEqual(command, 'this')
+        self.assertEqual(arguments, ['"is a simple"', 'test'])
+
+    def test_keeping_single_quoted_strings_together(self):
+        command, arguments = self.input_parser.parse_input('this \'is a simple\' test')
+        self.assertEqual(command, 'this')
+        self.assertEqual(arguments, ['\'is a simple\'', 'test'])
+
+    def test_keeping_bracket_elements_together(self):
+        command, arguments = self.input_parser.parse_input('this [is a simple] test')
+        self.assertEqual(command, 'this')
+        self.assertEqual(arguments, ['[is a simple]', 'test'])
+
+    def test_keeping_brackets_and_strings_together(self):
+        command, arguments = self.input_parser.parse_input('this [is \'a simple\'] test')
+        self.assertEqual(command, 'this')
+        self.assertEqual(arguments, ['[is \'a simple\']', 'test'])

--- a/neo/Prompt/test_input_parser.py
+++ b/neo/Prompt/test_input_parser.py
@@ -44,3 +44,8 @@ class TestInputParser(TestCase):
         command, arguments = self.input_parser.parse_input("this is \"a simple test")
         self.assertEqual(command, "this")
         self.assertEqual(arguments, ["is", "\"a", "simple", "test"])
+
+    def test_python_bytearrays(self):
+        command, arguments = self.input_parser.parse_input("testinvoke f8d448b227991cf07cb96a6f9c0322437f1599b9 transfer [bytearray(b'S\xefB\xc8\xdf!^\xbeZ|z\xe8\x01\xcb\xc3\xac/\xacI)'), bytearray(b'\xaf\x12\xa8h{\x14\x94\x8b\xc4\xa0\x08\x12\x8aU\nci[\xc1\xa5'), 1000]")
+        self.assertEqual(command, "testinvoke")
+        self.assertEqual(arguments, ["f8d448b227991cf07cb96a6f9c0322437f1599b9", "transfer", "[bytearray(b'S\xefB\xc8\xdf!^\xbeZ|z\xe8\x01\xcb\xc3\xac/\xacI)'), bytearray(b'\xaf\x12\xa8h{\x14\x94\x8b\xc4\xa0\x08\x12\x8aU\nci[\xc1\xa5'), 1000]"])

--- a/neo/Prompt/test_input_parser.py
+++ b/neo/Prompt/test_input_parser.py
@@ -46,6 +46,11 @@ class TestInputParser(TestCase):
         self.assertEqual(arguments, ["is", "\"a", "simple", "test"])
 
     def test_python_bytearrays(self):
+        command, arguments = self.input_parser.parse_input("testinvoke bytearray(b'S\xefB\xc8\xdf!^\xbeZ|z\xe8\x01\xcb\xc3\xac/\xacI)') b'\xaf\x12\xa8h{\x14\x94\x8b\xc4\xa0\x08\x12\x8aU\nci[\xc1\xa5'")
+        self.assertEqual(command, "testinvoke")
+        self.assertEqual(arguments, ["bytearray(b'S\xefB\xc8\xdf!^\xbeZ|z\xe8\x01\xcb\xc3\xac/\xacI)')", "b'\xaf\x12\xa8h{\x14\x94\x8b\xc4\xa0\x08\x12\x8aU\nci[\xc1\xa5'"])
+
+    def test_python_bytearrays_in_lists(self):
         command, arguments = self.input_parser.parse_input("testinvoke f8d448b227991cf07cb96a6f9c0322437f1599b9 transfer [bytearray(b'S\xefB\xc8\xdf!^\xbeZ|z\xe8\x01\xcb\xc3\xac/\xacI)'), bytearray(b'\xaf\x12\xa8h{\x14\x94\x8b\xc4\xa0\x08\x12\x8aU\nci[\xc1\xa5'), 1000]")
         self.assertEqual(command, "testinvoke")
         self.assertEqual(arguments, ["f8d448b227991cf07cb96a6f9c0322437f1599b9", "transfer", "[bytearray(b'S\xefB\xc8\xdf!^\xbeZ|z\xe8\x01\xcb\xc3\xac/\xacI)'), bytearray(b'\xaf\x12\xa8h{\x14\x94\x8b\xc4\xa0\x08\x12\x8aU\nci[\xc1\xa5'), 1000]"])

--- a/neo/Prompt/test_input_parser.py
+++ b/neo/Prompt/test_input_parser.py
@@ -29,3 +29,18 @@ class TestInputParser(TestCase):
         command, arguments = self.input_parser.parse_input('this [is \'a simple\'] test')
         self.assertEqual(command, 'this')
         self.assertEqual(arguments, ['[is \'a simple\']', 'test'])
+
+    def test_unmatched_brackets(self):
+        command, arguments = self.input_parser.parse_input('this [is \'a simple\' test')
+        self.assertEqual(command, 'this')
+        self.assertEqual(arguments, ['[is', '\'a simple\'', 'test'])
+
+    def test_unmatched_single_quotes(self):
+        command, arguments = self.input_parser.parse_input('this is \'a simple test')
+        self.assertEqual(command, 'this')
+        self.assertEqual(arguments, ['is', '\'a', 'simple', 'test'])
+
+    def test_unmatched_double_quotes(self):
+        command, arguments = self.input_parser.parse_input('this is "a simple test')
+        self.assertEqual(command, 'this')
+        self.assertEqual(arguments, ['is', '"a', 'simple', 'test'])

--- a/prompt.py
+++ b/prompt.py
@@ -37,6 +37,7 @@ from neo.Prompt.Commands.Tokens import token_approve_allowance, token_get_allowa
 from neo.Prompt.Commands.Wallet import DeleteAddress, ImportWatchAddr, ImportToken, ClaimGas, DeleteToken, AddAlias, \
     ShowUnspentCoins
 from neo.Prompt.Utils import get_arg
+from neo.Prompt.InputParser import InputParser
 from neo.Settings import settings, DIR_PROJECT_ROOT
 from neo.UserPreferences import preferences
 from neocore.KeyPair import KeyPair
@@ -120,6 +121,7 @@ class PromptInterface(object):
     start_dt = None
 
     def __init__(self):
+        self.input_parser = InputParser()
         self.start_height = Blockchain.Default().Height
         self.start_dt = datetime.datetime.utcnow()
 
@@ -810,12 +812,6 @@ class PromptInterface(object):
         else:
             print("Cannot configure %s try 'config sc-events on|off' or 'config debug on|off'", what)
 
-    def parse_result(self, result):
-        if len(result):
-            command_parts = [s for s in result.split()]
-            return command_parts[0], command_parts[1:]
-        return None, None
-
     def run(self):
         dbloop = task.LoopingCall(Blockchain.Default().PersistBlocks)
         dbloop.start(.1)
@@ -846,7 +842,7 @@ class PromptInterface(object):
                 continue
 
             try:
-                command, arguments = self.parse_result(result)
+                command, arguments = self.input_parser.parse_input(result)
 
                 if command is not None and len(command) > 0:
                     command = command.lower()


### PR DESCRIPTION
Note, this PR is an alternative to the #181 combination, but does not depend on #180.

**What current issue(s) does this address?, or what feature is it adding?**

During the last NEO Meetup, adding a space at the wrong spot would break the current command parser in `prompt.py`, the new implementation is aware of brackets, and quoted strings and should now allow a more natural way of writing lists (like `["arg1", "arg2"...]` instead of forcing us to squash the spaces (ie `["arg1","arg2"...]`).

**How did you solve this problem?**

I've written a parser with `pyparse` which was already an available dependency. Using a proper parser is probably the only way forward for the `prompt.py` language to get more powerful.

**How did you make sure your solution works?**

I extracted the problematic part of the code, added tests, and changed the implementation.

**Did you add any tests?**

Yes, see `neo/Prompt/test_input_parser.py`

**Are there any special changes in the code that we should be aware of?**

No.