### PR TITLE
Feature bootstrap updates

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,5 +1,5 @@
 from neo.Settings import settings
-from neo.Prompt.Commands.Bootstrap import BootstrapBlockchain
+from neo.Prompt.Commands.Bootstrap import BootstrapBlockchainFile
 import argparse
 
 
@@ -8,6 +8,8 @@ def main():
     parser.add_argument("-m", "--mainnet", action="store_true", default=False,
                         help="use MainNet instead of the default TestNet")
     parser.add_argument("-c", "--config", action="store", help="Use a specific config file")
+
+    parser.add_argument("-n", "--notifications", action="store_true", default=False, help="Bootstrap notification dataase")
 
     args = parser.parse_args()
 
@@ -21,7 +23,10 @@ def main():
     elif args.mainnet:
         settings.setup_mainnet()
 
-    BootstrapBlockchain()
+    if args.notifications:
+        BootstrapBlockchainFile(settings.NOTIFICATION_DB_PATH, settings.NOTIF_BOOTSTRAP_FILE)
+    else:
+        BootstrapBlockchainFile(settings.LEVELDB_PATH, settings.BOOTSTRAP_FILE)
 
 
 if __name__ == "__main__":

--- a/neo/Core/TX/TransactionAttribute.py
+++ b/neo/Core/TX/TransactionAttribute.py
@@ -8,6 +8,7 @@ Usage:
 from logzero import logger
 from neo.Network.Inventory import Inventory
 from neocore.IO.Mixins import SerializableMixin
+from neocore.UIntBase import UIntBase
 
 
 class TransactionAttributeUsage(object):
