### PR TITLE
Development

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -9,13 +9,22 @@ def main():
                         help="use MainNet instead of the default TestNet")
     parser.add_argument("-c", "--config", action="store", help="Use a specific config file")
 
-    parser.add_argument("-n", "--notifications", action="store_true", default=False, help="Bootstrap notification dataase")
+    parser.add_argument("-n", "--notifications", action="store_true", default=False,
+                        help="Bootstrap notification database")
+
+    parser.add_argument("-s", "--skipconfirm", action="store_true", default=False,
+                        help=("Bypass warning about overwritting data in $%" % settings.LEVELDB_PATH))
 
     args = parser.parse_args()
 
     if args.mainnet and args.config:
         print("Cannot use both --config and --mainnet parameters, please use only one.")
         exit(1)
+ 
+    if args.skipconfirm:
+        require_confirm = False
+    else:
+        require_confirm = True      
 
     # Setup depending on command line arguments. By default, the testnet settings are already loaded.
     if args.config:
@@ -24,9 +33,9 @@ def main():
         settings.setup_mainnet()
 
     if args.notifications:
-        BootstrapBlockchainFile(settings.NOTIFICATION_DB_PATH, settings.NOTIF_BOOTSTRAP_FILE)
+        BootstrapBlockchainFile(settings.NOTIFICATION_DB_PATH, settings.NOTIF_BOOTSTRAP_FILE, require_confirm)
     else:
-        BootstrapBlockchainFile(settings.LEVELDB_PATH, settings.BOOTSTRAP_FILE)
+        BootstrapBlockchainFile(settings.LEVELDB_PATH, settings.BOOTSTRAP_FILE, require_confirm)
 
 
 if __name__ == "__main__":

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -13,7 +13,7 @@ def main():
                         help="Bootstrap notification database")
 
     parser.add_argument("-s", "--skipconfirm", action="store_true", default=False,
-                        help=("Bypass warning about overwritting data in {}".format(settings.LEVELDB_PATH))
+                        help="Bypass warning about overwritting data in {}".format(settings.LEVELDB_PATH))
 
     args = parser.parse_args()
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -13,7 +13,7 @@ def main():
                         help="Bootstrap notification database")
 
     parser.add_argument("-s", "--skipconfirm", action="store_true", default=False,
-                        help=("Bypass warning about overwritting data in $%" % settings.LEVELDB_PATH))
+                        help=("Bypass warning about overwritting data in {}".format(settings.LEVELDB_PATH))
 
     args = parser.parse_args()
 

--- a/neo/Prompt/Commands/Bootstrap.py
+++ b/neo/Prompt/Commands/Bootstrap.py
@@ -14,9 +14,8 @@ def BootstrapBlockchainFile(target_dir, download_file, require_confirm=True):
         print("no bootstrap file specified.  Please update your configuration file.")
         sys.exit(0)
 
-    print("This will overwrite any data currently in %s.\nType 'confirm' to continue" % target_dir)
-
     if require_confirm:
+        print("This will overwrite any data currently in %s.\nType 'confirm' to continue" % target_dir)
         confirm = prompt("[confirm]> ", is_password=False)
         if confirm == 'confirm':
             return do_bootstrap(download_file, target_dir)


### PR DESCRIPTION
**What current issue(s) does this address?, or what feature is it adding?**
It adds a command line arg to skip the confirmation step when using bootstrap.py. This comes handy when calling the script in a non-interactive fashion. 

**How did you solve this problem?**
Add the -s or --skipconfirm arg to bootstrap.py, which sets require_confirm to False if it is passed in the command line. Also I moved the confirmation warning to the code block where require_confirm is True. 

**How did you make sure your solution works?**
Tested at each code addition and did a final check by pulling and testing the code from my fork remote.

**Did you add any tests?**
No, the change is pretty straightforward and I used the existing arg parsing as an example.

**Are there any special changes in the code that we should be aware of?**
Apart from printing a confirmation warning only when a confirmation is required, no changes.

**Did you run `make lint` and `make test`?**
'make lint' outputs 'pycodestyle neo examples prompt.py'
'make test' seems to get stuck at downloading the fixtures

**Are you making a PR to a feature branch or development rather than master?**
The development branch. The master branch does not contain the require_confirm option yet.
