### PR TITLE
Allow multiple open wallet

### DIFF
--- a/neo/Implementations/Wallets/peewee/PWDatabase.py
+++ b/neo/Implementations/Wallets/peewee/PWDatabase.py
@@ -16,14 +16,11 @@ class PWDatabase(object):
             PWDatabase.__proxy = Proxy()
         return PWDatabase.__proxy
 
-    __instance__ = None
-    __dbpath__ = 'accounts.db3'
-
     _db = None
 
-    def __init__(self):
+    def __init__(self, path):
         try:
-            self._db = SqliteDatabase(PWDatabase.__dbpath__, check_same_thread=False)
+            self._db = SqliteDatabase(path, check_same_thread=False)
             PWDatabase.DBProxy().initialize(self._db)
             self.startup()
         except Exception as e:
@@ -39,27 +36,3 @@ class PWDatabase(object):
     @property
     def DB(self):
         return self._db
-
-    @staticmethod
-    def Initialize(path=None):
-        if path is not None:
-            PWDatabase.__dbpath__ = path
-
-    @staticmethod
-    def Context():
-        if not PWDatabase.__instance__:
-            PWDatabase.__instance__ = PWDatabase()
-        return PWDatabase.__instance__
-
-    @staticmethod
-    def ContextDB():
-        return PWDatabase.Context().DB
-
-    @staticmethod
-    def Destroy():
-        if PWDatabase.__instance__:
-            try:
-                PWDatabase.__instance__.close()
-            except Exception as e:
-                pass
-        PWDatabase.__instance__ = None

--- a/prompt.py
+++ b/prompt.py
@@ -262,6 +262,7 @@ class PromptInterface(object):
             path = self.Wallet._path
             self._walletdb_loop.stop()
             self._walletdb_loop = None
+            self.Wallet.Close()
             self.Wallet = None
             print("Closed wallet %s" % path)
 


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
- External applications may need to have more than one wallet file open at once.  This change removes the singleton from the `PWDatabase` implementation so that multiple `SQLite` connections can be open at once.

**How did you make sure your solution works?**
- verified tests

