### PR TITLE
Localhuman rpc2

### DIFF
--- a/neo/Core/Block.py
+++ b/neo/Core/Block.py
@@ -204,7 +204,7 @@ class Block(BlockBase, InventoryMixin):
         reader.ReadByte()
         witness = Witness()
         witness.Deserialize(reader)
-        block.witness = witness
+        block.Script = witness
 
         block.Transactions = reader.ReadHashes()
 
@@ -234,7 +234,7 @@ class Block(BlockBase, InventoryMixin):
         Args:
             writer (neo.IO.BinaryWriter):
         """
-        super(BlockBase, self).Serialize(writer)
+        super(Block, self).Serialize(writer)
         writer.WriteSerializableArray(self.Transactions)
 
     def ToJson(self):
@@ -245,7 +245,7 @@ class Block(BlockBase, InventoryMixin):
              dict:
         """
         json = super(Block, self).ToJson()
-        if self.__is_trimmed:
+        if self.Transactions[0] and isinstance(self.Transactions[0],str):
             json['tx'] = ['0x%s' % tx for tx in self.Transactions]
         else:
             json['tx'] = [tx.ToJson() for tx in self.Transactions]

--- a/neo/Core/Block.py
+++ b/neo/Core/Block.py
@@ -245,7 +245,7 @@ class Block(BlockBase, InventoryMixin):
              dict:
         """
         json = super(Block, self).ToJson()
-        if self.Transactions[0] and isinstance(self.Transactions[0],str):
+        if self.Transactions[0] and isinstance(self.Transactions[0], str):
             json['tx'] = ['0x%s' % tx for tx in self.Transactions]
         else:
             json['tx'] = [tx.ToJson() for tx in self.Transactions]

--- a/neo/Core/Block.py
+++ b/neo/Core/Block.py
@@ -246,7 +246,7 @@ class Block(BlockBase, InventoryMixin):
         """
         json = super(Block, self).ToJson()
         if self.__is_trimmed:
-            json['tx'] = self.Transactions
+            json['tx'] = ['0x%s' % tx for tx in self.Transactions]
         else:
             json['tx'] = [tx.ToJson() for tx in self.Transactions]
 

