### PR TITLE
[Hackathon]: Banlist to protect against DDOS and sybil attacks

### DIFF
--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -397,7 +397,8 @@ class LevelDBBlockchain(Blockchain):
         if block.Index == header_len:
 
             if self._verify_blocks and not block.Verify():
-                return False
+                error = "FALSE_BLOCK"
+                return error
 
             self.AddHeader(block.Header)
 
@@ -565,7 +566,8 @@ class LevelDBBlockchain(Blockchain):
             if header.Index < count + len(self._header_index):
                 continue
             if self._verify_blocks and not header.Verify():
-                break
+                error = "FALSE_HEADER"
+                return error
 
             count = count + 1
 

--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -92,13 +92,13 @@ class NeoNode(Protocol):
         ip = None
         for line in f:
             attributes = line.split(",")
-            if(attributes[0] == "\n") continue
+            if(attributes[0] == "\n"): continue
             if(attributes[0] == self.host):
                 self.rating = int(attributes[1])
                 if self.rating > 90:
-                    Disconnect()
+                    self.Disconnect()
                 f.close()
-                break
+                return
 
         f.close()
 
@@ -145,10 +145,10 @@ class NeoNode(Protocol):
         f = open(filename, 'r+')
         for line in f:
             attributes = line.split(",")
-            if(attributes[0] == "\n") continue
+            if(attributes[0] == "\n"): continue
             attributes = line.split(",")
-            if(attributes[0] == str(self.host):
-                attributes[0] = str(currRating)
+            if attributes[0] == str(self.host):
+                attributes[0] = str(newRating)
 
         self.rating = newRating
 
@@ -156,10 +156,11 @@ class NeoNode(Protocol):
             self.Disconnect()
 
         f.close()
+        
 
 
 
-    def getRating(self, rating):
+    def getRating(self):
         """Searches through misbehaving.txt if rating is not already loaded."""
         if(self.rating != None):
             rating = self.rating
@@ -169,12 +170,13 @@ class NeoNode(Protocol):
         f = open(filename, 'r+')
         for line in f:
             attributes = line.split(",")
-            if(attributes[0] == "\n") continue
+            if(attributes[0] == "\n"): continue
             attributes = line.split(",")
             if(attributes[0] == str(self.host)):
                 rating = int(attributes[1])
 
         f.close()
+        return rating
 
 
 
@@ -343,7 +345,7 @@ class NeoNode(Protocol):
 
         peerlist = []
         for peer in self.leader.Peers:
-            make sure peers rating is <= 90 by checking the banlist
+            #make sure peers rating is <= 90 by checking the banlist
             if(peer.getRating <= 90):
                 peerlist.append( peer.GetNetworkAddressWithTime())
         self.Log("Peer list %s " % peerlist)
@@ -404,14 +406,13 @@ class NeoNode(Protocol):
 
             if error == "FALSE_HEADER":
                 rating = self.getRating()
-                if(rating <= 80) {
+                if(rating <= 80):
                     rating += 20
-                }
-                elif rating < 100 {
+                elif rating < 100:
                     rating = 100
-                }
-                changeRating(rating)
-                break
+              
+                self.changeRating(rating)
+                
 
         if BC.Default().HeaderHeight < self.Version.StartHeight:
             self.AskForMoreHeaders()
@@ -435,14 +436,13 @@ class NeoNode(Protocol):
             error = self.leader.InventoryReceived(block)
             if error == "FALSE_BLOCK":
                 rating = self.getRating()
-                if(rating <= 80) {
+                if(rating <= 80):
                     rating += 20
-                }
-                elif rating < 100 {
+                elif rating < 100:
                     rating = 100
-                }
-                changeRating(rating)
-                break
+               
+                self.changeRating(rating)
+                
 
         if len(self.myblockrequests) < self.leader.NREQMAX:
             self.DoAskForMoreBlocks()

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -162,8 +162,11 @@ class NodeLeader():
             if BC.Default().ContainsBlock(inventory.Index):
                 return False
 
-            if not BC.Default().AddBlock(inventory):
+            error = BC.Default().AddBlock(inventory)
+            if error == False:
                 return False
+            elif error == "FALSE_BLOCK"
+                return error
 
         else:
             if not inventory.Verify():

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -165,7 +165,7 @@ class NodeLeader():
             error = BC.Default().AddBlock(inventory)
             if error == False:
                 return False
-            elif error == "FALSE_BLOCK"
+            elif error == "FALSE_BLOCK":
                 return error
 
         else:


### PR DESCRIPTION
Issue 325

Theory: potential bad peers are:
1. those relaying false information
2. unstable connection or high latency connection
3. peers that only request but don't send out blocks (leechers; usually because of misconfigurations of port forwarding)

Solution: I added a ban list in the codebase. This solves a HUGE vulnerability because DDOS and sybil attacks are currently not protected against because any false blocks and headers are just discarded without any repercussion for the sender. I created a few functions that would create ratings for peers.

The commit needs some tweaking and testing (I couldn't compile neo correctly yet because make install kept erroring). Specifically, the FALSE_HEADER and FALSE_BLOCK errors need to be curtailed before merging because not all block errors come from malicious nodes.

Ideas for the future:

1. Peers have a second rating called "network trust." Network trust is how much you trust a peers peers. This is based on testing by connecting to a peers peers and seeing the result. If they misbehave, they get banned and the peer that shared those peers network trust goes down. This is a good way to mitigate bad peer of peers and works great alongside banlists.
2. When a node is testing new peer A that they got from seeding or from one of their peers, that node can get an indicator of trust by asking their other peers if they have seen A misbehaving. This is only one indicator of trust.