### PR TITLE
Fix settings data paths, privnet path warnings

### DIFF
--- a/docs/source/settings-and-logging.rst
+++ b/docs/source/settings-and-logging.rst
@@ -120,7 +120,7 @@ logger with the existing neo logging configuration, you can just import the logg
     # These log messages are sent to the console
     logger.debug("hello")
     logger.info("info")
-    logger.warn("warn")
+    logger.warning("warn")
     logger.error("error")
 
     # This is how you'd log an exception

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -280,9 +280,9 @@ class SettingsHolder:
         # Add a warning for migration purposes if we created a chain dir
         if warn_migration and ROOT_INSTALL_PATH != self.DATA_DIR_PATH:
             if os.path.exists(os.path.join(ROOT_INSTALL_PATH, 'Chains')):
-                logzero.logger.warn("[MIGRATION] You are now using the blockchain data at %s, but it appears you have existing data at %s/Chains" % (chain_path, ROOT_INSTALL_PATH))
-                logzero.logger.warn("[MIGRATION] If you would like to use your existing data, please move any data at %s/Chains to %s " % (ROOT_INSTALL_PATH, chain_path))
-                logzero.logger.warn("[MIGRATION] Or you can continue using your existing data by starting your script with the `--datadir=.` flag")
+                logzero.logger.warning("[MIGRATION] You are now using the blockchain data at %s, but it appears you have existing data at %s/Chains" % (chain_path, ROOT_INSTALL_PATH))
+                logzero.logger.warning("[MIGRATION] If you would like to use your existing data, please move any data at %s/Chains to %s " % (ROOT_INSTALL_PATH, chain_path))
+                logzero.logger.warning("[MIGRATION] Or you can continue using your existing data by starting your script with the `--datadir=.` flag")
 
     def check_privatenet(self):
         """

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -115,17 +115,17 @@ class SettingsHolder:
     @property
     def chain_leveldb_path(self):
         self.check_chain_dir_exists(warn_migration=True)
-        return os.path.join(self.DATA_DIR_PATH, self.LEVELDB_PATH)
+        return os.path.abspath(os.path.join(self.DATA_DIR_PATH, self.LEVELDB_PATH))
 
     @property
     def notification_leveldb_path(self):
         self.check_chain_dir_exists()
-        return os.path.join(self.DATA_DIR_PATH, self.NOTIFICATION_DB_PATH)
+        return os.path.abspath(os.path.join(self.DATA_DIR_PATH, self.NOTIFICATION_DB_PATH))
 
     @property
     def debug_storage_leveldb_path(self):
         self.check_chain_dir_exists()
-        return os.path.join(self.DATA_DIR_PATH, self.DEBUG_STORAGE_PATH)
+        return os.path.abspath(os.path.join(self.DATA_DIR_PATH, self.DEBUG_STORAGE_PATH))
 
     # Helpers
     @property
@@ -301,18 +301,18 @@ class SettingsHolder:
 
         # Now check if nonce is the same as in the chain path
         nonce_container = str(version["nonce"])
-        neopy_chain_meta_filename = os.path.join(self.LEVELDB_PATH, ".privnet-nonce")
+        neopy_chain_meta_filename = os.path.join(self.chain_leveldb_path, ".privnet-nonce")
         if os.path.isfile(neopy_chain_meta_filename):
             nonce_chain = open(neopy_chain_meta_filename, "r").read()
             if nonce_chain != nonce_container:
                 raise PrivnetConnectionError(
                     "Chain database in Chains/privnet is for a different private network than the current container. "
-                    "Consider deleting the Chain directory with 'rm -rf Chains/privnet*'."
+                    "Consider deleting the Chain directory with 'rm -rf %s/privnet*'." % self.chain_leveldb_path
                 )
         else:
             # When the Chains/privnet folder is removed, we need to create the directory
-            if not os.path.isdir(self.LEVELDB_PATH):
-                os.mkdir(self.LEVELDB_PATH)
+            if not os.path.isdir(self.chain_leveldb_path):
+                os.mkdir(self.chain_leveldb_path)
 
             # Write the nonce to the meta file
             with open(neopy_chain_meta_filename, "w") as f:

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -1060,11 +1060,11 @@ class Wallet(object):
         for key, unspents in paycoins.items():
             if unspents is None:
                 if not self.IsSynced:
-                    logger.warn("Wait for your wallet to be synced before doing "
-                                "transactions. To check enter 'wallet' and look at "
-                                "'percent_synced', it should be 100. Also the blockchain "
-                                "should be up to the latest blocks (see Progress). Issuing "
-                                "'wallet rebuild' restarts the syncing process.")
+                    logger.warning("Wait for your wallet to be synced before doing "
+                                   "transactions. To check enter 'wallet' and look at "
+                                   "'percent_synced', it should be 100. Also the blockchain "
+                                   "should be up to the latest blocks (see Progress). Issuing "
+                                   "'wallet rebuild' restarts the syncing process.")
                     return None
 
                 else:

--- a/neo/test_settings.py
+++ b/neo/test_settings.py
@@ -41,12 +41,12 @@ class SettingsTestCase(NeoTestCase):
 
         _settings.set_data_dir('.')
 
-        self.assertEqual(_settings.chain_leveldb_path, os.path.join(ROOT_INSTALL_PATH, _settings.LEVELDB_PATH))
-        self.assertEqual(_settings.notification_leveldb_path, os.path.join(ROOT_INSTALL_PATH, _settings.NOTIFICATION_DB_PATH))
-        self.assertEqual(_settings.debug_storage_leveldb_path, os.path.join(ROOT_INSTALL_PATH, _settings.DEBUG_STORAGE_PATH))
+        self.assertEqual(_settings.chain_leveldb_path, os.path.abspath(os.path.join(ROOT_INSTALL_PATH, _settings.LEVELDB_PATH)))
+        self.assertEqual(_settings.notification_leveldb_path, os.path.abspath(os.path.join(ROOT_INSTALL_PATH, _settings.NOTIFICATION_DB_PATH)))
+        self.assertEqual(_settings.debug_storage_leveldb_path, os.path.abspath(os.path.join(ROOT_INSTALL_PATH, _settings.DEBUG_STORAGE_PATH)))
 
-        _settings.DATA_DIR_PATH = '/whatever'
+        _settings.DATA_DIR_PATH = '/tmp/whatever'
 
-        self.assertEqual(_settings.chain_leveldb_path, os.path.join('/whatever', _settings.LEVELDB_PATH))
-        self.assertEqual(_settings.notification_leveldb_path, os.path.join('/whatever', _settings.NOTIFICATION_DB_PATH))
-        self.assertEqual(_settings.debug_storage_leveldb_path, os.path.join('/whatever', _settings.DEBUG_STORAGE_PATH))
+        self.assertEqual(_settings.chain_leveldb_path, os.path.abspath(os.path.join('/tmp/whatever', _settings.LEVELDB_PATH)))
+        self.assertEqual(_settings.notification_leveldb_path, os.path.abspath(os.path.join('/tmp/whatever', _settings.NOTIFICATION_DB_PATH)))
+        self.assertEqual(_settings.debug_storage_leveldb_path, os.path.abspath(os.path.join('/tmp/whatever', _settings.DEBUG_STORAGE_PATH)))


### PR DESCRIPTION
* Use `os.path.abspath` to convert paths like `/home/test/.neopython/./Chains` to `/home/test/.neopython/Chains`
* Fix privnet data check path (used old Chains path)
