### PR TITLE
Define VersionName in settings, removed from jsons

### DIFF
--- a/examples/json-rpc-api-server.py
+++ b/examples/json-rpc-api-server.py
@@ -72,15 +72,16 @@ def main():
     ndb = NotificationDB.instance()
     ndb.start()
 
-    api_server = JsonRpcApi(settings.NODE_PORT)
-
     # Run
     reactor.suggestThreadPoolSize(15)
     NodeLeader.Instance().Start()
 
     host = "0.0.0.0"
-    print("Starting server on %s:%s" % (host, settings.NODE_PORT))
-    api_server.app.run(host, settings.NODE_PORT)
+    port = settings.RPC_PORT
+    print("Starting json-rpc api server on http://%s:%s" % (host, port))
+
+    api_server = JsonRpcApi(port)
+    api_server.app.run(host, port)
 
 
 if __name__ == "__main__":

--- a/examples/json-rpc-api-server.py
+++ b/examples/json-rpc-api-server.py
@@ -35,7 +35,6 @@ def main():
     parser.add_argument("-p", "--privnet", action="store_true", default=False,
                         help="Use PrivNet instead of the default TestNet")
     parser.add_argument("-c", "--config", action="store", help="Use a specific config file")
-    parser.add_argument("--port", action="store", help="Port to use", default=8000)
     parser.add_argument("-t", "--set-default-theme", dest="theme",
                         choices=["dark", "light"],
                         help="Set the default theme to be loaded from the config file. Default: 'dark'")
@@ -73,13 +72,15 @@ def main():
     ndb = NotificationDB.instance()
     ndb.start()
 
-    api_server = JsonRpcApi(args.port)
+    api_server = JsonRpcApi(settings.NODE_PORT)
 
     # Run
     reactor.suggestThreadPoolSize(15)
     NodeLeader.Instance().Start()
 
-    api_server.app.run('0.0.0.0', args.port)
+    host = "0.0.0.0"
+    print("Starting server on %s:%s" % (host, settings.NODE_PORT))
+    api_server.app.run(host, settings.NODE_PORT)
 
 
 if __name__ == "__main__":

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -49,15 +49,17 @@ class SettingsHolder:
 
     LEVELDB_PATH = None
     NOTIFICATION_DB_PATH = None
+
+    RPC_PORT = None
     NODE_PORT = None
     WS_PORT = None
     URI_PREFIX = None
-    VERSION_NAME = None
     BOOTSTRAP_FILE = None
 
     ALL_FEES = None
-
     USE_DEBUG_STORAGE = False
+
+    VERSION_NAME = "/NEO-PYTHON:%s/" % __version__
 
     # Logging settings
     log_smart_contract_events = True
@@ -83,9 +85,6 @@ class SettingsHolder:
             return 'TestNet'
         return 'PrivateNet'
 
-    def __init__(self):
-        self.VERSION_NAME = "/NEO-PYTHON:%s/" % __version__
-
     # Setup methods
     def setup(self, config_file):
         """ Load settings from a JSON config file """
@@ -108,6 +107,7 @@ class SettingsHolder:
 
         config = data['ApplicationConfiguration']
         self.LEVELDB_PATH = os.path.join(DIR_PROJECT_ROOT, config['DataDirectoryPath'])
+        self.RPC_PORT = int(config['RPCPort'])
         self.NODE_PORT = int(config['NodePort'])
         self.WS_PORT = config['WsPort']
         self.URI_PREFIX = config['UriPrefix']

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -10,6 +10,8 @@ import json
 import os
 import logging
 from json.decoder import JSONDecodeError
+
+from neo import __version__
 from neocore.Cryptography import Helper
 
 import logzero
@@ -81,6 +83,9 @@ class SettingsHolder:
             return 'TestNet'
         return 'PrivateNet'
 
+    def __init__(self):
+        self.VERSION_NAME = "/NEO-PYTHON:%s/" % __version__
+
     # Setup methods
     def setup(self, config_file):
         """ Load settings from a JSON config file """
@@ -106,7 +111,7 @@ class SettingsHolder:
         self.NODE_PORT = int(config['NodePort'])
         self.WS_PORT = config['WsPort']
         self.URI_PREFIX = config['UriPrefix']
