### PR TITLE
Add num_peers to REST API

### DIFF
--- a/api-server.py
+++ b/api-server.py
@@ -66,7 +66,7 @@ def main():
     group.add_argument("-m", "--mainnet", action="store_true", default=False,
                        help="Use MainNet instead of the default TestNet")
     group.add_argument("-t", "--testnet", action="store_true", default=False,
-                       help="Use TestNett instead of the default TestNet")
+                       help="Use TestNet instead of the default TestNet")
     group.add_argument("-p", "--privnet", action="store_true", default=False,
                        help="Use PrivNet instead of the default TestNet")
     group.add_argument("--coznet", action="store_true", default=False,

--- a/neo/api/REST/NotificationRestApi.py
+++ b/neo/api/REST/NotificationRestApi.py
@@ -186,6 +186,8 @@ class NotificationRestApi(object):
         try:
             uint160 = UInt160.ParseString(contract_hash)
             contract_event = self.notif.get_token(uint160)
+            if not contract_event:
+                return self.format_message("Could not find contract with hash %s" % contract_hash)
             notifications = [contract_event]
         except Exception as e:
             logger.info("Could not get contract with hash %s because %s " % (contract_hash, e))

--- a/neo/api/REST/NotificationRestApi.py
+++ b/neo/api/REST/NotificationRestApi.py
@@ -8,6 +8,7 @@ import json
 from klein import Klein
 from logzero import logger
 
+from neo.Network.NodeLeader import NodeLeader
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
 from neo.Core.Blockchain import Blockchain
 from neocore.UInt160 import UInt160
@@ -199,6 +200,7 @@ class NotificationRestApi(object):
         return json.dumps({
             'current_height': Blockchain.Default().Height,
             'version': settings.VERSION_NAME,
+            'num_peers': len(NodeLeader.Instance().Peers)
         }, indent=4, sort_keys=True)
 
     def format_notifications(self, request, notifications):


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Added a `num_peers` property to the `/status` endpoint of the REST API.

Fixed traceback error for script hash that doesn't exist for `/tokens` endpoint.

**How did you solve this problem?**

Implemented.

**How did you make sure your solution works?**

Tested.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
