### PR TITLE
Added NotificationBootstrapFile for privnet

### DIFF
--- a/protocol.privnet.json
+++ b/protocol.privnet.json
@@ -35,6 +35,7 @@
     "SslCert": "",
     "SslCertPassword": "",
     "BootstrapFile":"",
+    "NotificationBootstrapFile":"",
     "DebugStorage":1
   }
 }


### PR DESCRIPTION
* Added the missing "NotificationBootstrapFile" key to the privnet config.


**What current issue(s) does this address?, or what feature is it adding?**

```
$ python prompt.py -p
Traceback (most recent call last):
  File "prompt.py", line 972, in <module>
    main()
  File "prompt.py", line 948, in main
    settings.setup_privnet()
  File "/Users/brian/Projects/Narrative/neo-python2/neo/Settings.py", line 137, in setup_privnet
    self.setup(FILENAME_SETTINGS_PRIVNET)
  File "/Users/brian/Projects/Narrative/neo-python2/neo/Settings.py", line 117, in setup
    self.NOTIF_BOOTSTRAP_FILE = config['NotificationBootstrapFile']
KeyError: 'NotificationBootstrapFile'
```

**How did you solve this problem?**

Added the missing key.

**How did you make sure your solution works?**

Tested it.

**Did you add any tests?**

No.

**Are there any special changes in the code that we should be aware of?**

No.

**Did you run `make lint` and `make test`?**

No.

**Are you making a PR to a feature branch or development rather than master?**

development