--- a/neo/Core/BlockBase.py
+++ b/neo/Core/BlockBase.py
@@ -209,15 +209,15 @@ class BlockBase(VerifiableMixin):
              dict:
         """
         json = {}
-        json["hash"] = self.Hash.ToString()
+        json["hash"] = self.Hash.To0xString()
 
         #        json["size"] = self.Size()
         json["version"] = self.Version
-        json["previousblockhash"] = self.PrevHash.ToString()
-        json["merkleroot"] = self.MerkleRoot.ToString()
+        json["previousblockhash"] = self.PrevHash.To0xString()
+        json["merkleroot"] = self.MerkleRoot.To0xString()
         json["time"] = self.Timestamp
         json["index"] = self.Index
-        json['next_consensus'] = self.NextConsensus.ToString()
+        json['next_consensus'] = self.NextConsensus.To0xString()
         json["consensus data"] = self.ConsensusData
         json["script"] = '' if not self.Script else self.Script.ToJson()
         return json

--- a/neo/Core/FunctionCode.py
+++ b/neo/Core/FunctionCode.py
@@ -88,7 +88,7 @@ class FunctionCode(SerializableMixin):
              dict:
         """
         return {
-            'hash': self.ScriptHash().ToString(),
+            'hash': self.ScriptHash().To0xString(),
             'script': self.Script.hex(),
             'parameters': self.ParameterList.hex(),
             'returntype': self.ReturnType if type(self.ReturnType) is int else self.ReturnType.hex()

--- a/neo/Core/State/AccountState.py
+++ b/neo/Core/State/AccountState.py
@@ -271,7 +271,7 @@ class AccountState(StateBase):
 
         balances = {}
         for key, value in self.Balances.items():
-            balances[key.ToString()] = str(value.value / Fixed8.D)
+            balances[key.To0xString()] = str(value.value / Fixed8.D)
 
         json['balances'] = balances
         return json

--- a/neo/Core/State/AssetState.py
+++ b/neo/Core/State/AssetState.py
@@ -177,7 +177,7 @@ class AssetState(StateBase):
              dict:
         """
         return {
-            'assetId': self.AssetId.ToString(),
+            'assetId': self.AssetId.To0xString(),
             'assetType': self.AssetType,
             'name': self.GetName(),
             'amount': self.Amount.value,

--- a/neo/Core/State/ContractState.py
+++ b/neo/Core/State/ContractState.py
@@ -144,8 +144,6 @@ class ContractState(StateBase):
         except Exception as e:
             pass
 
-        print("self contract properties: %s " % self.ContractProperties)
-
         return {
 
             'version': self.StateVersion,

--- a/neo/Core/TX/test_transactions.py
+++ b/neo/Core/TX/test_transactions.py
@@ -82,7 +82,7 @@ class TransactionTestCase(NeoTestCase):
         self.assertEqual(contract['author'], 'Erik Zhang')
         self.assertEqual(contract['description'], 'Lock your assets until a timestamp.')
 
-        self.assertEqual(contract['code']['hash'], 'ffbd1a7ad1e2348b6b3822426f364bfb4bcce3b9')
+        self.assertEqual(contract['code']['hash'], '0xffbd1a7ad1e2348b6b3822426f364bfb4bcce3b9')
         self.assertEqual(contract['code']['returntype'], 1)
         self.assertEqual(contract['code']['parameters'], '020500')
 

--- a/neo/Core/test_block.py
+++ b/neo/Core/test_block.py
@@ -165,7 +165,7 @@ class BlocksTestCase(NeoTestCase):
 
         json = block.ToJson()
         self.assertEqual(json['index'], 2992)
-        self.assertEqual(json['hash'], '0x%' % self.t992h.decode('utf-8'))
+        self.assertEqual(json['hash'], '0x%s' % self.t992h.decode('utf-8'))
         self.assertEqual(json['merkleroot'], '0x%s' % self.t992m.decode('utf-8'))
         self.assertEqual(len(json['tx']), 1)
         self.assertEqual(json['tx'][0]['txid'], '4c68669a54fa247d02545cff9d78352cb4a5059de7b3cd6ba82efad13953c9b9')

--- a/neo/Core/test_block.py
+++ b/neo/Core/test_block.py
@@ -165,8 +165,8 @@ class BlocksTestCase(NeoTestCase):
 
         json = block.ToJson()
         self.assertEqual(json['index'], 2992)
-        self.assertEqual(json['hash'], self.t992h.decode('utf-8'))
-        self.assertEqual(json['merkleroot'], self.t992m.decode('utf-8'))
+        self.assertEqual(json['hash'], '0x%s' % self.t992h.decode('utf-8'))
+        self.assertEqual(json['merkleroot'], '0x%s' % self.t992m.decode('utf-8'))
         self.assertEqual(len(json['tx']), 1)
         self.assertEqual(json['tx'][0]['txid'], '4c68669a54fa247d02545cff9d78352cb4a5059de7b3cd6ba82efad13953c9b9')
 
@@ -189,7 +189,7 @@ class BlocksTestCase(NeoTestCase):
         json = block.ToJson()
 
         self.assertEqual(json['index'], 1050514)
-        self.assertEqual(json['hash'], self.big_tx_hash.decode('utf-8'))
+        self.assertEqual(json['hash'], '0x%s' % self.big_tx_hash.decode('utf-8'))
         self.assertEqual(len(json['tx']), 65)
 
         for tx in json['tx']:

--- a/neo/Core/test_block.py
+++ b/neo/Core/test_block.py
@@ -165,7 +165,7 @@ class BlocksTestCase(NeoTestCase):
 
         json = block.ToJson()
         self.assertEqual(json['index'], 2992)
-        self.assertEqual(json['hash'], '0x%s' % self.t992h.decode('utf-8'))
+        self.assertEqual(json['hash'], '0x%' % self.t992h.decode('utf-8'))
         self.assertEqual(json['merkleroot'], '0x%s' % self.t992m.decode('utf-8'))
         self.assertEqual(len(json['tx']), 1)
         self.assertEqual(json['tx'][0]['txid'], '4c68669a54fa247d02545cff9d78352cb4a5059de7b3cd6ba82efad13953c9b9')

--- a/neo/IO/Helper.py
+++ b/neo/IO/Helper.py
@@ -3,7 +3,7 @@ from logzero import logger
 from .MemoryStream import MemoryStream, StreamManager
 from neocore.IO.BinaryReader import BinaryReader
 from neo.Core.TX.Transaction import Transaction
-
+from neo.Blockchain import GetBlockchain
 
 class Helper(object):
 
@@ -30,7 +30,7 @@ class Helper(object):
             serializable.Deserialize(reader)
             return serializable
         except Exception as e:
-            logger.error("Could not deserialize: %s " % e)
+            logger.error("Could not deserialize object: %s %s %s " % (GetBlockchain().Height, class_name,e))
         finally:
             StreamManager.ReleaseStream(mstream)
 

--- a/neo/IO/Helper.py
+++ b/neo/IO/Helper.py
@@ -5,6 +5,7 @@ from neocore.IO.BinaryReader import BinaryReader
 from neo.Core.TX.Transaction import Transaction
 from neo.Blockchain import GetBlockchain
 
+
 class Helper(object):
 
     @staticmethod
@@ -30,7 +31,7 @@ class Helper(object):
             serializable.Deserialize(reader)
             return serializable
         except Exception as e:
-            logger.error("Could not deserialize object: %s %s %s " % (GetBlockchain().Height, class_name,e))
+            logger.error("Could not deserialize object: %s %s %s " % (GetBlockchain().Height, class_name, e))
         finally:
             StreamManager.ReleaseStream(mstream)
 

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -516,7 +516,10 @@ class LevelDBBlockchain(Blockchain):
             bhash = height_or_hash.encode('utf-8')
             if bhash in self._header_index:
                 hash = bhash
-
+        elif intval is None and len(height_or_hash) == 66:
+            bhash = height_or_hash[2:].encode('utf-8')
+            if bhash in self._header_index:
+                hash = bhash
         elif intval is not None and self.GetBlockHash(intval) is not None:
             hash = self.GetBlockHash(intval)
 

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -199,7 +199,7 @@ class JsonRpcApi(object):
             script_hash = self.parse_uint_str(params[0])
             contract = Blockchain.Default().GetContract(script_hash)
             if contract is None:
-               raise JsonRpcError(-100, "Unknown contract")
+                raise JsonRpcError(-100, "Unknown contract")
             return contract.ToJson()
 
         elif method == "getrawmempool":

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -144,7 +144,7 @@ class JsonRpcApi(object):
             raise JsonRpcError(-100, "Unknown asset")
 
         elif method == "getbestblockhash":
-            return Blockchain.Default().CurrentHeaderHash.decode('utf-8')
+            return '0x%s' % Blockchain.Default().CurrentHeaderHash.decode('utf-8')
 
         elif method == "getblock":
             # this should work for either str or int
@@ -161,7 +161,7 @@ class JsonRpcApi(object):
                 jsn['confirmations'] = Blockchain.Default().Height - block.Index + 1
                 hash = Blockchain.Default().GetNextBlockHash(block.Hash)
                 if hash:
-                    jsn['nextblockhash'] = hash.decode('utf-8')
+                    jsn['nextblockhash'] = '0x%s' % hash.decode('utf-8')
                 return jsn
 
             # full tx data is not included by default
@@ -175,7 +175,7 @@ class JsonRpcApi(object):
         elif method == "getblockhash":
             height = params[0]
             if height >= 0 and height <= Blockchain.Default().Height:
-                return Blockchain.Default().GetBlockHash(height).decode('utf-8')
+                return '0x%s' % Blockchain.Default().GetBlockHash(height).decode('utf-8')
             else:
                 raise JsonRpcError(-100, "Invalid Height")
 

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -219,7 +219,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         self.assertIsNotNone(res['result'])
 
         # we should be able to instantiate a matching block with the result
-        output = binascii.unhexlify( res['result'])
+        output = binascii.unhexlify(res['result'])
         block = Helper.AsSerializableWithType(output, 'neo.Core.Block.Block')
         self.assertEqual(block.Index, 2003)
         self.assertEqual(len(block.Transactions), 2)
@@ -230,10 +230,10 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
         self.assertEqual(res['result']['code_version'], '3')
-        self.assertEqual(res['result']['properties']['storage'],True)
+        self.assertEqual(res['result']['properties']['storage'], True)
         self.assertEqual(res['result']['code']['hash'], '0x5b7074e873973a6ed3708862f219a6fbf4d1c411')
-        self.assertEqual(res['result']['code']['returntype'],5)
-        self.assertEqual(res['result']['code']['parameters'],'0710')
+        self.assertEqual(res['result']['code']['returntype'], 5)
+        self.assertEqual(res['result']['code']['parameters'], '0710')
 
     def test_get_contract_state_0x(self):
         contract_hash = '0x%s' % UInt160(data=bytearray(b'\x11\xc4\xd1\xf4\xfb\xa6\x19\xf2b\x88p\xd3n:\x97s\xe8tp[')).ToString()

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -85,7 +85,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         res = json.loads(self.app.home(mock_req))
 
         # taken from neoscan
-        expected_blockhash = '60ad7aebdae37f1cad7a15b841363b5a7da9fd36bf689cfde75c26c0fa085b64'
+        expected_blockhash = '0x60ad7aebdae37f1cad7a15b841363b5a7da9fd36bf689cfde75c26c0fa085b64'
         self.assertEqual(expected_blockhash, res["result"])
 
     def test_getblockhash_failure(self):
@@ -100,7 +100,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         req = self._gen_rpc_req("getaccountstate", params=[addr_str])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
-        self.assertEqual(res['result']['balances']['c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'], '4061.0')
+        self.assertEqual(res['result']['balances']['0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'], '4061.0')
         self.assertEqual(res['result']['script_hash'], addr_str)
 
     def test_account_state_not_existing_yet(self):
@@ -125,8 +125,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         req = self._gen_rpc_req("getassetstate", params=[asset_str])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
-
-        self.assertEqual(res['result']['assetId'], asset_str)
+        self.assertEqual(res['result']['assetId'], '0x%s' % asset_str)
         self.assertEqual(res['result']['admin'], 'AWKECj9RD8rS8RPcpCgYVjk1DeYyHwxZm3')
         self.assertEqual(res['result']['available'], 3825482025899)
 
@@ -143,7 +142,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         req = self._gen_rpc_req("getbestblockhash", params=[])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
-        self.assertEqual(res['result'], '370007195c10a05e355b606f8f8867239f026a925f2ddc46940f62c9136d3ff5')
+        self.assertEqual(res['result'], '0x370007195c10a05e355b606f8f8867239f026a925f2ddc46940f62c9136d3ff5')
 
     def test_get_connectioncount(self):
         # @TODO
@@ -157,11 +156,10 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         req = self._gen_rpc_req("getblock", params=[10, 1])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
-
         self.assertEqual(res['result']['index'], 10)
-        self.assertEqual(res['result']['hash'], '9410bd44beb7d6febc9278b028158af2781fcfb40cf2c6067b3525d24eff19f6')
+        self.assertEqual(res['result']['hash'], '0x9410bd44beb7d6febc9278b028158af2781fcfb40cf2c6067b3525d24eff19f6')
         self.assertEqual(res['result']['confirmations'], 756610)
-        self.assertEqual(res['result']['nextblockhash'], 'a0d34f68cb7a04d625ae095fa509479ec7dcb4dc87ecd865ab059d0f8a42decf')
+        self.assertEqual(res['result']['nextblockhash'], '0xa0d34f68cb7a04d625ae095fa509479ec7dcb4dc87ecd865ab059d0f8a42decf')
 
     def test_get_block_hash(self):
         req = self._gen_rpc_req("getblock", params=['a0d34f68cb7a04d625ae095fa509479ec7dcb4dc87ecd865ab059d0f8a42decf', 1])
@@ -170,7 +168,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
 
         self.assertEqual(res['result']['index'], 11)
         self.assertEqual(res['result']['confirmations'], 756609)
-        self.assertEqual(res['result']['previousblockhash'], '9410bd44beb7d6febc9278b028158af2781fcfb40cf2c6067b3525d24eff19f6')
+        self.assertEqual(res['result']['previousblockhash'], '0x9410bd44beb7d6febc9278b028158af2781fcfb40cf2c6067b3525d24eff19f6')
 
     def test_get_block_hash_failure(self):
         req = self._gen_rpc_req("getblock", params=['aad34f68cb7a04d625ae095fa509479ec7dcb4dc87ecd865ab059d0f8a42decf', 1])

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -10,7 +10,9 @@ from klein.test.test_resource import requestMock
 from neo import __version__
 from neo.api.JSONRPC.JsonRpcApi import JsonRpcApi
 from neo.Utils.BlockchainFixtureTestCase import BlockchainFixtureTestCase
+from neo.IO.Helper import Helper
 from neocore.UInt160 import UInt160
+import binascii
 
 
 def mock_request(body):
@@ -191,9 +193,10 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         res = json.loads(self.app.home(mock_req))
         self.assertIsNotNone(res['result'])
 
-        # output = binascii.unhexlify( res['result'])
-        # @TODO
-        # The getblock non verbose method is not serializing the blocks correctly
+        output = binascii.unhexlify( res['result'])
+        block = Helper.AsSerializableWithType(output, 'neo.Core.Block.Block')
+        self.assertEqual(block.Index, 2003)
+        self.assertEqual(len(block.Transactions), 2)
 
     # def test_get_contract_state(self):
     #     contract_hash = UInt160(data=bytearray(b'\x11\xc4\xd1\xf4\xfb\xa6\x19\xf2b\x88p\xd3n:\x97s\xe8tp['))

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -131,6 +131,13 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         self.assertEqual(res['result']['admin'], 'AWKECj9RD8rS8RPcpCgYVjk1DeYyHwxZm3')
         self.assertEqual(res['result']['available'], 3825482025899)
 
+    def test_get_asset_state_0x(self):
+        asset_str = '0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'
+        req = self._gen_rpc_req("getassetstate", params=[asset_str])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+        self.assertEqual(res['result']['assetId'], asset_str)
+
     def test_bad_asset_state(self):
         asset_str = '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282dee'
         req = self._gen_rpc_req("getassetstate", params=[asset_str])
@@ -172,6 +179,12 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         self.assertEqual(res['result']['confirmations'], 756609)
         self.assertEqual(res['result']['previousblockhash'], '0x9410bd44beb7d6febc9278b028158af2781fcfb40cf2c6067b3525d24eff19f6')
 
+    def test_get_block_hash_0x(self):
+        req = self._gen_rpc_req("getblock", params=['0xa0d34f68cb7a04d625ae095fa509479ec7dcb4dc87ecd865ab059d0f8a42decf', 1])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+        self.assertEqual(res['result']['index'], 11)
+
     def test_get_block_hash_failure(self):
         req = self._gen_rpc_req("getblock", params=['aad34f68cb7a04d625ae095fa509479ec7dcb4dc87ecd865ab059d0f8a42decf', 1])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
@@ -193,17 +206,29 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         res = json.loads(self.app.home(mock_req))
         self.assertIsNotNone(res['result'])
 
+        # we should be able to instantiate a matching block with the result
         output = binascii.unhexlify( res['result'])
         block = Helper.AsSerializableWithType(output, 'neo.Core.Block.Block')
         self.assertEqual(block.Index, 2003)
         self.assertEqual(len(block.Transactions), 2)
 
-    # def test_get_contract_state(self):
-    #     contract_hash = UInt160(data=bytearray(b'\x11\xc4\xd1\xf4\xfb\xa6\x19\xf2b\x88p\xd3n:\x97s\xe8tp['))
-    #     req = self._gen_rpc_req("getcontractstate", params=[13321])
-    #     mock_req = mock_request(json.dumps(req).encode("utf-8"))
-    #     res = json.loads(self.app.home(mock_req))
-    #     self.assertEqual(res['result'], 230)
+    def test_get_contract_state(self):
+        contract_hash = UInt160(data=bytearray(b'\x11\xc4\xd1\xf4\xfb\xa6\x19\xf2b\x88p\xd3n:\x97s\xe8tp[')).ToString()
+        req = self._gen_rpc_req("getcontractstate", params=[contract_hash])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+        self.assertEqual(res['result']['code_version'], '3')
+        self.assertEqual(res['result']['properties']['storage'],True)
+        self.assertEqual(res['result']['code']['hash'], '0x5b7074e873973a6ed3708862f219a6fbf4d1c411')
+        self.assertEqual(res['result']['code']['returntype'],5)
+        self.assertEqual(res['result']['code']['parameters'],'0710')
+
+    def test_get_contract_state_0x(self):
+        contract_hash = '0x%s' % UInt160(data=bytearray(b'\x11\xc4\xd1\xf4\xfb\xa6\x19\xf2b\x88p\xd3n:\x97s\xe8tp[')).ToString()
+        req = self._gen_rpc_req("getcontractstate", params=[contract_hash])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+        self.assertEqual(res['result']['code_version'], '3')
 
     def test_get_raw_mempool(self):
         # TODO: currently returns empty list. test with list would be great

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ mock==2.0.0
 mpmath==1.0.0
 neo-boa==0.2.2
 neo-python-rpc==0.1.8
-neocore==0.3.1
+neocore==0.3.2
 numpy==1.14.0
 pbr==3.1.1
 peewee==2.10.2


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
- upgrade to `neocore` `v.3.2`
- add hex string specifier to all UInt represented in JSON
- fixed how blocks are serialized so that non-verbose blocks can be retrieved from api
- added full transactions into output for blocks

**How did you solve this problem?**
- code
**How did you make sure your solution works?**
- tests
**Did you add any tests?**
- tests
**Are there any special changes in the code that we should be aware of?**
- no
