### PR TITLE
fix typo in help output (witdraw -> withdraw)

### DIFF
--- a/prompt.py
+++ b/prompt.py
@@ -107,7 +107,7 @@ class PromptInterface(object):
                 'withdraw holds # lists all current holds',
                 'withdraw completed # lists completed holds eligible for cleanup',
                 'withdraw cancel # cancels current holds',
-                'witdraw cleanup # cleans up completed holds',
+                'withdraw cleanup # cleans up completed holds',
                 'withdraw # withdraws the first hold availabe',
                 'withdraw all # withdraw all holds available',
                 'send {assetId or name} {address} {amount} (--from-addr={addr})',


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
typo shown when executing the "help" command 
**How did you solve this problem?**
fixed the typo 😺 
**How did you make sure your solution works?**
ran the prompt and saw the typo is now gone. searched the whole code base for the typo to make sure this is the only place it occured
**Are there any special changes in the code that we should be aware of?**
no
**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [ ] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