@@ -115,6 +116,9 @@ class TransactionAttribute(Inventory, SerializableMixin):
             Exception: if the length exceeds the maximum allowed number of attributes in a transaction.
         """
         writer.WriteByte(self.Usage)
+
+        if isinstance(self.Data, UIntBase):
+            self.Data = self.Data.Data
 
         length = len(self.Data)
 

--- a/neo/Prompt/Commands/Bootstrap.py
+++ b/neo/Prompt/Commands/Bootstrap.py
@@ -8,38 +8,31 @@ import shutil
 import os
 
 
-def BootstrapBlockchain():
+def BootstrapBlockchainFile(target_dir, download_file, require_confirm=True):
 
-    current_chain_dir = settings.LEVELDB_PATH
-
-    bootstrap_file = settings.BOOTSTRAP_FILE
-
-    if bootstrap_file is None:
+    if download_file is None:
         print("no bootstrap file specified.  Please update your configuration file.")
         sys.exit(0)
 
-    print("This will overwrite any data currently in %s.\nType 'confirm' to continue" % current_chain_dir)
+    print("This will overwrite any data currently in %s.\nType 'confirm' to continue" % target_dir)
 
-    confirm = prompt("[confirm]> ", is_password=False)
-
-    if confirm == 'confirm':
-        return do_bootstrap()
+    if require_confirm:
+        confirm = prompt("[confirm]> ", is_password=False)
+        if confirm == 'confirm':
+            return do_bootstrap(download_file, target_dir)
+    else:
+        return do_bootstrap(download_file, target_dir, tmp_file_name='./fixtures/btest.tar.gz', tmp_chain_name='btestchain')
 
     print("bootstrap cancelled")
     sys.exit(0)
 
 
-def do_bootstrap():
-
-    bootstrap_file = settings.BOOTSTRAP_FILE
-    destination_dir = settings.LEVELDB_PATH
+def do_bootstrap(bootstrap_file, destination_dir, tmp_file_name='./Chains/bootstrap.tar.gz', tmp_chain_name='tmpchain'):
 
     success = False
 
     print('will download file %s ' % bootstrap_file)
     print('')
-    tmp_file_name = './Chains/bootstrap.tar.gz'
-    tmp_chain_name = 'tmpchain'
 
     try:
         response = requests.get(bootstrap_file, stream=True)
@@ -97,9 +90,9 @@ def do_bootstrap():
     finally:
 
         print("cleaning up %s " % tmp_file_name)
-#        os.remove(tmp_file_name)
         print("cleaning up %s " % tmp_chain_name)
-        shutil.rmtree(tmp_chain_name)
+        if os.path.exists(tmp_chain_name):
+            shutil.rmtree(tmp_chain_name)
 
     if success:
         print("Successfully downloaded bootstrap chain!")

--- a/neo/Prompt/Commands/tests/test_bootstrap.py
+++ b/neo/Prompt/Commands/tests/test_bootstrap.py
@@ -1,0 +1,43 @@
+from unittest import TestCase
+from neo.Prompt.Commands.Bootstrap import BootstrapBlockchainFile
+import os
+import shutil
+
+
+class BootstrapTestCase(TestCase):
+
+    bootstrap_file_good = 'https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_testnet/bootstraptest.tar.gz'
+    bootstrap_file_bad = 'https://s3.us-east-2.amazonaws.com/blah.tar.gz'
+
+    bootstrap_target_dir = './fixtures/bootstrap_test'
+    bootstrap_target_dir_bad = 'does_not_exist'
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(self.bootstrap_target_dir)
+        except Exception as e:
+            pass
+
+    def test_1_bad_bootstrap_file(self):
+
+        # this should exit 0
+        with self.assertRaises(SystemExit):
+            BootstrapBlockchainFile(self.bootstrap_target_dir, self.bootstrap_file_bad, require_confirm=False)
+
+        # make sure no files are left around
+        self.assertFalse(os.path.exists(self.bootstrap_target_dir))
+
+    def test_2_good_bootstrap_file(self):
+        with self.assertRaises(SystemExit):
+            BootstrapBlockchainFile(self.bootstrap_target_dir, self.bootstrap_file_good, require_confirm=False)
+
+        self.assertTrue(os.path.exists(self.bootstrap_target_dir))
+
+    def test_3_good_bootstrap_bad_path(self):
+        with self.assertRaises(SystemExit):
+            BootstrapBlockchainFile(self.bootstrap_target_dir_bad, self.bootstrap_file_good, require_confirm=False)
+
+        self.assertFalse(os.path.exists(self.bootstrap_target_dir))

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -55,6 +55,7 @@ class SettingsHolder:
     WS_PORT = None
     URI_PREFIX = None
     BOOTSTRAP_FILE = None
+    NOTIF_BOOTSTRAP_FILE = None
 
     ALL_FEES = None
     USE_DEBUG_STORAGE = False
@@ -62,7 +63,7 @@ class SettingsHolder:
     VERSION_NAME = "/NEO-PYTHON:%s/" % __version__
 
     # Logging settings
-    log_smart_contract_events = True
+    log_smart_contract_events = False
 
     # Helpers
     @property
@@ -113,6 +114,7 @@ class SettingsHolder:
         self.URI_PREFIX = config['UriPrefix']
 
         self.BOOTSTRAP_FILE = config['BootstrapFile']
+        self.NOTIF_BOOTSTRAP_FILE = config['NotificationBootstrapFile']
 
         Helper.ADDRESS_VERSION = self.ADDRESS_VERSION
 

--- a/neo/SmartContract/tests/test_gas_costs.py
+++ b/neo/SmartContract/tests/test_gas_costs.py
@@ -80,7 +80,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
         expected_fee = Fixed8.FromDecimal(.001)
         self.assertEqual(expected_cost, engine.GasConsumed())
         self.assertEqual(tx.Gas, expected_fee)
-        self.assertEqual(result.GetByteArray(), bytearray(b'\xab\xab\xab\xab\xab\xab'))
+        self.assertEqual(result, bytearray(b'\xab\xab\xab\xab\xab\xab'))
 
     def test_build_contract_4(self):
         """

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -93,7 +93,7 @@ class ExecutionEngine():
 
     def ResultsForCode(self, contract):
         try:
-            return_type = contract.ReturnType
+            return_type = ContractParameterType(contract.ReturnType)
 
             item = self.EvaluationStack.Items[0]
             if return_type == ContractParameterType.Integer:
@@ -598,8 +598,7 @@ class ExecutionEngine():
 
                 except Exception as e:
                     estack.PushT(False)
-                    traceback.print_stack()
-                    traceback.print_exc()
+                    logger.error("Could not checksig: %s " % e)
 
             elif opcode == CHECKMULTISIG:
 

--- a/neo/api/REST/NotificationRestApi.py
+++ b/neo/api/REST/NotificationRestApi.py
@@ -34,20 +34,21 @@ class NotificationRestApi(object):
                         <h2>endpoints:</h2>
                         <p>
                             <ul>
-                                <li><pre>/block/{height}</pre></li>
-                                <li><pre>/addr/{addr}</pre></li>
-                                <li><pre>/tx/{hash}</pre></li>
-                                <li><pre>/tx/{hash}</pre></li>
-                                <li><pre>/tokens</pre></li>
-                                <li><pre>/token/{contract_hash}</pre></li>                                
+                                <li><pre>/block/{height}</pre> <em>notifications by block</em></li>
+                                <li><pre>/addr/{addr}</pre><em>notifications by address</em></li>
+                                <li><pre>/tx/{hash}</pre><em>notifications by tx</em></li>
+                                <li><pre>/contract/{hash}</pre><em>notifications by contract</em></li>
+                                <li><pre>/tokens</pre><em>lists all NEP5 Tokens</em></li>
+                                <li><pre>/token/{contract_hash}</pre><em>list an NEP5 Token</em></li>                                
                             </ul>
                         </p>
                         <div>
                             <hr/>
                             <h3>pagination</h3>
