### PR TITLE
Invoke from address selection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.6.2-dev] in progress
 -----------------------
-- ...
+- Added support for using ``--from-addr=`` to specify the address to use for ``testinvoke`` in ``prompt.py``. (`PR #329 <https://github.com/CityOfZion/neo-python/pull/329>`_)
 
 
 [0.6.1] 2018-03-16

--- a/neo/Prompt/Commands/BuildNRun.py
+++ b/neo/Prompt/Commands/BuildNRun.py
@@ -1,4 +1,4 @@
-from neo.Prompt.Utils import get_arg
+from neo.Prompt.Utils import get_arg, get_from_addr
 from neo.Prompt.Commands.LoadSmartContract import GatherLoadedContractParams, generate_deploy_script
 from neo.SmartContract.ContractParameterType import ContractParameterType
 from neo.SmartContract.ContractParameter import ContractParameter
@@ -12,6 +12,8 @@ from neo.Core.State.ContractState import ContractPropertyState
 
 
 def LoadAndRun(arguments, wallet):
+
+    arguments, from_addr = get_from_addr(arguments)
 
     path = get_arg(arguments)
 
@@ -29,13 +31,14 @@ def LoadAndRun(arguments, wallet):
             script = content
 
             print("arguments.... %s " % arguments)
-            DoRun(script, arguments, wallet, path)
+            DoRun(script, arguments, wallet, path, from_addr=from_addr)
 
     except Exception as e:
         print("Could not load script %s " % e)
 
 
 def BuildAndRun(arguments, wallet, verbose=True, min_fee=DEFAULT_MIN_FEE):
+    arguments, from_addr = get_from_addr(arguments)
     path = get_arg(arguments)
 
     contract_script = Compiler.instance().load_and_save(path)
@@ -43,10 +46,10 @@ def BuildAndRun(arguments, wallet, verbose=True, min_fee=DEFAULT_MIN_FEE):
     newpath = path.replace('.py', '.avm')
     print("Saved output to %s " % newpath)
 
-    return DoRun(contract_script, arguments, wallet, path, verbose, min_fee=min_fee)
+    return DoRun(contract_script, arguments, wallet, path, verbose, from_addr, min_fee)
 
 
-def DoRun(contract_script, arguments, wallet, path, verbose=True, min_fee=DEFAULT_MIN_FEE):
+def DoRun(contract_script, arguments, wallet, path, verbose=True, from_addr=None, min_fee=DEFAULT_MIN_FEE):
 
     test = get_arg(arguments, 1)
 
