### PR TITLE
Add gzip compression support to RPC calls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.6.4-dev] in progress
 -----------------------
+- Add GZIP compression to RPC server responses if the caller supports it.
 
 
 [0.6.3] 2018-03-21

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -443,7 +443,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         body = json.dumps(req).encode("utf-8")
 
         # first validate that we get a gzip response if we accept gzip encoding
-        mock_req = requestMock(path=b'/', method="POST", body=body, headers={'Accept-Encoding': ['gzip']})
+        mock_req = requestMock(path=b'/', method="POST", body=body, headers={'Accept-Encoding': ['deflate', 'gzip;q=1.0', '*;q=0.5']})
         res = self.app.home(mock_req)
 
         GZIP_MAGIC = b'\x1f\x8b'

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -437,3 +437,28 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         res = json.loads(self.app.home(mock_req))
         self.assertTrue('error' in res)
         self.assertEqual(res['error']['code'], -32603)
+
+    def test_gzip_compression(self):
+        req = self._gen_rpc_req("getblock", params=['a0d34f68cb7a04d625ae095fa509479ec7dcb4dc87ecd865ab059d0f8a42decf', 1])
+        body = json.dumps(req).encode("utf-8")
+
+        # first validate that we get a gzip response if we accept gzip encoding
+        mock_req = requestMock(path=b'/', method="POST", body=body, headers={'Accept-Encoding': ['gzip']})
+        res = self.app.home(mock_req)
+
+        GZIP_MAGIC = b'\x1f\x8b'
+        self.assertIsInstance(res, bytes)
+        self.assertTrue(res.startswith(GZIP_MAGIC))
+
+        # then validate that we don't get a gzip response if we don't accept gzip encoding
+        mock_req = requestMock(path=b'/', method="POST", body=body, headers={})
+        res = self.app.home(mock_req)
+
+        self.assertIsInstance(res, str)
+
+        try:
+            json.loads(res)
+            valid_json = True
+        except ValueError:
+            valid_json = False
+        self.assertTrue(valid_json)

--- a/neo/api/utils.py
+++ b/neo/api/utils.py
@@ -1,24 +1,46 @@
 import json
+import gzip
 from functools import wraps
+
+COMPRESS_FASTEST = 1
+BASE_STRING_SIZE = 49
+MTU_TCP_PACKET_SIZE = 1500
+COMPRESS_THRESHOLD = MTU_TCP_PACKET_SIZE + BASE_STRING_SIZE
 
 
 # @json_response decorator for class methods
 def json_response(func):
     """ @json_response decorator adds header and dumps response object """
+
     @wraps(func)
     def wrapper(self, request, *args, **kwargs):
         res = func(self, request, *args, **kwargs)
+        response_data = json.dumps(res) if isinstance(res, dict) else res
         request.setHeader('Content-Type', 'application/json')
-        return json.dumps(res) if isinstance(res, dict) else res
+
+        if len(response_data) > COMPRESS_THRESHOLD:
+            accept_encoding = request.getHeader('Accept-Encoding')
+            if accept_encoding:
+                encodings = accept_encoding.split(',')
+
+                if 'gzip' in encodings:
+                    response_data = gzip.compress(bytes(response_data, 'utf-8'), compresslevel=COMPRESS_FASTEST)
+                    request.setHeader('Content-Encoding', 'gzip')
+                    request.setHeader('Content-Length', len(response_data))
+
+        return response_data
+
     return wrapper
 
 
 # @cors_header decorator to add the CORS headers
 def cors_header(func):
     """ @cors_header decorator adds CORS headers """
+
     @wraps(func)
     def wrapper(self, request, *args, **kwargs):
         res = func(self, request, *args, **kwargs)
         request.setHeader('Access-Control-Allow-Origin', '*')
         return res
+
     return wrapper


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Adds optional gzip compression if the caller supports it. This feature was recently added here: https://github.com/neo-project/neo/pull/201/commits/6e1921346326e6f89bbca4c39e6123b3eae1c060

**How did you solve this problem?**
update the json decorator used in the RPC server

**How did you make sure your solution works?**
added a test

**Are there any special changes in the code that we should be aware of?**
nope

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
