### PR TITLE
Update bootstrap script with new paths

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ All notable changes to this project are documented in this file.
 - Fixed missing uri locations in ``neo/api/REST/RestApi.py`` (`PR #342 <https://github.com/CityOfZion/neo-python/pull/342>`_)
 - Fixed privatenet check by fixing the chain path for checks in Settings (`PR #341 <https://github.com/CityOfZion/neo-python/pull/341>`_)
 - Fixed ``neo-privnet.sample.wallet``
+- Fixed ``bootstrap.py`` to use the specified data directory, instead of hard-coded relative paths.
 
 
 [0.6.1] 2018-03-16

--- a/neo/Prompt/Commands/Bootstrap.py
+++ b/neo/Prompt/Commands/Bootstrap.py
@@ -7,9 +7,6 @@ import tarfile
 import shutil
 import os
 
-DEFAULT_TMP_BOOTSTRAP_FILE = os.path.join(settings.DATA_DIR_PATH,
-                                          'bootstrap.tar.gz')
-
 
 def BootstrapBlockchainFile(target_dir, download_file, require_confirm=True):
 
@@ -33,7 +30,10 @@ def BootstrapBlockchainFile(target_dir, download_file, require_confirm=True):
     sys.exit(0)
 
 
-def do_bootstrap(bootstrap_file, destination_dir, tmp_file_name=DEFAULT_TMP_BOOTSTRAP_FILE, tmp_chain_name='tmpchain'):
+def do_bootstrap(bootstrap_file, destination_dir, tmp_file_name=None, tmp_chain_name='tmpchain'):
+
+    if tmp_file_name is None:
+        tmp_file_name = os.path.join(settings.DATA_DIR_PATH, 'bootstrap.tar.gz')
 
     success = False
 

--- a/neo/Prompt/Commands/Bootstrap.py
+++ b/neo/Prompt/Commands/Bootstrap.py
@@ -7,6 +7,9 @@ import tarfile
 import shutil
 import os
 
+DEFAULT_TMP_BOOTSTRAP_FILE = os.path.join(settings.DATA_DIR_PATH,
+                                          'bootstrap.tar.gz')
+
 
 def BootstrapBlockchainFile(target_dir, download_file, require_confirm=True):
 
@@ -20,13 +23,17 @@ def BootstrapBlockchainFile(target_dir, download_file, require_confirm=True):
         if confirm == 'confirm':
             return do_bootstrap(download_file, target_dir)
     else:
-        return do_bootstrap(download_file, target_dir, tmp_file_name='./fixtures/btest.tar.gz', tmp_chain_name='btestchain')
+
+        return do_bootstrap(download_file,
+                            target_dir,
+                            tmp_file_name=os.path.join(settings.DATA_DIR_PATH, 'btest.tar.gz'),
+                            tmp_chain_name='btestchain')
 
     print("bootstrap cancelled")
     sys.exit(0)
 
 
-def do_bootstrap(bootstrap_file, destination_dir, tmp_file_name='./Chains/bootstrap.tar.gz', tmp_chain_name='tmpchain'):
+def do_bootstrap(bootstrap_file, destination_dir, tmp_file_name=DEFAULT_TMP_BOOTSTRAP_FILE, tmp_chain_name='tmpchain'):
 
     success = False
 
@@ -92,6 +99,7 @@ def do_bootstrap(bootstrap_file, destination_dir, tmp_file_name='./Chains/bootst
         print("cleaning up %s " % tmp_chain_name)
         if os.path.exists(tmp_chain_name):
             shutil.rmtree(tmp_chain_name)
+            os.remove(tmp_file_name)
 
     if success:
         print("Successfully downloaded bootstrap chain!")


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
https://github.com/CityOfZion/neo-python/issues/338 - With the new user data paths, the download of the bootstrap files are failing.

**How did you solve this problem?**
Removed the hard-coded relative paths in the bootstrap script and added dynamic user paths based on the new `DATA_DIR_PATH`.

**How did you make sure your solution works?**
Checked it manually. Downloaded the chains on my personal computer using these changes.

**Are there any special changes in the code that we should be aware of?**
Not really, I just added a call to `os.remove()` on the downloaded file since it isn't removed and stays there wasting space.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
