### PR TITLE
Fix multi-signature contract usage and add NEO TestNet fund retrieval instructions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ All notable changes to this project are documented in this file.
 - Added VM instruction counter to ``ExecutionEngine.py`` error messages to indicate the final instruction that failed. Allows for setting conditional breakpoints to support SC debugging.
 - Renamed ``neo.api.REST.NotificationRestApi`` to ``neo.api.REST.RestApi``
 - Added ``-v/--verbose`` argument to prompt.py, which makes prompt.py show smart contract events by default
+- Fix multi-signature contract import to allow using a single signature
+- Fix fund sending from multi-signature contract
+- Added instructions on retrieving NEO TestNet funds
 
 
 [0.5.3] 2018-03-04

--- a/docs/source/prompt.rst
+++ b/docs/source/prompt.rst
@@ -290,4 +290,109 @@ You may want to observe or interact with ``NEP5`` Tokens with your wallet.  To d
 Smart Contracts in the prompt
 -----------------------------
 
-View a full description of interactinng with smart contracts in the prompt:  :ref:`Smart Contracts within the Prompt`
+View a full description of interacting with smart contracts in the prompt:  :ref:`Smart Contracts within the Prompt`
+
+----------------------------
+Retrieving NEO TestNet funds
+----------------------------
+
+This section explains how to obtain the TesNet funds requested via the official NEO `request form <https://neo.org/testnet>`_.
+
+Obtaining the funds requires 2 steps
+
+1. Adding a multi signature address to your wallet.
+2. Transfering the funds to your own address.
+
+Adding a multi signature address
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+For this we'll need 2 pieces of information
+
+1. The public key sent in the email you received from NEO.
+2. A public key from our own wallet. Have your wallet open and type ``wallet`` in the prompt to obtain the needed information.
+
+.. code-block:: sh
+
+    neo> wallet
+    Wallet {
+        ...
+        "public_keys": [
+            {
+                "Address": "ANFLgwKG8Eni9gJmKfM7yFXEaWwoGkSUid",
+                "Public Key": "037b8992e8384212f82e05c8836816c0f14dff9528397138731638b17d6357021e" <--- take this
+            }
+        ],
+        ...
+    }
+
+
+Next we create the multi signature address as follows.
+
+.. code-block:: sh
+
+    neo> import multisig_addr
+    please specify multisig contract like such: 'import multisig {pubkey in wallet} {minimum # of signatures required} {signing pubkey 1} {signing pubkey 2}...'
+
+    neo> import multisig_addr 037b8992e8384212f82e05c8836816c0f14dff9528397138731638b17d6357021e 1 037b8992e8384212f82e05c8836816c0f14dff9528397138731638b17d6357021e 02883118351f8f47107c83ab634dc7e4
+    ffe29d274e7d3dcf70159c8935ff769beb
+    [I 180310 16:49:19 UserWallet:191] contract does not exist yet
+    Added multi-sig contract address ALXEKioZntX73QawcnfcHUDvTVm8qXjAxf to wallet
+
+
+Inspect your wallet again and you should see your balance (specifically look at the ``synced_balances`` key). If you don't see the added balance then run ``wallet rebuild`` and wait until it's fully synced and try again.
+
+.. code-block:: sh
+
+    neo> wallet
+    Wallet {
+        "path": "test",
+        "addresses": [
+            {
+                "address": "ANFLgwKG8Eni9gJmKfM7yFXEaWwoGkSUid",
+                "script_hash": "47028f2a3d33466f29fba10e65c90fd8f3d01e1f",
+                "tokens": null
+            },
+            {
+                "version": 0,
+                "script_hash": "ALXEKioZntX73QawcnfcHUDvTVm8qXjAxf",
+                "frozen": false,
+                "votes": [],
+                "balances": {
+                    "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b": "50.0",
+                    "0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7": "50.0"
+                },
+                "is_watch_only": false
+            }
+        ],
+        ...
+        "synced_balances": [
+            "[NEO]: 50.0 ",
+            "[NEOGas]: 50.0 "
+        ],
+        "public_keys": [
+            {
+                "Address": "ANFLgwKG8Eni9gJmKfM7yFXEaWwoGkSUid",
+                "Public Key": "037b8992e8384212f82e05c8836816c0f14dff9528397138731638b17d6357021e"
+            },
+            {
+                "Address": "ALXEKioZntX73QawcnfcHUDvTVm8qXjAxf",
+                "Public Key": "037b8992e8384212f82e05c8836816c0f14dff9528397138731638b17d6357021e"
+            }
+        ],
+        ...
+    }
+
+
+Transfering the funds to your own address.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Now that we can access the funds we can send them to our own address as follows
+
+.. code-block:: sh
+
+    neo> send NEO ANFLgwKG8Eni9gJmKfM7yFXEaWwoGkSUid 5 --from-addr=ALXEKioZntX73QawcnfcHUDvTVm8qXjAxf
+    [Password]> **********
+    [I 180310 17:02:42 Transaction:611] Verifying transaction: b'c32b0e3d9adbef6720abfad5106dcd2dacb17b31d4f9d32cbcf8ed6e7f566ef3'
+    Relayed Tx: c32b0e3d9adbef6720abfad5106dcd2dacb17b31d4f9d32cbcf8ed6e7f566ef3
+
+
+Note that the ``--from-addr`` parameter specifies our multi signature contract address to take the funds from.

