### PR TITLE
Feature send attrs

### DIFF
--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -3,12 +3,12 @@ from neo.Core.TX.Transaction import TransactionOutput, ContractTransaction
 from neo.Core.TX.TransactionAttribute import TransactionAttribute, TransactionAttributeUsage
 from neo.SmartContract.ContractParameterContext import ContractParametersContext
 from neo.Network.NodeLeader import NodeLeader
-from neo.Prompt.Utils import get_arg, get_from_addr, get_asset_id, lookup_addr_str
+from neo.Prompt.Utils import get_arg, get_from_addr, get_asset_id, lookup_addr_str, get_tx_attr_from_args
 from neo.Prompt.Commands.Tokens import do_token_transfer, amount_from_string
 from neo.Wallets.NEP5Token import NEP5Token
 from neocore.UInt256 import UInt256
 from neocore.Fixed8 import Fixed8
-
+import pdb
 import json
 from prompt_toolkit import prompt
 import traceback
@@ -24,6 +24,7 @@ def construct_and_send(prompter, wallet, arguments, prompt_password=True):
             return False
 
         arguments, from_address = get_from_addr(arguments)
+        arguments, user_tx_attributes = get_tx_attr_from_args(arguments)
 
         to_send = get_arg(arguments)
         address_to = get_arg(arguments, 1)
@@ -92,6 +93,9 @@ def construct_and_send(prompter, wallet, arguments, prompt_password=True):
             data = standard_contract.Data
             tx.Attributes = [TransactionAttribute(usage=TransactionAttributeUsage.Script,
                                                   data=data)]
+
+        # insert any additional user specified tx attributes
+        tx.Attributes = tx.Attributes + user_tx_attributes
 
         context = ContractParametersContext(tx, isMultiSig=signer_contract.IsMultiSigContract)
         wallet.Sign(context)

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -115,7 +115,6 @@ def get_tx_attr_from_args(params):
             to_remove.append(item)
             try:
                 attr_str = item.replace('--tx-attr=', '')
-                print("attr str: %s " % attr_str)
                 tx_attr_obj = eval(attr_str)
                 if type(tx_attr_obj) is dict:
                     if attr_obj_to_tx_attr(tx_attr_obj) is not None:
@@ -139,7 +138,8 @@ def attr_obj_to_tx_attr(obj):
         datum = obj['data']
         if type(datum) is str:
             datum = datum.encode('utf-8')
-        return TransactionAttribute(usage=obj['usage'], data=datum)
+        usage = obj['usage']
+        return TransactionAttribute(usage=usage, data=datum)
     except Exception as e:
         logger.error("could not convert object %s into TransactionAttribute: %s " % (obj, e))
     return None

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -5,8 +5,10 @@ from neo.Core.Helper import Helper
 from neo.Core.Blockchain import Blockchain
 from neo.Wallets.Coin import CoinState
 from neo.Core.TX.Transaction import TransactionInput
+from neo.Core.TX.TransactionAttribute import TransactionAttribute, TransactionAttributeUsage
 from neocore.UInt256 import UInt256
 from decimal import Decimal
+from logzero import logger
 import json
 
 
@@ -103,6 +105,44 @@ def get_from_addr(params):
         params.remove(item)
 
     return params, from_addr
+
+
+def get_tx_attr_from_args(params):
+    to_remove = []
+    tx_attr_dict = []
+    for item in params:
+        if '--tx-attr=' in item:
+            to_remove.append(item)
+            try:
+                attr_str = item.replace('--tx-attr=', '')
+                print("attr str: %s " % attr_str)
+                tx_attr_obj = eval(attr_str)
+                if type(tx_attr_obj) is dict:
+                    if attr_obj_to_tx_attr(tx_attr_obj) is not None:
+                        tx_attr_dict.append(attr_obj_to_tx_attr(tx_attr_obj))
+                elif type(tx_attr_obj) is list:
+                    for obj in tx_attr_obj:
+                        if attr_obj_to_tx_attr(obj) is not None:
+                            tx_attr_dict.append(attr_obj_to_tx_attr(obj))
+                else:
+                    logger.error("Invalid transaction attribute specification: %s " % type(tx_attr_obj))
+            except Exception as e:
+                logger.error("Could not parse json from tx attrs: %s " % e)
+    for item in to_remove:
+        params.remove(item)
+
+    return params, tx_attr_dict
+
+
+def attr_obj_to_tx_attr(obj):
+    try:
+        datum = obj['data']
+        if type(datum) is str:
+            datum = datum.encode('utf-8')
+        return TransactionAttribute(usage=obj['usage'], data=datum)
+    except Exception as e:
+        logger.error("could not convert object %s into TransactionAttribute: %s " % (obj, e))
+    return None
 
 
 def parse_param(p, wallet=None, ignore_int=False, prefer_hex=True):


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
Added ability to include transaction attributes with the `send` command.  example:
`send neo APRgMZHZubii29UXF9uFa6sohrsYupNAvx 10 --tx-attr={'usage':241,'data':'My Remark'}`

**How did you solve this problem?**
-added a parser that looks for the `--tx-attr` flag

**How did you make sure your solution works?**
- manual and automated testing

**Did you add any tests?**
- added new tests in `neo/Prompt/Command/tests/test_send_command`

**Are there any special changes in the code that we should be aware of?**
- Transaction attributes are awesome, good way to add meta-data to transactions.  but don't overuse them :)
