### PR TITLE
Zero Length bytearray fix

### DIFF
--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -142,7 +142,7 @@ class ExecutionEngine():
                        PUSH9, PUSH10, PUSH11, PUSH12, PUSH13, PUSH14, PUSH15, PUSH16]
 
             if opcode == PUSH0:
-                estack.PushT(bytearray([0]))
+                estack.PushT(bytearray(0))
 
             elif opcode == PUSHDATA1:
                 lenngth = context.OpReader.ReadByte()


### PR DESCRIPTION

**What current issue(s) does this address?, or what feature is it adding?**
- push a zero length bytearray onto the stack for PUSH0 instead of a by…tearray with one item of zero
- should resolve the following: https://github.com/CityOfZion/neo-boa/issues/43 https://github.com/CityOfZion/neo-boa/issues/44

**How did you solve this problem?**
- changed `bytearray([0])` to `bytearray(0)`

**How did you make sure your solution works?**
- tests

**Did you add any tests?**
- no

**Are there any special changes in the code that we should be aware of?**
- this may change the behavior of how SC operate within `neo-python`.  Where `PUSH0` before pushed `bytearray(b'\x00')` onto the stack, `PUSH0` now pushes `bytearray(b'')`
- this does not affect how the SC would perform within the C# nodes, and this change brings the `neo-python` implementation into alignment with the reference implementation

**Did you run `make lint` and `make test`?**
- yes

**Are you making a PR to a feature branch or development rather than master?**
- yes
