### PR TITLE
make contract search case-insensitive

### DIFF
--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -213,17 +213,19 @@ class LevelDBBlockchain(Blockchain):
         contracts = DBCollection(self._db, sn, DBPrefix.ST_Contract, ContractState)
         keys = contracts.Keys
 
+        query = query.casefold()
+
         for item in keys:
 
             contract = contracts.TryGet(keyval=item)
             try:
-                if query in contract.Name.decode('utf-8'):
+                if query in contract.Name.decode('utf-8').casefold():
                     res.append(contract)
-                elif query in contract.Author.decode('utf-8'):
+                elif query in contract.Author.decode('utf-8').casefold():
                     res.append(contract)
-                elif query in contract.Description.decode('utf-8'):
+                elif query in contract.Description.decode('utf-8').casefold():
                     res.append(contract)
-                elif query in contract.Email.decode('utf-8'):
+                elif query in contract.Email.decode('utf-8').casefold():
                     res.append(contract)
             except Exception as e:
                 logger.info("Could not query contract: %s " % e)

--- a/neo/SmartContract/test_smart_contract3.py
+++ b/neo/SmartContract/test_smart_contract3.py
@@ -46,6 +46,10 @@ class SmartContractTest3(BlockchainFixtureTestCase):
         self.assertEqual(contract_added.Name, b'test create')
         self.assertEqual(contract_added.Email, b'flow@neo.org')
 
+        self.assertEqual(len(Blockchain.Default().SearchContracts("test create")),  1)
+        self.assertEqual(len(Blockchain.Default().SearchContracts("TEST CREate")),  1)
+        self.assertEqual(len(Blockchain.Default().SearchContracts("TEST CREATE!")), 0)
+
         code = contract_added.Code
 
         self.assertIsNotNone(code)

--- a/neo/SmartContract/test_smart_contract3.py
+++ b/neo/SmartContract/test_smart_contract3.py
@@ -46,8 +46,8 @@ class SmartContractTest3(BlockchainFixtureTestCase):
         self.assertEqual(contract_added.Name, b'test create')
         self.assertEqual(contract_added.Email, b'flow@neo.org')
 
-        self.assertEqual(len(Blockchain.Default().SearchContracts("test create")),  1)
-        self.assertEqual(len(Blockchain.Default().SearchContracts("TEST CREate")),  1)
+        self.assertEqual(len(Blockchain.Default().SearchContracts("test create")), 1)
+        self.assertEqual(len(Blockchain.Default().SearchContracts("TEST CREate")), 1)
         self.assertEqual(len(Blockchain.Default().SearchContracts("TEST CREATE!")), 0)
 
         code = contract_added.Code


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

issue #204 

**How did you solve this problem?**

I called casefold() on the strings before the "__ in __" checks.

**How did you make sure your solution works?**

I added calls to SearchContract to one of the tests.

**Did you add any tests?**

yes

**Are there any special changes in the code that we should be aware of?**

no

**Did you run `make lint` and `make test`?**

yes

**Are you making a PR to a feature branch or development rather than master?**

yes, development