### PR TITLE
Optionally specifiy custom host with `-p`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,6 @@ All notable changes to this project are documented in this file.
 - Fixed issue with missing ``notifications/`` prefix for ``addr`` call in ``neo/api/REST/RestApi.py``
 - prompt.py: When using a privnet with ``-p``, check if chain database is correct. Renamed ``Chains/Priv_Notif`` to ``Chains/privnet_notif`` (if you need your old privnet notification db, you need to rename it manually).
 - Optionally allow to use custom privnet hosts with ``-p`` (`PR #312 <https://github.com/CityOfZion/neo-python/pull/312>`_)
-- Added ``neo-privnet.wallet`` to the project root. This is the standard wallet for `private networks <https://hub.docker.com/r/cityofzion/neo-privatenet/>`_.
 
 
 [0.5.3] 2018-03-04

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ All notable changes to this project are documented in this file.
 - Fixed issue with missing ``notifications/`` prefix for ``addr`` call in ``neo/api/REST/RestApi.py``
 - prompt.py: When using a privnet with ``-p``, check if chain database is correct. Renamed ``Chains/Priv_Notif`` to ``Chains/privnet_notif`` (if you need your old privnet notification db, you need to rename it manually).
 - Optionally allow to use custom privnet hosts with ``-p`` (`PR #312 <https://github.com/CityOfZion/neo-python/pull/312>`_)
+- Added ``neo-privnet.wallet`` to the project root. This is the standard wallet for `private networks <https://hub.docker.com/r/cityofzion/neo-privatenet/>`_.
 
 
 [0.5.3] 2018-03-04

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,8 +15,9 @@ All notable changes to this project are documented in this file.
 - Fix multi-signature contract import to allow using a single signature
 - Fix fund sending from multi-signature contract
 - Added instructions on retrieving NEO TestNet funds
+- Fixed issue with missing ``notifications/`` prefix for ``addr`` call in ``neo/api/REST/RestApi.py``
 - prompt.py: When using a privnet with ``-p``, check if chain database is correct. Renamed ``Chains/Priv_Notif`` to ``Chains/privnet_notif`` (if you need your old privnet notification db, you need to rename it manually).
-- Fixed issue with missing ``addr`` location in ``neo/api/REST/RestApi.py``
+- Optionally allow to use custom privnet hosts with ``-p`` (`PR #312 <https://github.com/CityOfZion/neo-python/pull/312>`_)
 
 
 [0.5.3] 2018-03-04

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -160,9 +160,9 @@ class SettingsHolder:
             if ":" in host:
                 raise Exception("No protocol prefix or port allowed in host, use just the IP or domain.")
             print("Using custom privatenet host:", host)
-            self.SEED_LIST = [entry.replace("127.0.0.1", host) for entry in self.SEED_LIST]
-            self.RPC_LIST = [entry.replace("127.0.0.1", host) for entry in self.RPC_LIST]
-            print("- Seeds:", ", ".join(self.SEED_LIST))
+            self.SEED_LIST = ["%s:20333" % host]
+            self.RPC_LIST = ["http://%s:30333" % host]
+            print("- P2P:", ", ".join(self.SEED_LIST))
             print("- RPC:", ", ".join(self.RPC_LIST))
 
     def setup_coznet(self):

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -147,9 +147,23 @@ class SettingsHolder:
         """ Load settings from the testnet JSON config file """
         self.setup(FILENAME_SETTINGS_TESTNET)
 
-    def setup_privnet(self):
-        """ Load settings from the privnet JSON config file """
+    def setup_privnet(self, host=None):
+        """
+        Load settings from the privnet JSON config file
+
+        Args:
+            host (string): can be either an IP which will be used for seeds with standard ports and RPC
+                           or in the format of `IP:port`, which will be used as the only seed
+        """
         self.setup(FILENAME_SETTINGS_PRIVNET)
+        if isinstance(host, str):
+            if ":" in host:
+                raise Exception("No protocol prefix or port allowed in host, use just the IP or domain.")
+            print("Using custom privatenet host:", host)
+            self.SEED_LIST = [entry.replace("127.0.0.1", host) for entry in self.SEED_LIST]
+            self.RPC_LIST = [entry.replace("127.0.0.1", host) for entry in self.RPC_LIST]
+            print("- Seeds:", ", ".join(self.SEED_LIST))
+            print("- RPC:", ", ".join(self.RPC_LIST))
 
     def setup_coznet(self):
         """ Load settings from the coznet JSON config file """

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -153,7 +153,7 @@ class SettingsHolder:
 
         Args:
             host (string, optional): if supplied, uses this IP or domain as neo nodes. The host must
