### PR TITLE
API syslog / logger improvements

### DIFF
--- a/api-server.py
+++ b/api-server.py
@@ -225,5 +225,6 @@ def translate_syslog_facility(syslog_facility):
     elif syslog_facility == SysLogHandler.LOG_LOCAL7:
         return syslog.LOG_LOCAL7
 
+
 if __name__ == "__main__":
     main()

--- a/api-server.py
+++ b/api-server.py
@@ -107,7 +107,7 @@ def main():
 
     if args.syslog:
         logzero.logfile("", disableStderrLogger=args.quiet)
-        syslog_handler = SysLogHandler()
+        syslog_handler = SysLogHandler(facility='local0')
         logger.addHandler(syslog_handler)
     else:
         logzero.logfile(LOGFILE_FN, maxBytes=LOGFILE_MAX_BYTES, backupCount=LOGFILE_BACKUP_COUNT, disableStderrLogger=args.quiet)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ hyperlink==18.0.0
 idna==2.6
 incremental==17.5.0
 klein==17.10.0
-logzero==1.3.1
+logzero==1.4.0
 memory-profiler==0.52.0
 mmh3==2.5.1
 mock==2.0.0


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Logging for neo-python API server was disjointed. Some logs would go to stdout and others to a log file and stderr. This change allows you to use syslog (and only syslog) for logging if you choose, which gives sys admins more control over how to handle log files, rotation, etc.

**How did you solve this problem?**

Upgraded to 1.4.0 of logzero and added support for 

**How did you make sure your solution works?**

Tested it and deployed it on our API nodes.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