--- a/neo/Prompt/Commands/LoadSmartContract.py
+++ b/neo/Prompt/Commands/LoadSmartContract.py
@@ -12,7 +12,6 @@ from neo.SmartContract.Contract import Contract
 
 
 def ImportContractAddr(wallet, args):
-
     if wallet is None:
         print("please open a wallet")
         return
@@ -56,7 +55,6 @@ def ImportContractAddr(wallet, args):
 
 
 def LoadContract(args):
-
     if len(args) < 5:
         print("please specify contract to load like such: 'import contract {path} {params} {return_type} {needs_storage} {needs_dynamic_invoke}'")
         return
@@ -117,7 +115,6 @@ def LoadContract(args):
 
 
 def GatherLoadedContractParams(args, script):
-
     if len(args) < 4:
         raise Exception("please specify contract properties like {params} {return_type} {needs_storage} {needs_dynamic_invoke}")
     params = parse_param(args[0], ignore_int=True, prefer_hex=False)
@@ -147,7 +144,6 @@ def GatherLoadedContractParams(args, script):
 
 
 def GatherContractDetails(function_code, prompter):
-
     name = None
     version = None
     author = None
@@ -226,9 +222,8 @@ def generate_deploy_script(script, name='test', version='test', author='test', e
 
 
 def ImportMultiSigContractAddr(wallet, args):
-
     if len(args) < 4:
-        print("please specify multisig contract like such: 'import multisig {pubkey in wallet} {minimum # of signatures required} {signing pubkey 1} {signing pubkey 2}...'")
+        print("please specify multisig contract like such: 'import multisig_addr {pubkey in wallet} {minimum # of signatures required} {signing pubkey 1} {signing pubkey 2}...'")
         return
 
     if wallet is None:
@@ -240,7 +235,6 @@ def ImportMultiSigContractAddr(wallet, args):
     publicKeys = args[2:]
 
     if publicKeys[1]:
-
         pubkey_script_hash = Crypto.ToScriptHash(pubkey, unhex=True)
 
         verification_contract = Contract.CreateMultiSigContract(pubkey_script_hash, int(m), publicKeys)

--- a/neo/SmartContract/Contract.py
+++ b/neo/SmartContract/Contract.py
@@ -91,8 +91,8 @@ class Contract(SerializableMixin, VerificationCode):
     @staticmethod
     def CreateMultiSigRedeemScript(m, publicKeys):
 
-        if m < 2 or m > len(publicKeys) or len(publicKeys) > 1024:
-            raise Exception('Invalid keys')
+        if m < 1 or m > len(publicKeys) or len(publicKeys) > 1024:
+            raise Exception('Argument Exception')
 
         sb = ScriptBuilder()
         sb.push(m)
@@ -114,7 +114,7 @@ class Contract(SerializableMixin, VerificationCode):
 
         pk = [ECDSA.decode_secp256r1(p).G for p in publicKeys]
         return Contract(Contract.CreateMultiSigRedeemScript(m, pk),
-                        bytearray(b'\x00\x00\x00'),
+                        bytearray(m),
                         publicKeyHash)
 
     @staticmethod

--- a/prompt.py
+++ b/prompt.py
@@ -84,6 +84,7 @@ class PromptInterface(object):
                 'import nep2 {nep2_encrypted_key}',
                 'import contract {path/to/file.avm} {params} {returntype} {needs_storage} {needs_dynamic_invoke}',
                 'import contract_addr {contract_hash} {pubkey}',
+                'import multisig_addr {pubkey in wallet} {minimum # of signatures required} {signing pubkey 1} {signing pubkey 2}...',
                 'import watch_addr {address}',
                 'import token {token_contract_hash}',
                 'export wif {address}',


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
It was unclear how to retrieve NEO TestNet funds using NEO Python as that required a multi-signature contract for which no visible support was present on the prompt. I exposed the `import multisig_addr` command and fixed the `Contract` implementation such that its functional.

**How did you solve this problem?**
write docs & fix code

**How did you make sure your solution works?**
retrieved my testnet funds and send them to my own wallet address. NEOSCAN confirms it's successful

**Are there any special changes in the code that we should be aware of?**
nah

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
