### PR TITLE
Fix to redact WIF keys, nep2 keys and contract metadata from the command history file (fixes #301)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.6.2-dev] in progress
 -----------------------
-- ...
+- Fixed ``prompt.py`` to redact WIF keys, nep2 keys and contract metadata from ``.prompt.py.history``
 
 
 [0.6.1] 2018-03-16

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -283,6 +283,7 @@ class PromptInterface(object):
             return
 
         if item == 'wif':
+            self.redact_commands('import wif')
             if not self.Wallet:
                 print("Please open a wallet before importing WIF")
                 return
@@ -306,6 +307,9 @@ class PromptInterface(object):
             return
 
         elif item == 'nep2':
+
+            self.redact_commands('import nep2')
+
             if not self.Wallet:
                 print("Please open a wallet before importing a NEP2 key")
                 return
@@ -358,6 +362,9 @@ class PromptInterface(object):
         item = get_arg(arguments)
 
         if item == 'wif':
+
+            self.redact_commands('export wif')
+
             if not self.Wallet:
                 return print("Please open a wallet")
 
@@ -377,6 +384,9 @@ class PromptInterface(object):
             return
 
         elif item == 'nep2':
+
+            self.redact_commands('export nep2')
+
             if not self.Wallet:
                 return print("Please open a wallet")
 
@@ -756,6 +766,8 @@ class PromptInterface(object):
                         "-------------------------------------------------------------------------------------------------------------------------------------\n")
                     print("Enter your password to continue and deploy this contract")
 
+                    self.redact_commands('contract')
+
                     passwd = prompt("[password]> ", is_password=True)
                     if not self.Wallet.ValidatePassword(passwd):
                         return print("Incorrect password")
@@ -848,6 +860,39 @@ class PromptInterface(object):
 
         else:
             print("Cannot configure %s try 'config sc-events on|off', 'config debug on|off', 'config sc-debug-notify on|off' or 'config vm-log on|off'" % what)
+
+    def redact_commands(self, command):
+
+        if command in ['import wif', 'export wif', 'export wif', 'export nep2']:
+            history_file = open(FILENAME_PROMPT_HISTORY)
+            history_lines = history_file.readlines()
+            history_file.close()
+
+            w = open(FILENAME_PROMPT_HISTORY, "w")
+
+            for line in history_lines:
+                if ("+" + command) in line and len("+" + command + " ") < len(line):
+                    w.writelines("+" + command + " <" + command.split(" ")[1] + ">\n")
+                else:
+                    w.writelines(line)
+            w.close()
+
+        elif command == 'contract':
+            history_file = open(FILENAME_PROMPT_HISTORY)
+            history_lines = history_file.readlines()
+            history_file.close()
+
+            w = open(FILENAME_PROMPT_HISTORY, "w")
+            index = -1
+            for i in range(len(history_lines) - 1, 0, -1):
+                if 'contract' in history_lines[i]:
+                    index = i
+                    break
+
+            for i in range(index + 1):
+                w.writelines(history_lines[i])
+
+            w.close()
 
     def run(self):
         dbloop = task.LoopingCall(Blockchain.Default().PersistBlocks)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Fixes #301 

**How did you solve this problem?**
By changing the content of ``.prompt.py.history`` file after a particular command among `import wif {wif}`, `export wif {wif}`, `import nep2 {nep2}`, ``export nep2 {nep2}`` are executed. The WIF keys and the nep2 keys are replaced with `<wif>` and `<nep2>` respectively. Metadata (name, description) generated by the command `import contract {path/to/file.avm} {params} {returntype} {needs_storage} {needs_dynamic_invoke}` is also purged from the `.prompt.py.history` file.
 
**How did you make sure your solution works?**
I tried running the above specified commands and they are successfully redacted.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
