### PR TITLE
Update makefile to phony 'test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build docs help test
+.PHONY: clean clean-test clean-pyc clean-build docs help test lint coverage
 .DEFAULT_GOAL := help
 define BROWSER_PYSCRIPT
 import os, webbrowser, sys

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean-test clean-pyc clean-build docs help
+.PHONY: clean clean-test clean-pyc clean-build docs help test
 .DEFAULT_GOAL := help
 define BROWSER_PYSCRIPT
 import os, webbrowser, sys


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
if a user has a file called `test` in the root directory, then `make test` will always claim its up to date and not run. (it happened to me because I had a wallet called `test`)

**How did you solve this problem?**
add 'test to the phony list

**How did you make sure your solution works?**
`make test` now works :)

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
Do we add such a minor change to the changelog? 