-                                     use the standard ports (P2P 20333-20336, RPC 30333).
+                                     use these standard ports: P2P 20333, RPC 30333.
         """
         self.setup(FILENAME_SETTINGS_PRIVNET)
         if isinstance(host, str):

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -152,8 +152,8 @@ class SettingsHolder:
         Load settings from the privnet JSON config file
 
         Args:
-            host (string): can be either an IP which will be used for seeds with standard ports and RPC
-                           or in the format of `IP:port`, which will be used as the only seed
+            host (string, optional): if supplied, uses this IP or domain as neo nodes. The host must
+                                     use the standard ports (P2P 20333-20336, RPC 30333).
         """
         self.setup(FILENAME_SETTINGS_PRIVNET)
         if isinstance(host, str):

--- a/prompt.py
+++ b/prompt.py
@@ -975,7 +975,7 @@ def main():
     group.add_argument("-m", "--mainnet", action="store_true", default=False,
                        help="Use MainNet instead of the default TestNet")
     group.add_argument("-p", "--privnet", nargs="?", metavar="host", const=True, default=False,
-                       help="Use a private net instead of the default TestNet, optionally using a custom host (default: localhost)")
+                       help="Use a private net instead of the default TestNet, optionally using a custom host (default: 127.0.0.1)")
     group.add_argument("--coznet", action="store_true", default=False,
                        help="Use the CoZ network instead of the default TestNet")
     group.add_argument("-c", "--config", action="store", help="Use a specific config file")

--- a/prompt.py
+++ b/prompt.py
@@ -974,8 +974,8 @@ def main():
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-m", "--mainnet", action="store_true", default=False,
                        help="Use MainNet instead of the default TestNet")
-    group.add_argument("-p", "--privnet", action="store_true", default=False,
-                       help="Use PrivNet instead of the default TestNet")
+    group.add_argument("-p", "--privnet", nargs="?", metavar="host", const=True, default=False,
+                       help="Use a private net instead of the default TestNet, optionally using a custom host (default: localhost)")
     group.add_argument("--coznet", action="store_true", default=False,
                        help="Use the CoZ network instead of the default TestNet")
     group.add_argument("-c", "--config", action="store", help="Use a specific config file")
@@ -1001,7 +1001,7 @@ def main():
     elif args.mainnet:
         settings.setup_mainnet()
     elif args.privnet:
-        settings.setup_privnet()
+        settings.setup_privnet(args.privnet)
     elif args.coznet:
         settings.setup_coznet()
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

This PR allows `prompt.py` users to specify custom hosts with the `-p` privatenet argument. Useful for instance for events such as hackathons, where people want to connect to the privnet running on a shared server somewhere.

Help output:

    $ python prompt.py -h
    usage: prompt.py [-h] [-m | -p [host] | --coznet | -c CONFIG]
                    [-t {dark,light}] [-v] [--version]

    optional arguments:
    -h, --help            show this help message and exit
    -m, --mainnet         Use MainNet instead of the default TestNet
    -p [host], --privnet [host]
                            Use a private net instead of the default TestNet,
                            optionally using a custom host (default: 127.0.0.1)
    --coznet              Use the CoZ network instead of the default TestNet
    -c CONFIG, --config CONFIG
                            Use a specific config file
    -t {dark,light}, --set-default-theme {dark,light}
                            Set the default theme to be loaded from the config
                            file. Default: 'dark'
    -v, --verbose         Show smart-contract events by default
    --version             show program's version number and exit

Normal privatenet behavior (as before):

    $ python prompt.py -p

With a custom host:

    $ python prompt.py -p example.com
    Using custom privatenet host: example.com
    - Seeds: example.com:20333, example.com:20334, example.com:20335, example.com:20336
    - RPC: http://example.com:30333

With an invalid host:

    $ python prompt.py -p http://example.com
    Traceback (most recent call last):
    File "prompt.py", line 1048, in <module>
        main()
    File "prompt.py", line 1004, in main
        settings.setup_privnet(args.privnet)
    File "/Users/chris/Projects/chris/neo/neo-python/neo/Settings.py", line 161, in setup_privnet
        raise Exception("No protocol prefix or port allowed in host, use just the IP or domain.")
    Exception: No protocol prefix or port allowed in host, use just the IP or domain.
    
**How did you solve this problem?**

Added nargs to argparse line in prompt, and added a `host` argument in `Settings.setup_privnet`

**How did you make sure your solution works?**

Manual tests

**Are there any special changes in the code that we should be aware of?**

No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
