### PR TITLE
Added warning about not using awesome-neo chain files to bootstrappin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ neo>
 
 If you use neo-python for the first time, you need to synchronize the blockchain, which may take a long time. Included in this project is `bootstrap.py` to automatically download a chain directory for you. To bootstrap for testnet, run `python bootstrap.py`, get a cup of coffee and wait. To bootstrap for mainnet, use `python bootstrap.py -m` and get 8 cups of coffee (3.3 GB file).
 
+Important: do not use the chain files from https://github.com/CityOfZion/awesome-neo.git, they will not work with neo-python.
+
 ### Available Wallet commands
 
 ```


### PR DESCRIPTION
…g section.


**What current issue(s) does this address, or what feature is it adding?**
Prevent people from trying to use awesome-neo C# chain files with neo-python

**How did you solve this problem?**
Add a warning to the README

**How did you make sure your solution works?**
Not applicable, no code

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [ ] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
