### PR TITLE
Gracefully close wallet on exit

### DIFF
--- a/prompt.py
+++ b/prompt.py
@@ -175,6 +175,7 @@ class PromptInterface(object):
     def quit(self):
         print('Shutting down. This may take a bit...')
         self.go_on = False
+        self.do_close_wallet()
         NotificationDB.close()
         Blockchain.Default().Dispose()
         reactor.stop()


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**

Wallet database isn't closed gracefully during exit, which could potentially lead to database corruption if the database is still open and being written to during shutdown.

**How did you solve this problem?**

Close the wallet before running the rest of the shutdown tasks.

**How did you make sure your solution works?**

Tested quitting with wallet open and with wallet closed

**Did you add any tests?**

No

**Are there any special changes in the code that we should be aware of?**

No

**Did you run `make lint` and `make test`?**

Yes

**Are you making a PR to a feature branch or development rather than master?**

development