### PR TITLE
Fix to redact WIF keys, nep2 keys and contract metadata from the command history file (fixes #301)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to this project are documented in this file.
 [0.6.2-dev] in progress
 -----------------------
 - Added support for using ``--from-addr=`` to specify the address to use for ``testinvoke`` in ``prompt.py``. (`PR #329 <https://github.com/CityOfZion/neo-python/pull/329>`_)
-
+- Fixed ``neo/bin/prompt.py`` to redact WIF keys, nep2 keys and contract metadata from the command history file ``.prompt.py.history``.
 
 [0.6.1] 2018-03-16
 ----------------------------

--- a/neo/Prompt/Commands/LoadSmartContract.py
+++ b/neo/Prompt/Commands/LoadSmartContract.py
@@ -153,31 +153,26 @@ def GatherContractDetails(function_code, prompter):
     print("Please fill out the following contract details:")
     name = prompt("[Contract Name] > ",
                   completer=prompter.get_completer(),
-                  history=prompter.history,
                   get_bottom_toolbar_tokens=prompter.get_bottom_toolbar,
                   style=prompter.token_style)
 
     version = prompt("[Contract Version] > ",
                      completer=prompter.get_completer(),
-                     history=prompter.history,
                      get_bottom_toolbar_tokens=prompter.get_bottom_toolbar,
                      style=prompter.token_style)
 
     author = prompt("[Contract Author] > ",
                     completer=prompter.get_completer(),
-                    history=prompter.history,
                     get_bottom_toolbar_tokens=prompter.get_bottom_toolbar,
                     style=prompter.token_style)
 
     email = prompt("[Contract Email] > ",
                    completer=prompter.get_completer(),
-                   history=prompter.history,
                    get_bottom_toolbar_tokens=prompter.get_bottom_toolbar,
                    style=prompter.token_style)
 
     description = prompt("[Contract Description] > ",
                          completer=prompter.get_completer(),
-                         history=prompter.history,
                          get_bottom_toolbar_tokens=prompter.get_bottom_toolbar,
                          style=prompter.token_style)
 

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -55,9 +55,7 @@ settings.set_logfile(LOGFILE_FN, LOGFILE_MAX_BYTES, LOGFILE_BACKUP_COUNT)
 FILENAME_PROMPT_HISTORY = os.path.join(PATH_USER_DATA, '.prompt.py.history')
 
 
-class NeoHistory(FileHistory):
-    contract_meta_count = 0
-
+class PromptFileHistory(FileHistory):
     def append(self, string):
         string = self.redact_command(string)
         if len(string) == 0:
@@ -79,19 +77,12 @@ class NeoHistory(FileHistory):
         command = [comm for comm in ['import wif', 'export wif', 'import nep2', 'export nep2'] if comm in string]
         if len(command) > 0:
             command = command[0]
+            # only redacts command if wif/nep2 keys are in the command, not if the argument is left empty.
             if command in string and len(command + " ") < len(string):
+                # example: import wif 5HueCGU8  -->  import wif <wif>
                 return command + " <" + command.split(" ")[1] + ">"
             else:
                 return string
-        elif "import contract" in string:
-            self.contract_meta_count += 1
-            return string
-        elif self.contract_meta_count != 0 and self.contract_meta_count != 5:
-            self.contract_meta_count += 1
-            return ""
-        elif self.contract_meta_count != 0 and self.contract_meta_count == 5:
-            self.contract_meta_count = 0
-            return ""
 
         return string
 
@@ -161,7 +152,7 @@ class PromptInterface(object):
                 'debugstorage {on/off/reset}'
                 ]
 
-    history = NeoHistory(FILENAME_PROMPT_HISTORY)
+    history = PromptFileHistory(FILENAME_PROMPT_HISTORY)
 
     token_style = None
     start_height = None


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Fixes #301 

**How did you solve this problem?**
By extending the `FileHistory` class to make a custom `History` object that redacts commands before appending them to ``.prompt.py.history`` file when one of the following commands `import wif {wif}`, `export wif {wif}`, `import nep2 {nep2}`, ``export nep2 {nep2}`` are executed. The WIF keys and the nep2 keys are replaced with `<wif>` and `<nep2>` respectively. Metadata (name, description) generated by the command `import contract {path/to/file.avm} {params} {returntype} {needs_storage} {needs_dynamic_invoke}` is also not added to the `.prompt.py.history` file.

**How did you make sure your solution works?**
I tried running the above specified commands and they are successfully redacted.


**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
