### PR TITLE
Change VMFault reporting to only output when debug logging is enabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.6.4-dev] in progress
 -----------------------
-
+- Change VM fault reporting to only happen when debug logging is enabled
 
 [0.6.3] 2018-03-21
 -----------------------

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -21,7 +21,6 @@ from neorpc.Client import RPCClient
 from neorpc.Settings import settings as rpc_settings
 import sys
 
-
 dir_current = os.path.dirname(os.path.abspath(__file__))
 
 # ROOT_INSTALL_PATH is the root path of neo-python, whether installed as package or from git.
@@ -38,7 +37,6 @@ if os.path.isdir(USER_HOME_DIR) and not os.path.isdir(PATH_USER_DATA):
 # This detects if we are running from an 'editable' version (like ``python neo/bin/prompt.py``)
 # or from a packaged install version from pip
 IS_PACKAGE_INSTALL = 'site-packages/neo' in dir_current
-
 
 # The filenames for various files. Might be improved by using system
 # user directories: https://github.com/ActiveState/appdirs
@@ -60,7 +58,6 @@ class DependencyError(Exception):
 
 
 def check_depdendencies():
-
     # Get installed packages
     installed_packages = pip.get_installed_distributions(local_only=False)
     installed_packages_list = sorted(["%s==%s" % (i.key, i.version) for i in installed_packages])
@@ -107,6 +104,7 @@ class SettingsHolder:
     VERSION_NAME = "/NEO-PYTHON:%s/" % __version__
 
     # Logging settings
+    log_level = None
     log_smart_contract_events = False
     log_vm_instructions = False
 