-        self.VERSION_NAME = config['VersionName']
+
         self.BOOTSTRAP_FILE = config['BootstrapFile']
 
         Helper.ADDRESS_VERSION = self.ADDRESS_VERSION

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -67,15 +67,9 @@ class JsonRpcError(Exception):
 class JsonRpcApi(object):
     app = Klein()
     port = None
-    nonce = None
 
     def __init__(self, port):
         self.port = port
-
-        # `nonce` in neo-cli this comes from https://github.com/neo-project/neo/blob/46c635adda6cf61090a67a3bef0f3bb1bc85dd81/neo/Network/LocalNode.cs#L68
-        # In neo-python the closest thing to it is https://github.com/CityOfZion/neo-python/blob/master/neo/Network/NeoNode.py#L34
-        # since we don't get direct access to this NeoNode, we generate a new nonce here
-        self.nonce = random.randint(1294967200, 4294967200)
 
     #
     # JSON-RPC API Route
@@ -211,7 +205,7 @@ class JsonRpcApi(object):
         elif method == "getversion":
             return {
                 "port": self.port,
-                "nonce": self.nonce,
+                "nonce": NodeLeader.Instance().NodeId,
                 "useragent": settings.VERSION_NAME
             }
 

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -7,12 +7,14 @@ See also:
 * http://www.jsonrpc.org/specification
 """
 import json
+import random
 from json.decoder import JSONDecodeError
 
 from klein import Klein
 from logzero import logger
 
 from neo import __version__
+from neo.Settings import settings
 from neo.Core.Blockchain import Blockchain
 from neo.api.utils import json_response
 from neo.Core.State.AccountState import AccountState
@@ -65,9 +67,15 @@ class JsonRpcError(Exception):
 class JsonRpcApi(object):
     app = Klein()
     port = None
+    nonce = None
 
     def __init__(self, port):
         self.port = port
+
+        # `nonce` in neo-cli this comes from https://github.com/neo-project/neo/blob/46c635adda6cf61090a67a3bef0f3bb1bc85dd81/neo/Network/LocalNode.cs#L68
+        # In neo-python the closest thing to it is https://github.com/CityOfZion/neo-python/blob/master/neo/Network/NeoNode.py#L34
+        # since we don't get direct access to this NeoNode, we generate a new nonce here
+        self.nonce = random.randint(1294967200, 4294967200)
 
     #
     # JSON-RPC API Route
@@ -203,8 +211,8 @@ class JsonRpcApi(object):
         elif method == "getversion":
             return {
                 "port": self.port,
-                "nonce": 771199013,  # TODO: make this the real nonce, currently taken straight from testnet neo-cli
-                "useragent": "/neo-python:%s/" % __version__  # This ok, or should we mimic `/NEO:2.6.0/`?
+                "nonce": self.nonce,
+                "useragent": settings.VERSION_NAME
             }
 
         elif method == "getrawtransaction":

--- a/neo/api/JSONRPC/neo-cli-json-rpc-docs.md
+++ b/neo/api/JSONRPC/neo-cli-json-rpc-docs.md
@@ -26,6 +26,8 @@ Documentation for the JSON-RPC implementation
     curl -X POST http://seed2.neo.org:20332 -H 'Content-Type: application/json' -d '{ "jsonrpc": "2.0", "id": 5, "method": "getrawmempool", "params": [] }'
     { "jsonrpc": "2.0", "id": 5, "result": [] }
 
+On MainNet there are actually entries, each of which has this format: `0xde3bc1dead8a89b06787db663b59c4f33efe0afe6b97b1c9c997f2695d7ae0da`
+
 ## `getversion`
 
     curl -X POST http://seed2.neo.org:20332 -H 'Content-Type: application/json' -d '{ "jsonrpc": "2.0", "id": 5, "method": "getversion", "params": [] }'

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -25,7 +25,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         return './fixtures/test_chain'
 
     def setUp(self):
-        self.app = JsonRpcApi(20333)
+        self.app = JsonRpcApi(20332)
 
     def test_invalid_json_payload(self):
         mock_req = mock_request(b"{ invalid")
@@ -223,5 +223,5 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         req = self._gen_rpc_req("getversion", params=[])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
-        self.assertEqual(res["result"]["port"], 20333)
+        self.assertEqual(res["result"]["port"], 20332)
         self.assertEqual(res["result"]["useragent"], "/NEO-PYTHON:%s/" % __version__)

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -224,4 +224,4 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
         self.assertEqual(res["result"]["port"], 20333)
-        self.assertEqual(res["result"]["useragent"], "/neo-python:%s/" % __version__)
+        self.assertEqual(res["result"]["useragent"], "/NEO-PYTHON:%s/" % __version__)

--- a/neo/api/REST/NotificationRestApi.py
+++ b/neo/api/REST/NotificationRestApi.py
@@ -1,6 +1,4 @@
 """
