### PR TITLE
Minor bugfixes in API examples, CHANGELOG fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,15 +1,17 @@
 Changelog
 =========
 
-All notable changes to this project following the ``0.4.0`` release will be documented in this file.
+All notable changes to this project are documented in this file.
 
-[0.4.7] 2018-02-13
+[0.4.7-dev] work in progress
 ----------------------------
+
 - Fix Gas Cost Calculation (`PR #220 <https://github.com/CityOfZion/neo-python/pull/220>`_)
 - Clarify message for token mint command (`PR #212 <https://github.com/CityOfZion/neo-python/pull/212>`_)
 - Troubleshooting osx script (`PR #208 <https://github.com/CityOfZion/neo-python/pull/208>`_)
 - Make Contract Search case insensitive (`PR #207 <https://github.com/CityOfZion/neo-python/pull/207>`_)
 - implement a more robust CLI command parser
+
 
 [0.4.6] 2018-01-24
 ------------------

--- a/examples/json-rpc-api-server.py
+++ b/examples/json-rpc-api-server.py
@@ -6,7 +6,7 @@ This example provides a JSON-RPC API to query blockchain data, implementing `neo
 import argparse
 import os
 
-import logzero
+from logzero import logger
 from twisted.internet import reactor, task
 
 from neo import __version__
@@ -52,9 +52,6 @@ def main():
     elif args.privnet:
         settings.setup_privnet()
 
-    if args.theme:
-        preferences.set_theme(args.theme)
-
     # Instantiate the blockchain and subscribe to notifications
     blockchain = LevelDBBlockchain(settings.LEVELDB_PATH)
     Blockchain.RegisterBlockchain(blockchain)
@@ -72,7 +69,7 @@ def main():
 
     host = "0.0.0.0"
     port = settings.RPC_PORT
-    print("Starting json-rpc api server on http://%s:%s" % (host, port))
+    logger.info("Starting json-rpc api server on http://%s:%s" % (host, port))
 
     api_server = JsonRpcApi(port)
     api_server.app.run(host, port)

--- a/examples/json-rpc-api-server.py
+++ b/examples/json-rpc-api-server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This example provides a JSON-RPC API to query blockchain data, implementing `neo.api.JSONRPC.JsonRpcApi`
 """

--- a/examples/notification-rest-api-server.py
+++ b/examples/notification-rest-api-server.py
@@ -6,7 +6,7 @@ This example provides a REST API to query notifications from the blockchain, imp
 import argparse
 import os
 
-import logzero
+from logzero import logger
 from twisted.internet import reactor, task
 
 from neo import __version__
@@ -52,9 +52,6 @@ def main():
     elif args.privnet:
         settings.setup_privnet()
 
-    if args.theme:
-        preferences.set_theme(args.theme)
-
     # Instantiate the blockchain and subscribe to notifications
     blockchain = LevelDBBlockchain(settings.LEVELDB_PATH)
     Blockchain.RegisterBlockchain(blockchain)
@@ -70,7 +67,9 @@ def main():
     reactor.suggestThreadPoolSize(15)
     NodeLeader.Instance().Start()
 
-    notif_server.app.run('0.0.0.0', 8000)
+    port = 8000
+    logger.info("Starting notification-api server on port %s" % (port))
+    notif_server.app.run('0.0.0.0', port)
 
 
 if __name__ == "__main__":

--- a/examples/notification-rest-api-server.py
+++ b/examples/notification-rest-api-server.py
@@ -1,6 +1,8 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This example provides a REST API to query notifications from the blockchain, implementing `neo.api.RESTAPI.NotificationRestApi`
+
+See it live here: http://notifications.neeeo.org/
 """
 
 import argparse


### PR DESCRIPTION
* Minor bugfixes for the API examples
* CHANGELOG fix: `0.4.7` has not been released, it is still `0.4.7-dev`. For a release, I'd merge dev into master and follow the release steps described at the bottom of the README