### PR TITLE
Rest api block height exceeded

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,8 @@ All notable changes to this project are documented in this file.
 
 [0.5.4-dev] Work in progress
 ----------------------------
-- update to neo-boa==0.3.4
+- All requests to the API that are invalid will now receive a ``None`` for results rather than an empty list ``[]``
+- update to neo-boa==0.3.7
 - `api-server.py <https://github.com/CityOfZion/neo-python/blob/development/api-server.py>`_: Improved logging setup. See the options with ``./api-server.py -h``
 - Renamed ``neo.api.REST.NotificationRestApi`` to ``neo.api.REST.RestApi``
 

--- a/neo/api/REST/RestApi.py
+++ b/neo/api/REST/RestApi.py
@@ -123,7 +123,10 @@ class RestApi(object):
     def get_by_block(self, request, block):
         request.setHeader('Content-Type', 'application/json')
         try:
-            notifications = self.notif.get_by_block(block)
+            if int(block) > Blockchain.Default().Height:
+                return self.format_message("Higher than current block")
+            else:
+                notifications = self.notif.get_by_block(block)
         except Exception as e:
             logger.info("Could not get notifications for block %s %s" % (block, e))
             return self.format_message("Could not get notifications for block %s because %s " % (block, e))
@@ -205,7 +208,7 @@ class RestApi(object):
             'num_peers': len(NodeLeader.Instance().Peers)
         }, indent=4, sort_keys=True)
 
-    def format_notifications(self, request, notifications):
+    def format_notifications(self, request, notifications, show_none=False):
         notif_len = len(notifications)
         page_len = 500
         page = 0
@@ -228,7 +231,7 @@ class RestApi(object):
             'current_height': Blockchain.Default().Height,
             'message': message,
             'total': notif_len,
-            'results': [n.ToJson() for n in notifications],
+            'results': None if show_none else [n.ToJson() for n in notifications],
             'page': page,
             'page_len': page_len
         }, indent=4, sort_keys=True)
@@ -238,7 +241,7 @@ class RestApi(object):
             'current_height': Blockchain.Default().Height,
             'message': message,
             'total': 0,
-            'results': [],
+            'results': None,
             'page': 0,
             'page_len': 0
         }, indent=4, sort_keys=True)

--- a/neo/api/REST/test_rest_api.py
+++ b/neo/api/REST/test_rest_api.py
@@ -115,8 +115,8 @@ class NotificationDBTestCase(BlockchainFixtureTestCase):
         jsn = json.loads(res)
         self.assertEqual(jsn['total'], 0)
         results = jsn['results']
-        self.assertIsInstance(results, list)
-        self.assertIn('Could not get notifications', jsn['message'])
+        self.assertIsInstance(results, type(None))
+        self.assertIn('Higher than current block', jsn['message'])
 
     def test_7_by_addr(self):
         mock_req = requestMock(path=b'/addr/AL5e5ZcqtBTKjcQ8reiePrUBMYSD88v59a')
@@ -132,7 +132,7 @@ class NotificationDBTestCase(BlockchainFixtureTestCase):
         jsn = json.loads(res)
         self.assertEqual(jsn['total'], 0)
         results = jsn['results']
-        self.assertIsInstance(results, list)
+        self.assertIsInstance(results, type(None))
         self.assertIn('Could not get notifications', jsn['message'])
 
     def test_9_by_tx(self):
@@ -149,7 +149,7 @@ class NotificationDBTestCase(BlockchainFixtureTestCase):
         jsn = json.loads(res)
         self.assertEqual(jsn['total'], 0)
         results = jsn['results']
-        self.assertIsInstance(results, list)
+        self.assertIsInstance(results, type(None))
         self.assertIn('Could not get tx with hash', jsn['message'])
 
     def test_get_by_contract(self):
@@ -197,3 +197,13 @@ class NotificationDBTestCase(BlockchainFixtureTestCase):
         self.assertEqual(jsn['total'], 1027)
         results = jsn['results']
         self.assertEqual(len(results), 27)
+
+
+    def test_block_heigher_than_current(self):
+        mock_req = requestMock(path=b'/block/8000000')
+        res = self.app.get_by_block(mock_req, 800000)
+        jsn = json.loads(res)
+        self.assertEqual(jsn['total'], 0)
+        results = jsn['results']
+        self.assertIsInstance(results, type(None))
+        self.assertIn('Higher than current block', jsn['message'])

--- a/neo/api/REST/test_rest_api.py
+++ b/neo/api/REST/test_rest_api.py
@@ -198,7 +198,6 @@ class NotificationDBTestCase(BlockchainFixtureTestCase):
         results = jsn['results']
         self.assertEqual(len(results), 27)
 
-
     def test_block_heigher_than_current(self):
         mock_req = requestMock(path=b'/block/8000000')
         res = self.app.get_by_block(mock_req, 800000)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

When requesting a block higher than the current block, the API should return `None` for results rather than `[]`.

**How did you solve this problem?**
- code

**How did you make sure your solution works?**
- added tests

**Are there any special changes in the code that we should be aware of?**
- All requests to the API that are invalid will now receive a `None` for results rather than an empty list `[]`
**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