@@ -262,6 +260,7 @@ class SettingsHolder:
         Args:
             level (int): eg. logging.DEBUG or logging.ERROR. See also https://docs.python.org/2/library/logging.html#logging-levels
         """
+        self.log_level = level
         logzero.loglevel(level)
 
     def check_chain_dir_exists(self, warn_migration=False):

--- a/neo/SmartContract/tests/test_vm_error_output.py
+++ b/neo/SmartContract/tests/test_vm_error_output.py
@@ -4,6 +4,8 @@ from boa.compiler import Compiler
 from neo.Prompt.Commands.BuildNRun import TestBuild
 from neo.VM.ExecutionEngine import ExecutionEngine
 from mock import patch
+from neo.Settings import settings
+from logging import DEBUG, INFO
 
 
 class StringIn(str):
@@ -20,6 +22,7 @@ class TestVMErrors(BoaTest):
         super(TestVMErrors, cls).setUpClass()
         output = Compiler.instance().load('%s/sc_vm_errors.py' % os.path.dirname(__file__)).default
         cls.script = output.write()
+        settings.set_loglevel(DEBUG)
 
     @patch('logzero.logger.error')
     def test_invalid_array_index(self, mocked_logger):
@@ -40,3 +43,10 @@ class TestVMErrors(BoaTest):
     def test_invalid_appcall(self, mocked_logger):
         tx, results, total_ops, engine = TestBuild(self.script, [4, ['my_arg0']], self.GetWallet1(), '0210', '07', dynamic=True)
         mocked_logger.assert_called_with(StringIn("Trying to call an unknown contract"))
+
+    # make sure this test is always last because we change the logging level
+    @patch('logzero.logger.error')
+    def test_no_logging_if_loglevel_not_debug(self, mocked_logger):
+        settings.set_loglevel(INFO)
+        tx, results, total_ops, engine = TestBuild(self.script, [1, ['my_arg0']], self.GetWallet1(), '0210', '07')
+        self.assertEqual(0, mocked_logger.call_count)

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -11,6 +11,7 @@ from neo.VM.InteropService import Array, Struct, StackItem, CollectionMixin, Map
 from neocore.UInt160 import UInt160
 from neo.Settings import settings
 from neo.VM.VMFault import VMFault
+from logging import DEBUG as LOGGING_LEVEL_DEBUG
 
 
 class ExecutionEngine():
@@ -902,11 +903,6 @@ class ExecutionEngine():
         else:
             op = self.CurrentContext.OpReader.ReadByte(do_ord=False)
 
-#        opname = ToName(op)
-#        logger.info("____________________________________________________")
-#        logger.info("[%s] [%s] %02x -> %s" % (self.CurrentContext.InstructionPointer,self.ops_processed,int.from_bytes(op,byteorder='little'), opname))
-#        logger.info("-----------------------------------")
-
         self.ops_processed += 1
 
         try:
@@ -947,6 +943,9 @@ class ExecutionEngine():
 
     def VM_FAULT_and_report(self, id, *args):
         self._VMState |= VMState.FAULT
+
+        if settings.log_level != LOGGING_LEVEL_DEBUG:
+            return
 
         if id == VMFault.INVALID_JUMP:
             error_msg = "Attemping to JMP/JMPIF/JMPIFNOT to an invalid location."
@@ -1016,7 +1015,6 @@ class ExecutionEngine():
         else:
             error_msg = id
 
-        # these get used a lot actually now, so we dont want them printed to the console
         if id in [VMFault.THROW, VMFault.THROWIFNOT]:
             logger.debug("({}) {}".format(self.ops_processed, id))
         else:

--- a/neo/VM/tests/test_interop_map.py
+++ b/neo/VM/tests/test_interop_map.py
@@ -5,6 +5,8 @@ from neo.VM.ExecutionContext import ExecutionContext
 from neo.VM import OpCode
 from neo.VM import VMState
 from mock import patch
+from neo.Settings import settings
+from logging import DEBUG
 
 
 class StringIn(str):
@@ -13,17 +15,19 @@ class StringIn(str):
 
 
 class InteropTest(TestCase):
-
     engine = None
     econtext = None
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
+        super(InteropTest, cls).setUpClass()
+        settings.set_loglevel(DEBUG)
 
+    def setUp(self):
         self.engine = ExecutionEngine()
         self.econtext = ExecutionContext()
 
     def test_interop_map1(self):
-
         map = Map()
 
         self.assertEqual(map.Keys, [])
@@ -35,7 +39,6 @@ class InteropTest(TestCase):
         self.assertEqual(map.Values, [ByteArray(b'abc')])
 
     def test_interop_map2(self):
-
         map = Map({'a': 1, 'b': 2, 'c': 3})
 
         self.assertEqual(map.Count, 3)
@@ -47,7 +50,6 @@ class InteropTest(TestCase):
         self.assertEqual(map.GetMap(), {})
 
     def test_interop_map3(self):
-
         map = Map({'a': 1, 'b': 2, 'c': 3})
 
         self.assertEqual(map.GetBoolean(), True)
@@ -73,7 +75,6 @@ class InteropTest(TestCase):
         self.assertEqual(map.GetMap(), {'b': 2, 'c': 3, 'h': 9})
 
     def test_op_map1(self):
-
         self.engine.ExecuteOp(OpCode.NEWMAP, self.econtext)
 
         self.assertEqual(len(self.engine.EvaluationStack.Items), 1)
@@ -81,7 +82,6 @@ class InteropTest(TestCase):
         self.assertEqual(self.engine.EvaluationStack.Items[0].GetMap(), {})
 
     def test_op_map2(self):
-
         self.engine.ExecuteOp(OpCode.NEWMAP, self.econtext)
         self.engine.EvaluationStack.PushT(StackItem.New('mykey'))
         self.engine.EvaluationStack.PushT(StackItem.New('myVal'))
@@ -90,7 +90,6 @@ class InteropTest(TestCase):
         self.assertEqual(len(self.engine.EvaluationStack.Items), 0)
 
     def test_op_map3(self):
-
         # set item should fail if not enough things on estack
 
         self.engine.EvaluationStack.PushT(StackItem.New('myvalue'))
@@ -104,7 +103,6 @@ class InteropTest(TestCase):
 
     @patch('logzero.logger.error')
     def test_op_map4(self, mocked_logger):
-
         # set item should fail if these are out of order
         self.engine.EvaluationStack.PushT(StackItem.New('mykey'))
         self.engine.ExecuteOp(OpCode.NEWMAP, self.econtext)
@@ -117,7 +115,6 @@ class InteropTest(TestCase):
 
     @patch('logzero.logger.error')
     def test_op_map5(self, mocked_logger):
-
         # set item should fail if these are out of order
         self.engine.EvaluationStack.PushT(StackItem.New('mykey'))
         self.engine.EvaluationStack.PushT(StackItem.New('mykey'))


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
This changes VM fault reporting to only occur when `config debug` (debug logging) is enabled. There's 2 reasons for this;
1) it could help with performance as described in my comment here: https://github.com/CityOfZion/neo-python/issues/352#issuecomment-375582004
2) after the VMFault reporting was added, I saw some users on Discord who thought their neo-python install was broken because they were now notified of the errors that were actually always happening anyway. This should also give them some peace of mind.  

**How did you solve this problem?**
make VM Fault reporting dependent on `setting.log_level`

**How did you make sure your solution works?**
added a new test case

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
