### PR TITLE
Support Synchronous Wallet Rebuilds

### DIFF
--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -655,7 +655,7 @@ class Wallet(object):
             block_limit (int): the number of blocks to process synchronously. defaults to 1000. set to 0 to block until the wallet is fully rebuilt.
         """
         blockcount = 0
-        while self._current_height <= Blockchain.Default().Height and (block_limit==0 or blockcount < block_limit):
+        while self._current_height <= Blockchain.Default().Height and (block_limit == 0 or blockcount < block_limit):
 
             block = Blockchain.Default().GetBlockByHeight(self._current_height)
 

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -642,17 +642,20 @@ class Wallet(object):
         # abstract
         pass
 
-    def ProcessBlocks(self):
+    def ProcessBlocks(self, block_limit=1000):
         """
         Method called on a loop to check the current height of the blockchain.  If the height of the blockchain
         is more than the current stored height in the wallet, we get the next block in line and
         processes it.
 
-        In the case that the wallet height is far behind the height of the blockchain, we do this 500
+        In the case that the wallet height is far behind the height of the blockchain, we do this 1000
         blocks at a time.
+
+        Args:
+            block_limit (int): the number of blocks to process synchronously. defaults to 1000. set to 0 to block until the wallet is fully rebuilt.
         """
         blockcount = 0
-        while self._current_height <= Blockchain.Default().Height and blockcount < 1000:
+        while self._current_height <= Blockchain.Default().Height and (block_limit==0 or blockcount < block_limit):
 
             block = Blockchain.Default().GetBlockByHeight(self._current_height)
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

There are situations where it can be useful to synchronously wait for the wallet rebuild process to complete before returning. We have a script that processes transactions in bulk. It needs to use a wallet to sign the transactions, but sometimes the wallet can become corrupted and result in "insufficient funds" errors. When this happens, we need to rebuild the wallet from a local copy. It's useful to have that rebuild process block until the wallet is fully rebuilt.

https://github.com/NarrativeNetwork/tokensale-neo-smartcontract/blob/master/util/bulk-process-tx.py#L295

**How did you solve this problem?**

Added an optional argument to allow wallet rebuilds be performed synchronously so that `ProcessBlocks` does not return until the wallet is fully rebuilt. We could alternatively handle this blocking behavior externally, but I think it may be useful to other devs integrating in a similar fashion to be able to leverage this optional parameter to synchronously block on the rebuild, as well.

**How did you make sure your solution works?**

Tested that it has no impact on existing behavior and only changes behavior when the new, optional parameter is used.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