@@ -59,7 +62,7 @@ def DoRun(contract_script, arguments, wallet, path, verbose=True, min_fee=DEFAUL
 
             script = GatherLoadedContractParams(f_args, contract_script)
 
-            tx, result, total_ops, engine = test_deploy_and_invoke(script, i_args, wallet, min_fee)
+            tx, result, total_ops, engine = test_deploy_and_invoke(script, i_args, wallet, from_addr, min_fee)
             i_args.reverse()
 
             return_type_results = []

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -39,9 +39,9 @@ import json
 DEFAULT_MIN_FEE = Fixed8.FromDecimal(.0001)
 
 
-def InvokeContract(wallet, tx, fee=Fixed8.Zero()):
+def InvokeContract(wallet, tx, fee=Fixed8.Zero(), from_addr=None):
 
-    wallet_tx = wallet.MakeTransaction(tx=tx, fee=fee, use_standard=True)
+    wallet_tx = wallet.MakeTransaction(tx=tx, fee=fee, use_standard=True, from_addr=from_addr)
 
 #    pdb.set_trace()
 
@@ -204,7 +204,7 @@ def TestInvokeContract(wallet, args, withdrawal_tx=None, parse_params=True, from
 
             outputs.append(output)
 
-        return test_invoke(out, wallet, outputs, withdrawal_tx, min_fee=min_fee)
+        return test_invoke(out, wallet, outputs, withdrawal_tx, from_addr, min_fee)
 
     else:
 
@@ -319,7 +319,7 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None, from_addr=None, min
     return None, None, None, None
 
 
-def test_deploy_and_invoke(deploy_script, invoke_args, wallet, min_fee=DEFAULT_MIN_FEE):
+def test_deploy_and_invoke(deploy_script, invoke_args, wallet, from_addr=None, min_fee=DEFAULT_MIN_FEE):
 
     bc = GetBlockchain()
 
@@ -344,7 +344,7 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet, min_fee=DEFAULT_M
     dtx.scripts = []
     dtx.Script = binascii.unhexlify(deploy_script)
 
-    dtx = wallet.MakeTransaction(tx=dtx)
+    dtx = wallet.MakeTransaction(tx=dtx, from_addr=from_addr)
     context = ContractParametersContext(dtx)
     wallet.Sign(context)
     dtx.scripts = context.GetScripts()
@@ -445,7 +445,7 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet, min_fee=DEFAULT_M
             itx.Attributes = [TransactionAttribute(usage=TransactionAttributeUsage.Script,
                                                    data=Crypto.ToScriptHash(contract.Script, unhex=False).Data)]
 
-        itx = wallet.MakeTransaction(tx=itx)
+        itx = wallet.MakeTransaction(tx=itx, from_addr=from_addr)
         context = ContractParametersContext(itx)
         wallet.Sign(context)
         itx.scripts = context.GetScripts()

--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -1,5 +1,5 @@
 from neo.Prompt.Commands.Invoke import InvokeContract, InvokeWithTokenVerificationScript
-from neo.Prompt.Utils import get_asset_id, get_asset_attachments
+from neo.Prompt.Utils import get_asset_id, get_from_addr
 from neocore.Fixed8 import Fixed8
 from prompt_toolkit import prompt
 from decimal import Decimal
@@ -156,6 +156,8 @@ def token_mint(wallet, args, prompt_passwd=True):
 def token_crowdsale_register(wallet, args, prompt_passwd=True):
     token = get_asset_id(wallet, args[0])
 
+    args, from_addr = get_from_addr(args)
+
     if len(args) < 2:
         raise Exception("Specify addr to register for crowdsale")
     register_addr = args[1:]
@@ -175,7 +177,7 @@ def token_crowdsale_register(wallet, args, prompt_passwd=True):
                 print("incorrect password")
                 return
 
-        return InvokeContract(wallet, tx, fee)
+        return InvokeContract(wallet, tx, fee, from_addr)
 
     else:
         print("Could not register addresses: %s " % str(results[0]))

--- a/neo/SmartContract/tests/test_gas_costs.py
+++ b/neo/SmartContract/tests/test_gas_costs.py
@@ -44,7 +44,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
 
         wallet = self.GetWallet1()
 
-        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", True, False, "put", "key1", "b'ab'"]
+        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", "True", "False", "put", "key1", "b'ab'", "--from-addr=" + self.wallet_1_addr]
 
         tx, result, total_ops, engine = BuildAndRun(arguments, wallet, False, min_fee=Fixed8.FromDecimal(.0004))
 
@@ -64,7 +64,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
 
         wallet = self.GetWallet1()
 
-        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", True, False, "put_5", "key1", "b'abababababab'"]
+        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", "True", "False", "put_5", "key1", "b'abababababab'"]
 
         tx, result, total_ops, engine = BuildAndRun(arguments, wallet, False)
 
@@ -84,7 +84,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
         """
         wallet = self.GetWallet1()
 
-        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", True, False, "put_and_get", "key1", "b'abababababab'"]
+        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", "True", "False", "put_and_get", "key1", "b'abababababab'"]
 
         tx, result, total_ops, engine = BuildAndRun(arguments, wallet, False)
 
@@ -104,7 +104,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
         """
         wallet = self.GetWallet1()
 
-        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", True, False, "put_and_get", "key1", self.big_str]
+        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", "True", "False", "put_and_get", "key1", self.big_str]
 
         tx, result, total_ops, engine = BuildAndRun(arguments, wallet, False)
 
@@ -132,7 +132,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
         """
         wallet = self.GetWallet1()
 
-        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", True, False, "put_5", "key1", self.big_str]
+        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", "True", "False", "put_5", "key1", self.big_str]
 
         tx, result, total_ops, engine = BuildAndRun(arguments, wallet, False)
 
@@ -149,7 +149,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
         """
         wallet = self.GetWallet1()
 
-        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", True, False, "put_9", "key1", "b'ababababab'"]
+        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", "True", "False", "put_9", "key1", "b'ababababab'"]
 
         tx, result, total_ops, engine = BuildAndRun(arguments, wallet, False)
 

--- a/neo/Wallets/NEP5Token.py
+++ b/neo/Wallets/NEP5Token.py
@@ -268,7 +268,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
 
         return tx, fee, results
 
-    def CrowdsaleRegister(self, wallet, register_addresses):
+    def CrowdsaleRegister(self, wallet, register_addresses, from_addr=None):
         """
         Register for a crowd sale.
 
@@ -285,7 +285,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
         invoke_args = [self.ScriptHash.ToString(), 'crowdsale_register',
                        [parse_param(p, wallet) for p in register_addresses]]
 
-        tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True)
+        tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True, from_addr)
 
         return tx, fee, results
 

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -104,7 +104,7 @@ class PromptInterface(object):
                 'wallet tkn_approve {token symbol} {address_from} {address to} {amount}',
                 'wallet tkn_allowance {token symbol} {address_from} {address to}',
                 'wallet tkn_mint {token symbol} {mint_to_addr} (--attach-neo={amount}, --attach-gas={amount})',
-                'wallet tkn_register {addr} ({addr}...)',
+                'wallet tkn_register {addr} ({addr}...) (--from-addr={addr})',
                 'wallet unspent',
                 'wallet close',
                 'withdraw_request {asset_name} {contract_hash} {to_addr} {amount}',
@@ -116,7 +116,7 @@ class PromptInterface(object):
                 'withdraw all # withdraw all holds available',
                 'send {assetId or name} {address} {amount} (--from-addr={addr})',
                 'sign {transaction in JSON format}',
-                'testinvoke {contract hash} {params} (--attach-neo={amount}, --attach-gas={amount})',
+                'testinvoke {contract hash} {params} (--attach-neo={amount}, --attach-gas={amount}) (--from-addr={addr})',
                 'debugstorage {on/off/reset}'
                 ]
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

#322

**How did you solve this problem?**

Added support for `--from-addr=` parameters for the various invoke methods in both `prompt.py` and other relevant commands.

**How did you make sure your solution works?**

Tested it. Updated a test to use it.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
