### PR TITLE
Fixed bug with SmartContract event handler sharing

### DIFF
--- a/neo/contrib/smartcontract.py
+++ b/neo/contrib/smartcontract.py
@@ -40,11 +40,12 @@ class SmartContract:
     sent in the smart contract.
     """
     contract_hash = None
-    event_handlers = defaultdict(list)
+    event_handlers = None
 
     def __init__(self, contract_hash):
         assert contract_hash
         self.contract_hash = str(contract_hash)
+        self.event_handlers = defaultdict(list)
 
         # Handle EventHub events for SmartContract decorators
         @events.on(SmartContractEvent.RUNTIME_NOTIFY)


### PR DESCRIPTION

**What current issue(s) does this address?, or what feature is it adding?**

Event handlers were not being properly isolated between multiple SmartContract instances.

**How did you solve this problem?**

Initialize the event_handlers dictionary in the constructor instead of sharing the dictionary statically across all SmartContract instances.

**How did you make sure your solution works?**

Tested it. Events were firing multiple times with multiple SmartContracts previously. Now, they only fire for the proper script hash.

**Did you add any tests?**

No.

**Are there any special changes in the code that we should be aware of?**

No.

**Did you run `make lint` and `make test`?**

Yes, but tests appear to be failing presently on `development`.

**Are you making a PR to a feature branch or development rather than master?**

`development`