### PR TITLE
Missing transaction tx, or None, as return of SC Invokes

### DIFF
--- a/prompt.py
+++ b/prompt.py
@@ -716,10 +716,10 @@ class PromptInterface(object):
 
                 result = InvokeContract(self.Wallet, tx, fee)
 
-                return
+                return tx
             else:
                 print("Error testing contract invoke")
-                return
+                return false
 
         print("Please specify a contract to invoke")
 
@@ -756,11 +756,11 @@ class PromptInterface(object):
 
                     result = InvokeContract(self.Wallet, tx, Fixed8.Zero())
 
-                    return
+                    return tx
                 else:
                     print("Test invoke failed")
                     print("TX is %s, results are %s" % (tx, results))
-                    return
+                    return false
 
     def show_mem(self):
         process = psutil.Process(os.getpid())

--- a/prompt.py
+++ b/prompt.py
@@ -716,10 +716,13 @@ class PromptInterface(object):
 
                 result = InvokeContract(self.Wallet, tx, fee)
 
+                if result is False:
+                    return None
+                
                 return tx
             else:
                 print("Error testing contract invoke")
-                return false
+                return None
 
         print("Please specify a contract to invoke")
 
@@ -756,11 +759,15 @@ class PromptInterface(object):
 
                     result = InvokeContract(self.Wallet, tx, Fixed8.Zero())
 
+                    
+                    if result is False:
+                        return None
+                    
                     return tx
                 else:
                     print("Test invoke failed")
                     print("TX is %s, results are %s" % (tx, results))
-                    return false
+                    return None
 
     def show_mem(self):
         process = psutil.Process(os.getpid())


### PR DESCRIPTION
InvokeContract was not returning tx object or False status


**What current issue(s) does this address?, or what feature is it adding?**
The possibility of easy accessing the tx result of a "testinvoke" or "import contract" in the prompt.
Several users may use prompt.py as example.

**How did you solve this problem?**
Quite of. It is just an idea for better template for being used.

**How did you make sure your solution works?**
Not sure

**Did you add any tests?**
Manual and auto tests

**Are there any special changes in the code that we should be aware of?**
no

**Did you run `make lint` and `make test`?**
no

**Are you making a PR to a feature branch or development rather than master?**
no
