### PR TITLE
Added TransactionInvocation.GetScript to StateReader.py (fixes #324)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to this project are documented in this file.
 [0.6.2-dev] in progress
 -----------------------
 - Added support for using ``--from-addr=`` to specify the address to use for ``testinvoke`` in ``prompt.py``. (`PR #329 <https://github.com/CityOfZion/neo-python/pull/329>`_)
-
+- Added TransactionInvocation.GetScript to ``StateReader.py``
 
 [0.6.1] 2018-03-16
 ----------------------------

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -19,7 +19,6 @@ from neo.EventHub import dispatch_smart_contract_event, dispatch_smart_contract_
 from neo.SmartContract.SmartContractEvent import SmartContractEvent, NotifyEvent
 from neocore.Cryptography.ECCurve import ECDSA
 from neo.SmartContract.TriggerType import Application, Verification
-
 from neo.VM.InteropService import StackItem, stack_item_to_py
 from neo.Settings import settings
 
@@ -81,6 +80,7 @@ class StateReader(InteropService):
         self.Register("Neo.Transaction.GetOutputs", self.Transaction_GetOutputs)
         self.Register("Neo.Transaction.GetReferences", self.Transaction_GetReferences)
         self.Register("Neo.Transaction.GetUnspentCoins", self.Transaction_GetUnspentCoins)
+        self.Register("Neo.InvocationTransaction.GetScript", self.InvocationTransaction_GetScript)
 
         self.Register("Neo.Attribute.GetData", self.Attribute_GetData)
         self.Register("Neo.Attribute.GetUsage", self.Attribute_GetUsage)
@@ -632,6 +632,14 @@ class StateReader(InteropService):
 
         refs = [StackItem.FromInterface(unspent) for unspent in Blockchain.Default().GetAllUnspent(tx.Hash)]
         engine.EvaluationStack.PushT(refs)
+        return True
+
+    def InvocationTransaction_GetScript(self, engine):
+
+        tx = engine.EvaluationStack.Pop().GetInterface()
+        if tx is None:
+            return False
+        engine.EvaluationStack.PushT(tx.Script)
         return True
 
     def Attribute_GetUsage(self, engine):


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Fixes #324 
**How did you solve this problem?**
By adding TransactionInvocation.GetScript to StateReader.py

**How did you make sure your solution works?**
Reviewed official StateReader C# implementation as well as other methods in neo-python's StateReader

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
