### PR TITLE
Docs for Python 3.6 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ found at [Read The Docs](https://neo-python.readthedocs.io/en/latest/).
 - Open a new [issue](https://github.com/CityOfZion/neo-python/issues/new) if you encounter a problem.
 - Or ping **@localhuman**  or **@metachris** on the [NEO Discord](https://discord.gg/R8v48YA).
 - Pull requests welcome. You can help with wallet functionality, writing tests
-  or documentation, or on any other feature you deem awesome. 
-  
+  or documentation, or on any other feature you deem awesome.
+
 ## Getting started
 
 neo-python has two System dependencies (everything else is covered with `pip`):
@@ -88,15 +88,26 @@ Instructions on the system setup for neo-python:
 brew install leveldb
 ```
 
-#### Ubuntu/Debian
+#### Ubuntu/Debian 16.10+
+
+Ubuntu starting at 16.10 supports Python 3.6 in the official repositories, and you can just install Python 3.6 and all the system dependencies like this:
 
 ```
-apt-get install libleveldb-dev python3.6-dev python3-pip python3-venv libssl-dev g++
+apt-get install python3.6 python3.6-dev python3-pip python3-venv libleveldb-dev libssl-dev g++
+```
+
+#### Older Ubuntu versions (eg. 16.04)
+
+For older Ubuntu versions you'll need to use an external repository like Felix Krull's deadsnakes PPA at https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa (read more [here](https://askubuntu.com/questions/865554/how-do-i-install-python-3-6-using-apt-get)):
+
+```
+apt-get install software-properties-common python-software-properties
+sudo add-apt-repository ppa:deadsnakes/ppa
+sudo apt-get update
+apt-get install python3.6 python3.6-dev python3-pip python3-venv libleveldb-dev libssl-dev g++
 ```
 
 #### Centos/Redhat/Fedora
-
-This is a bit more tricky...
 
 ```
 # Install Python 3.6:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ apt-get install python3.6 python3.6-dev python3.6-venv python3-pip libleveldb-de
 
 #### Older Ubuntu versions (eg. 16.04)
 
-For older Ubuntu versions you'll need to use an external repository like Felix Krull's deadsnakes PPA at https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa (read more [here](https://askubuntu.com/questions/865554/how-do-i-install-python-3-6-using-apt-get)):
+For older Ubuntu versions you'll need to use an external repository like Felix Krull's deadsnakes PPA at https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa (read more [here](https://askubuntu.com/questions/865554/how-do-i-install-python-3-6-using-apt-get)).
+
+(The use of the third-party software links in this documentation is done at your own discretion and risk and with agreement that you will be solely responsible for any damage to your computer system or loss of data that results from such activities.)
+
 
 ```
 apt-get install software-properties-common python-software-properties

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ brew install leveldb
 Ubuntu starting at 16.10 supports Python 3.6 in the official repositories, and you can just install Python 3.6 and all the system dependencies like this:
 
 ```
-apt-get install python3.6 python3.6-dev python3-pip python3-venv libleveldb-dev libssl-dev g++
+apt-get install python3.6 python3.6-dev python3.6-venv python3-pip libleveldb-dev libssl-dev g++
 ```
 
 #### Older Ubuntu versions (eg. 16.04)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,13 +19,15 @@
 #
 # Once you are inside the container, you can start neo-python with `python3 prompt.py -p` (using -p to connect to a private net).
 # To update neo-python, just run `git pull` and `pip install -e .`
-FROM ubuntu:16.04
+FROM ubuntu:17.10
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
     wget \
     git-core \
-    python3-dev \
+    python3.6 \
+    python3.6-dev \
+    python3.6-venv \
     python3-pip \
     libleveldb-dev \
     libssl-dev \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -20,13 +20,15 @@
 # Once you are inside the container, you can start neo-python with `python3 prompt.py -p` (using -p to connect to a private net).
 # To update neo-python, just run `git pull` and `pip install -e .`
 #
-FROM ubuntu:16.04
+FROM ubuntu:17.10
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
     wget \
     git-core \
-    python3-dev \
+    python3.6 \
+    python3.6-dev \
+    python3.6-venv \
     python3-pip \
     libleveldb-dev \
     libssl-dev \

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -18,28 +18,14 @@ Make a Python 3 virtual environment and activate it via
 
 ::
 
-    python3 -m venv venv
-    source venv/bin/activate
-
-or to explicitly install Python 3.6,
-
-::
-
-    virtualenv -p /usr/local/bin/python3.6 venv
+    python3.6 -m venv venv
     source venv/bin/activate
 
 Then install the requirements via
 
 ::
 
-    pip install -r requirements.txt
-
-
-Finally, install a reference to the `neo` working directory, in order to be able to `import neo` from
-anywhere in the project (eg. examples):
-
-::
-
+    pip install -U setuptools pip wheel
     pip install -e .
 
 
@@ -65,27 +51,48 @@ OSX
 
     brew install leveldb
 
-Ubuntu/Debian
-"""""""""""""
+
+Ubuntu/Debian 16.10+
+""""""""""""""""""""
+
+Ubuntu starting at 16.10 supports Python 3.6 in the official repositories, and you can just install Python 3.6 and all the system dependencies like this:
 
 ::
 
-    apt-get install libleveldb-dev python3.6-dev python3-pip libssl-dev
+    apt-get install python3.6 python3.6-dev python3-pip python3-venv libleveldb-dev libssl-dev g++
 
 
-    
+Older Ubuntu versions (eg. 16.04)
+"""""""""""""""""""""""""""""""""
+
+For older Ubuntu versions you'll need to use an external repository like Felix Krull's deadsnakes PPA at https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa (read more `here <https://askubuntu.com/questions/865554/how-do-i-install-python-3-6-using-apt-get>`_):
+
+::
+
+    apt-get install software-properties-common python-software-properties
+    sudo add-apt-repository ppa:deadsnakes/ppa
+    sudo apt-get update
+    apt-get install python3.6 python3.6-dev python3-pip python3-venv libleveldb-dev libssl-dev g++
+
+
 Centos/Redhat/Fedora
 """"""""""""""""""""
 
-This is a bit more tricky. You may need to enable the epel repo for the leveldb-devel package, which you can do by editing ``/etc/yum.repos.d/epel.repo``.
-
 ::
 
-    yum -y install development tools python36 python36-devel python36-pip readline-devel leveldb-devel libffi-devel
+    # Install Python 3.6:
+    yum install -y centos-release-scl
+    yum install -y rh-python36
+    scl enable rh-python36 bash
+
+    # Install dependencies:
+    yum install -y epel-release
+    yum install -y readline-devel leveldb-devel libffi-devel gcc-c++ redhat-rpm-config gcc python-devel openssl-devel
 
 
 Windows
 """""""
+
 This has not been tested at this time. Installing the Python package plyvel seems to require C++ compiler support tied to Visual Studio and libraries.
 
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -67,6 +67,8 @@ Older Ubuntu versions (eg. 16.04)
 
 For older Ubuntu versions you'll need to use an external repository like Felix Krull's deadsnakes PPA at https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa (read more `here <https://askubuntu.com/questions/865554/how-do-i-install-python-3-6-using-apt-get>`_):
 
+(The use of the third-party software links in this documentation is done at your own discretion and risk and with agreement that you will be solely responsible for any damage to your computer system or loss of data that results from such activities.)
+
 ::
 
     apt-get install software-properties-common python-software-properties


### PR DESCRIPTION
* Updated README.md and docs/install.rst with infos about setting up the new Python 3.6 system, in particular relevant because Ubuntu <16.10 (eg. 16.04, the latest LTS) does not support python-3.6 out of the box.
* Also updated the Docker files
