### PR TITLE
pypi PR minor fixes in Settings and prompt: use proper paths rather than `os.getcwd()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 
 # command to install dependencies
 install:
-  - pip install -r requirements.txt
+  - pip install -e .
   - pip install coveralls
 
 # command to run tests

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -27,12 +27,8 @@ dir_current = os.path.dirname(os.path.abspath(__file__))
 # ROOT_INSTALL_PATH is the root path of neo-python, whether installed as package or from git.
 ROOT_INSTALL_PATH = os.path.abspath(os.path.join(dir_current, ".."))
 
-# PATH_USER_DATA_ROOT is the root path where to store data (Chain databases, history, etc.)
-PATH_USER_DATA_ROOT = os.path.join(os.path.expanduser('~'), ".neopython")
-if os.name == 'nt':
-    from win32com.shell import shellcon, shell
-    path_appdata = shell.SHGetFolderPath(0, shellcon.CSIDL_APPDATA, 0, 0)
-    PATH_USER_DATA_ROOT = os.path.join(path_appdata, ".neopython")
+# PATH_USER_DATA is the root path where to store data (Chain databases, history, etc.)
+PATH_USER_DATA = os.path.join(os.path.expanduser('~'), ".neopython")  # Works for both Windows and *nix
 
 # This detects if we are running from an 'editable' version (like ``python neo/bin/prompt.py``)
 # or from a packaged install version from pip
@@ -87,7 +83,7 @@ class SettingsHolder:
     PUBLISH_TX_FEE = None
     REGISTER_TX_FEE = None
 
-    DATA_DIR_PATH = PATH_USER_DATA_ROOT
+    DATA_DIR_PATH = PATH_USER_DATA
     LEVELDB_PATH = None
     NOTIFICATION_DB_PATH = None
 

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -24,17 +24,19 @@ import sys
 
 dir_current = os.path.dirname(os.path.abspath(__file__))
 
-IS_PACKAGE_INSTALL = False
-ROOT_INSTALL_PATH = None
+# ROOT_INSTALL_PATH is the root path of neo-python, whether installed as package or from git.
+ROOT_INSTALL_PATH = os.path.abspath(os.path.join(dir_current, ".."))
 
-# This detects if we are running from
-# an 'editable' version ( like ``python neo/bin/prompt.py`` )
+# PATH_USER_DATA_ROOT is the root path where to store data (Chain databases, history, etc.)
+PATH_USER_DATA_ROOT = os.path.join(os.path.expanduser('~'), ".neopython")
+if os.name == 'nt':
+    from win32com.shell import shellcon, shell
+    path_appdata = shell.SHGetFolderPath(0, shellcon.CSIDL_APPDATA, 0, 0)
+    PATH_USER_DATA_ROOT = os.path.join(path_appdata, ".neopython")
+
+# This detects if we are running from an 'editable' version (like ``python neo/bin/prompt.py``)
 # or from a packaged install version from pip
-if 'site-packages/neo' in dir_current:
-    ROOT_INSTALL_PATH = os.path.abspath(os.path.join(dir_current, ".."))
-    IS_PACKAGE_INSTALL = True
-else:
-    ROOT_INSTALL_PATH = os.getcwd()
+IS_PACKAGE_INSTALL = 'site-packages/neo' in dir_current
 
 # The filenames for various files. Might be improved by using system
 # user directories: https://github.com/ActiveState/appdirs
@@ -85,7 +87,7 @@ class SettingsHolder:
     PUBLISH_TX_FEE = None
     REGISTER_TX_FEE = None
 
-    DATA_DIR_PATH = '%s/.neopython' % os.path.expanduser('~')
+    DATA_DIR_PATH = PATH_USER_DATA_ROOT
     LEVELDB_PATH = None
     NOTIFICATION_DB_PATH = None
 

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -30,6 +30,10 @@ ROOT_INSTALL_PATH = os.path.abspath(os.path.join(dir_current, ".."))
 # PATH_USER_DATA is the root path where to store data (Chain databases, history, etc.)
 PATH_USER_DATA = os.path.join(os.path.expanduser('~'), ".neopython")  # Works for both Windows and *nix
 
+# Make sure the data path exists
+if not os.path.isdir(PATH_USER_DATA):
+    os.mkdir(PATH_USER_DATA)
+
 # This detects if we are running from an 'editable' version (like ``python neo/bin/prompt.py``)
 # or from a packaged install version from pip
 IS_PACKAGE_INSTALL = 'site-packages/neo' in dir_current

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -17,10 +17,6 @@ from prompt_toolkit.styles import style_from_dict
 from prompt_toolkit.token import Token
 from twisted.internet import reactor, task
 
-
-if os.path.exists(os.path.join(os.getcwd(), 'neo')):
-    sys.path.insert(0, os.getcwd())
-
 from neo import __version__
 from neo.Core.Blockchain import Blockchain
 from neocore.Fixed8 import Fixed8
@@ -44,19 +40,19 @@ from neo.Prompt.Commands.Wallet import DeleteAddress, ImportWatchAddr, ImportTok
     ShowUnspentCoins
 from neo.Prompt.Utils import get_arg
 from neo.Prompt.InputParser import InputParser
-from neo.Settings import settings, PrivnetConnectionError
+from neo.Settings import settings, PrivnetConnectionError, PATH_USER_DATA_ROOT
 from neo.UserPreferences import preferences
 from neocore.KeyPair import KeyPair
 from neocore.UInt256 import UInt256
 
 # Logfile settings & setup
-LOGFILE_FN = os.path.join(os.getcwd(), 'prompt.log')
+LOGFILE_FN = os.path.join(PATH_USER_DATA_ROOT, 'prompt.log')
 LOGFILE_MAX_BYTES = 5e7  # 50 MB
 LOGFILE_BACKUP_COUNT = 3  # 3 logfiles history
 settings.set_logfile(LOGFILE_FN, LOGFILE_MAX_BYTES, LOGFILE_BACKUP_COUNT)
 
 # Prompt history filename
-FILENAME_PROMPT_HISTORY = os.path.join(os.getcwd(), '.prompt.py.history')
+FILENAME_PROMPT_HISTORY = os.path.join(PATH_USER_DATA_ROOT, '.prompt.py.history')
 
 
 class PromptInterface(object):

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -40,19 +40,19 @@ from neo.Prompt.Commands.Wallet import DeleteAddress, ImportWatchAddr, ImportTok
     ShowUnspentCoins
 from neo.Prompt.Utils import get_arg
 from neo.Prompt.InputParser import InputParser
-from neo.Settings import settings, PrivnetConnectionError, PATH_USER_DATA_ROOT
+from neo.Settings import settings, PrivnetConnectionError, PATH_USER_DATA
 from neo.UserPreferences import preferences
 from neocore.KeyPair import KeyPair
 from neocore.UInt256 import UInt256
 
 # Logfile settings & setup
-LOGFILE_FN = os.path.join(PATH_USER_DATA_ROOT, 'prompt.log')
+LOGFILE_FN = os.path.join(PATH_USER_DATA, 'prompt.log')
 LOGFILE_MAX_BYTES = 5e7  # 50 MB
 LOGFILE_BACKUP_COUNT = 3  # 3 logfiles history
 settings.set_logfile(LOGFILE_FN, LOGFILE_MAX_BYTES, LOGFILE_BACKUP_COUNT)
 
 # Prompt history filename
-FILENAME_PROMPT_HISTORY = os.path.join(PATH_USER_DATA_ROOT, '.prompt.py.history')
+FILENAME_PROMPT_HISTORY = os.path.join(PATH_USER_DATA, '.prompt.py.history')
 
 
 class PromptInterface(object):


### PR DESCRIPTION
Replaced `os.getcwd()` with proper paths, because using the current working directory can lead to various unwanted edge-cases (like creating a prompt-history file in whatever directory the user currently is in).

Also cleaned up settings paths a little bit.

This is a PR to the other open PR #321.