-                            <p>results are offered in page size of 1000</p>
+                            <p>results are offered in page size of 500</p>
                             <p>you may request a different page by specifying the <code>page</code> query string param, for example:</p>
                             <pre>/block/123456?page=3</pre>
+                            <p>page index starts at 0, so the 2nd page would be <code>?page=1</code></p>
                             <hr/>
                             <h3>sample output</h3>
                             <pre>
@@ -176,7 +177,7 @@ class NotificationRestApi(object):
     def format_notifications(self, request, notifications):
 
         notif_len = len(notifications)
-        page_len = 1000
+        page_len = 500
         page = 0
         message = ''
         if b'page' in request.args:

--- a/neo/api/REST/test_notification_rest_api.py
+++ b/neo/api/REST/test_notification_rest_api.py
@@ -191,7 +191,6 @@ class NotificationDBTestCase(BlockchainFixtureTestCase):
         results = jsn['results']
         self.assertEqual(len(results), 500)
 
-
         mock_req = requestMock(path=b'/addr/AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM?page=2')
         res = self.app.get_by_addr(mock_req, 'AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM')
         jsn = json.loads(res)

--- a/neo/api/REST/test_notification_rest_api.py
+++ b/neo/api/REST/test_notification_rest_api.py
@@ -182,9 +182,17 @@ class NotificationDBTestCase(BlockchainFixtureTestCase):
         jsn = json.loads(res)
         self.assertEqual(jsn['total'], 1027)
         results = jsn['results']
-        self.assertEqual(len(results), 1000)
+        self.assertEqual(len(results), 500)
 
         mock_req = requestMock(path=b'/addr/AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM?page=1')
+        res = self.app.get_by_addr(mock_req, 'AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM')
+        jsn = json.loads(res)
+        self.assertEqual(jsn['total'], 1027)
+        results = jsn['results']
+        self.assertEqual(len(results), 500)
+
+
+        mock_req = requestMock(path=b'/addr/AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM?page=2')
         res = self.app.get_by_addr(mock_req, 'AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM')
         jsn = json.loads(res)
         self.assertEqual(jsn['total'], 1027)

--- a/protocol.coz.json
+++ b/protocol.coz.json
@@ -38,6 +38,7 @@
     "SslCert": "",
     "SslCertPassword": "",
     "BootstrapFile":"",
+    "NotificationBootstrapFile":"",
     "DebugStorage":1
   }
 }

--- a/protocol.mainnet.json
+++ b/protocol.mainnet.json
@@ -40,8 +40,8 @@
     "UriPrefix": [ "http://*:10332" ],
     "SslCert": "",
     "SslCertPassword": "",
-    "BootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/Chain1550000.tar.gz",
-    "NotificationBootstrapFile":"",
+    "BootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/ChainMain1920000.tar.gz",
+    "NotificationBootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/MainNotifications1920000.tar.gz",
     "DebugStorage":1
   }
 }

--- a/protocol.mainnet.json
+++ b/protocol.mainnet.json
@@ -41,6 +41,7 @@
     "SslCert": "",
     "SslCertPassword": "",
     "BootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/Chain1550000.tar.gz",
+    "NotificationBootstrapFile":"",
     "DebugStorage":1
   }
 }

--- a/protocol.testnet.json
+++ b/protocol.testnet.json
@@ -10,7 +10,8 @@
             "http://*:20332"
         ],
         "WsPort": 20334,
-        "BootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_testnet/ChainTestnet1060000.tar.gz",
+        "BootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_testnet/ChainTestnet1140000.tar.gz",
+        "NotificationBootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_testnet/TestnetNotifications1140000.tar.gz",
         "DebugStorage":1
     },
     "ProtocolConfiguration": {


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
- updates bootstrap files
- adds ability to download bootstrap notification DB
- fixes issue with TXAttr serialization
- adds tests for bootstrap
- updates home page for notification server
- change notification server page size to 500

**How did you solve this problem?**
- code
**How did you make sure your solution works?**
- tests
**Did you add any tests?**
- yes
**Are there any special changes in the code that we should be aware of?**

- if you would like to download the bootstrap data for notifications, you can do that with the `--notifications` flag for the bootstrap command:
```
python bootstrap.py --notifications -m # download notifications for mainnet
python bootstrap.py --notifications # download notifications for testnet
```

**Did you run `make lint` and `make test`?**
- yes

**Are you making a PR to a feature branch or development rather than master?**
- yes
