### PR TITLE
Rename NotificationRestApi to RestAPi

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ All notable changes to this project are documented in this file.
 ----------------------------
 - update to neo-boa==0.3.4
 - `api-server.py <https://github.com/CityOfZion/neo-python/blob/development/api-server.py>`_: Improved logging setup. See the options with ``./api-server.py -h``
-
+- Renamed ``neo.api.REST.NotificationRestApi`` to ``neo.api.REST.RestApi``
 
 [0.5.3] 2018-03-04
 ------------------

--- a/api-server.py
+++ b/api-server.py
@@ -2,7 +2,7 @@
 """
 API server to run the JSON-RPC and REST API.
 
-Uses neo.api.JSONRPC.JsonRpcApi and neo.api.REST.NotificationRestApi
+Uses neo.api.JSONRPC.JsonRpcApi and neo.api.REST.RestApi
 
 Print the help and all possible arguments:
 
@@ -53,7 +53,7 @@ from neo.Core.Blockchain import Blockchain
 from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
 from neo.api.JSONRPC.JsonRpcApi import JsonRpcApi
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
-from neo.api.REST.NotificationRestApi import NotificationRestApi
+from neo.api.REST.RestApi import RestApi
 
 from neo.Network.NodeLeader import NodeLeader
 from neo.Settings import settings
@@ -203,7 +203,7 @@ def main():
 
     if args.port_rest:
         logger.info("Starting REST api server on http://%s:%s" % (host, args.port_rest))
-        api_server_rest = NotificationRestApi()
+        api_server_rest = RestApi()
         endpoint_rest = "tcp:port={0}:interface={1}".format(args.port_rest, host)
         endpoints.serverFromString(reactor, endpoint_rest).listen(Site(api_server_rest.app.resource()))
 

--- a/examples/rest-api-server.py
+++ b/examples/rest-api-server.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-This example provides a REST API to query notifications from the blockchain, implementing `neo.api.RESTAPI.NotificationRestApi`
-
+This example provides a REST API to query notifications from the blockchain, implementing `neo.api.RESTAPI.RestApi`
 See it live here: http://notifications.neeeo.org/
+
+See also api-server.py for a more complete API implementation
 """
 
 import argparse
@@ -15,7 +16,7 @@ from neo import __version__
 from neo.Core.Blockchain import Blockchain
 from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
-from neo.api.REST.NotificationRestApi import NotificationRestApi
+from neo.api.REST.RestApi import RestApi
 from neo.Network.NodeLeader import NodeLeader
 from neo.Settings import settings, DIR_PROJECT_ROOT
 from neo.UserPreferences import preferences
@@ -63,15 +64,15 @@ def main():
     ndb = NotificationDB.instance()
     ndb.start()
 
-    notif_server = NotificationRestApi()
+    api_server = RestApi()
 
     # Run
     reactor.suggestThreadPoolSize(15)
     NodeLeader.Instance().Start()
 
     port = 8000
-    logger.info("Starting notification-api server on port %s" % (port))
-    notif_server.app.run('0.0.0.0', port)
+    logger.info("Starting rest-api server on port %s" % (port))
+    api_server.app.run('0.0.0.0', port)
 
 
 if __name__ == "__main__":

--- a/neo/api/REST/RestApi.py
+++ b/neo/api/REST/RestApi.py
@@ -20,7 +20,7 @@ from neo.api.utils import cors_header
 API_URL_PREFIX = "/v1"
 
 
-class NotificationRestApi(object):
+class RestApi(object):
     app = Klein()
     notif = None
 

--- a/neo/api/REST/test_rest_api.py
+++ b/neo/api/REST/test_rest_api.py
@@ -9,7 +9,7 @@ import tarfile
 import logzero
 import shutil
 
-from neo.api.REST.NotificationRestApi import NotificationRestApi
+from neo.api.REST.RestApi import RestApi
 
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
 from klein.test.test_resource import requestMock
@@ -27,7 +27,7 @@ class NotificationDBTestCase(BlockchainFixtureTestCase):
     addr_to = 'AHbmRX5sL8oxp4dJZRNg5crCGUGxuMUyRB'
     addr_from = 'AcFnRrVC5emrTEkuFuRPufcuTb6KsAJ3vR'
 
-    app = None  # type:NotificationRestApi
+    app = None  # type:RestApi
 
     @classmethod
     def leveldb_testpath(self):
@@ -72,7 +72,7 @@ class NotificationDBTestCase(BlockchainFixtureTestCase):
         shutil.rmtree(cls.N_NOTIFICATION_DB_NAME)
 
     def setUp(self):
-        self.app = NotificationRestApi()
+        self.app = RestApi()
 
     def test_1_ok(self):
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

RestApi is a more fitting name, because this thing is already evolving to be the standard REST API for notifications and much more ^^

**How did you solve this problem?**

Rename

**How did you make sure your solution works?**

Test

**Are there any special changes in the code that we should be aware of?**

No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
