### PR TITLE
update video link to the latest 0.5 demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ neo-python has two System dependencies (everything else is covered with `pip`):
 - [LevelDB](https://github.com/google/leveldb)
 - [Python 3.6+](https://www.python.org/downloads/release/python-364/) (3.5 and below is not supported)
 
-We have published a Youtube [video](https://youtu.be/oy6Z_zd42-4) to help get
+We have published a Youtube [video](https://www.youtube.com/watch?v=ZZXz261AXrM) to help get
 you started. There are many more videos under the
 [CityOfZion](https://www.youtube.com/channel/UCzlQUNLrRa8qJkz40G91iJg) Youtube
 channel, check them out.


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
The readme was still pointing to an old video from somewhere in Q3 2017 with information that (at least partially) doesn't hold anymore. Now updated to the latest and greatest.

**How did you solve this problem?**
change link

**How did you make sure your solution works?**
clicky click it

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