-
-
 The REST API is using the Python package 'klein', which makes it possible to
 create HTTP routes and handlers with Twisted in a similar style to Flask:
 https://github.com/twisted/klein

--- a/protocol.coz.json
+++ b/protocol.coz.json
@@ -31,6 +31,7 @@
   "ApplicationConfiguration": {
     "DataDirectoryPath": "Chains/coznet",
     "NotificationDataPath": "Chains/coz_notif",
+    "RPCPort": 20332,
     "NodePort": 20333,
     "WsPort": 20334,
     "UriPrefix": [ "http://*:20332"],

--- a/protocol.coz.json
+++ b/protocol.coz.json
@@ -36,7 +36,6 @@
     "UriPrefix": [ "http://*:20332"],
     "SslCert": "",
     "SslCertPassword": "",
-    "VersionName":"/NEO-PYTHON:2.3.4/",
     "BootstrapFile":"",
     "DebugStorage":1
   }

--- a/protocol.mainnet.json
+++ b/protocol.mainnet.json
@@ -40,6 +40,7 @@
   "ApplicationConfiguration": {
     "DataDirectoryPath": "Chains/Main",
     "NotificationDataPath": "Chains/Main_Notif",
+    "RPCPort": 10332,
     "NodePort": 10333,
     "WsPort": 10334,
     "UriPrefix": [ "http://*:10332" ],

--- a/protocol.mainnet.json
+++ b/protocol.mainnet.json
@@ -45,7 +45,6 @@
     "UriPrefix": [ "http://*:10332" ],
     "SslCert": "",
     "SslCertPassword": "",
-    "VersionName":"/NEO-PYTHON:2.3.4/",
     "BootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/Chain1550000.tar.gz",
     "DebugStorage":1
   }

--- a/protocol.privnet.json
+++ b/protocol.privnet.json
@@ -33,7 +33,6 @@
     "UriPrefix": [ "http://*:20332" ],
     "SslCert": "",
     "SslCertPassword": "",
-    "VersionName":"/NEO-PYTHON:2.3.4/",
     "BootstrapFile":"",
     "DebugStorage":1
   }

--- a/protocol.privnet.json
+++ b/protocol.privnet.json
@@ -28,6 +28,7 @@
   "ApplicationConfiguration": {
     "DataDirectoryPath": "./Chains/privnet",
     "NotificationDataPath": "Chains/Priv_Notif",
+    "RPCPort": 20332,
     "NodePort": 20333,
     "WsPort": 20334,
     "UriPrefix": [ "http://*:20332" ],

--- a/protocol.testnet.json
+++ b/protocol.testnet.json
@@ -8,7 +8,6 @@
         "UriPrefix": [
             "http://*:20332"
         ],
-        "VersionName": "/NEO-PYTHON:2.3.4/",
         "WsPort": 20334,
         "BootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_testnet/Chain780000.tar.gz",
         "DebugStorage":1

--- a/protocol.testnet.json
+++ b/protocol.testnet.json
@@ -2,6 +2,7 @@
     "ApplicationConfiguration": {
         "DataDirectoryPath": "Chains/SC234",
         "NotificationDataPath": "Chains/Test_Notif",
+        "RPCPort": 20332,
         "NodePort": 20333,
         "SslCert": "",
         "SslCertPassword": "",


### PR DESCRIPTION
`"VersionName": "/NEO-PYTHON:2.3.4/"` was hardcoded in the protocol jsons, i removed it from the jsons and just define it once in settings.py, which will always use the correct current version of neo-python.

Added this to the JsonRpcApi getversion response too.