### PR TITLE
Fix missing URL in RestApi for address notifications (#305)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - Added VM instruction counter to ``ExecutionEngine.py`` error messages to indicate the final instruction that failed. Allows for setting conditional breakpoints to support SC debugging.
 - Renamed ``neo.api.REST.NotificationRestApi`` to ``neo.api.REST.RestApi``
 - Added ``-v/--verbose`` argument to prompt.py, which makes prompt.py show smart contract events by default
+- Fixed issue with missing ``addr`` location in ``neo/api/REST/RestApi.py``
 
 
 [0.5.3] 2018-03-04

--- a/neo/api/REST/RestApi.py
+++ b/neo/api/REST/RestApi.py
@@ -132,7 +132,7 @@ class RestApi(object):
             return self.format_message("Could not get notifications for block %s because %s " % (block, e))
         return self.format_notifications(request, notifications)
 
-    @app.route('%s/addr/<string:address>' % API_URL_PREFIX, methods=['GET'])
+    @app.route('%s/notifications/addr/<string:address>' % API_URL_PREFIX, methods=['GET'])
     @cors_header
     def get_by_addr(self, request, address):
         request.setHeader('Content-Type', 'application/json')


### PR DESCRIPTION
Closes CityOfZion/neo-python/#305

`/v1/notifications/addr/<addr>` is now responding.

Now in the right branch hopefully, apologies for the misunderstanding.