### PR TITLE
Privnet chain check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ All notable changes to this project are documented in this file.
 - Added VM instruction counter to ``ExecutionEngine.py`` error messages to indicate the final instruction that failed. Allows for setting conditional breakpoints to support SC debugging.
 - Renamed ``neo.api.REST.NotificationRestApi`` to ``neo.api.REST.RestApi``
 - Added ``-v/--verbose`` argument to prompt.py, which makes prompt.py show smart contract events by default
-- prompt.py: When using a privnet with ``-p``, check if chain database is correct.
+- prompt.py: When using a privnet with ``-p``, check if chain database is correct. Renamed ``Chains/Priv_Notif`` to ``Chains/privnet_notif`` (if you need your old privnet notification db, you need to rename it manually).
 
 
 [0.5.3] 2018-03-04

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - Added VM instruction counter to ``ExecutionEngine.py`` error messages to indicate the final instruction that failed. Allows for setting conditional breakpoints to support SC debugging.
 - Renamed ``neo.api.REST.NotificationRestApi`` to ``neo.api.REST.RestApi``
 - Added ``-v/--verbose`` argument to prompt.py, which makes prompt.py show smart contract events by default
+- prompt.py: When using a privnet with ``-p``, check if chain database is correct.
 
 
 [0.5.3] 2018-03-04

--- a/prompt.py
+++ b/prompt.py
@@ -960,7 +960,7 @@ def check_privatenet():
         if nonce_chain != nonce_container:
             raise PrivnetWrongChainDatabaseError(
                 "Chain database in Chains/privnet is for a different private network than the current container. "
-                "Consider deleting the Chain directory with 'rm -rf Chains/privnet."
+                "Consider deleting the Chain directory with 'rm -rf Chains/privnet*'."
             )
     else:
         with open(neopy_chain_meta_filename, "w") as f:

--- a/prompt.py
+++ b/prompt.py
@@ -943,11 +943,10 @@ class PromptInterface(object):
 
 def check_privatenet():
     """ Check if privatenet is running, and if container is same as the chain file """
-    host = "http://127.0.0.1:30333"
-    rpc_settings.setup([host])
+    rpc_settings.setup(settings.RPC_LIST)
     client = RPCClient()
     version = client.get_version()
-    # print("version", version)
+    print("Privatenet useragent '%s', nonce: %s" % (version["useragent"], version["nonce"]))
     if not version:
         logger.error("Error: private network doesn't seem to be running")
         return
@@ -959,7 +958,7 @@ def check_privatenet():
         nonce_chain = open(neopy_chain_meta_filename, "r").read()
         if nonce_chain != nonce_container:
             raise PrivnetWrongChainDatabaseError(
-                "Chain database in Chains/privnet is for a different private network than the current container. "
+                "Chain database in Chains/privnet is for a different private network than the current container (or RPC is not enabled). "
                 "Consider deleting the Chain directory with 'rm -rf Chains/privnet*'."
             )
     else:

--- a/protocol.privnet.json
+++ b/protocol.privnet.json
@@ -15,7 +15,7 @@
         "127.0.0.1:20336"
     ],
     "RPCList":[
-      "127.0.0.1:20332"
+      "http://127.0.0.1:30333"
     ],
     "SystemFee": {
         "EnrollmentTransaction": 1000,

--- a/protocol.privnet.json
+++ b/protocol.privnet.json
@@ -27,7 +27,7 @@
 
   "ApplicationConfiguration": {
     "DataDirectoryPath": "./Chains/privnet",
-    "NotificationDataPath": "Chains/Priv_Notif",
+    "NotificationDataPath": "Chains/privnet_notif",
     "RPCPort": 20332,
     "NodePort": 20333,
     "WsPort": 20334,

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ mmh3==2.5.1
 mock==2.0.0
 mpmath==1.0.0
 neo-boa==0.3.7
-neo-python-rpc==0.1.8
+neo-python-rpc==0.2.0
 neocore==0.3.6
 numpy==1.14.1
 pbr==3.1.1


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

In prompt.py, added a check if the privnet database is of the same privnet container. An old database is a common error case, without an error message and the only indicator a not increasing block count.

**How did you solve this problem?**

Code

**How did you make sure your solution works?**

Test

**Are there any special changes in the code that we should be aware of?**

No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
