### PR TITLE
engine should fail when it runs out of gas

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.6.4-dev] in progress
 -----------------------
-
+- fix engine error states
 
 [0.6.3] 2018-03-21
 -----------------------

--- a/neo/Prompt/Commands/BuildNRun.py
+++ b/neo/Prompt/Commands/BuildNRun.py
@@ -37,7 +37,7 @@ def LoadAndRun(arguments, wallet):
         print("Could not load script %s " % e)
 
 
-def BuildAndRun(arguments, wallet, verbose=True, min_fee=DEFAULT_MIN_FEE):
+def BuildAndRun(arguments, wallet, verbose=True, min_fee=DEFAULT_MIN_FEE, invocation_test_mode=True):
     arguments, from_addr = get_from_addr(arguments)
     path = get_arg(arguments)
 
@@ -46,10 +46,10 @@ def BuildAndRun(arguments, wallet, verbose=True, min_fee=DEFAULT_MIN_FEE):
     newpath = path.replace('.py', '.avm')
     print("Saved output to %s " % newpath)
 
-    return DoRun(contract_script, arguments, wallet, path, verbose, from_addr, min_fee)
+    return DoRun(contract_script, arguments, wallet, path, verbose, from_addr, min_fee, invocation_test_mode)
 
 
-def DoRun(contract_script, arguments, wallet, path, verbose=True, from_addr=None, min_fee=DEFAULT_MIN_FEE):
+def DoRun(contract_script, arguments, wallet, path, verbose=True, from_addr=None, min_fee=DEFAULT_MIN_FEE, invocation_test_mode=True):
 
     test = get_arg(arguments, 1)
 
@@ -62,7 +62,7 @@ def DoRun(contract_script, arguments, wallet, path, verbose=True, from_addr=None
 
             script = GatherLoadedContractParams(f_args, contract_script)
 
-            tx, result, total_ops, engine = test_deploy_and_invoke(script, i_args, wallet, from_addr, min_fee)
+            tx, result, total_ops, engine = test_deploy_and_invoke(script, i_args, wallet, from_addr, min_fee, invocation_test_mode)
             i_args.reverse()
 
             return_type_results = []

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -325,7 +325,7 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None, from_addr=None, min
     return None, None, None, None
 
 
-def test_deploy_and_invoke(deploy_script, invoke_args, wallet, from_addr=None, min_fee=DEFAULT_MIN_FEE):
+def test_deploy_and_invoke(deploy_script, invoke_args, wallet, from_addr=None, min_fee=DEFAULT_MIN_FEE, invocation_test_mode=True):
 
     bc = GetBlockchain()
 
@@ -467,7 +467,7 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet, from_addr=None, m
             table=script_table,
             service=service,
             gas=itx.Gas,
-            testMode=True
+            testMode=invocation_test_mode
         )
 
         engine.LoadScript(itx.Script, False)

--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -223,30 +223,37 @@ class ApplicationEngine(ExecutionEngine):
                 #                print("gas consumeb: %s " % self.gas_consumed)
                 except Exception as e:
                     logger.error("Exception calculating gas consumed %s " % e)
+                    self._VMState |= VMState.FAULT
                     return False
 
                 if not self.testMode and self.gas_consumed > self.gas_amount:
                     logger.error("NOT ENOUGH GAS")
+                    self._VMState |= VMState.FAULT
                     return False
 
                 if not self.CheckItemSize():
                     logger.error("ITEM SIZE TOO BIG")
+                    self._VMState |= VMState.FAULT
                     return False
 
                 if not self.CheckStackSize():
                     logger.error("STACK SIZE TOO BIG")
+                    self._VMState |= VMState.FAULT
                     return False
 
                 if not self.CheckArraySize():
                     logger.error("ARRAY SIZE TOO BIG")
+                    self._VMState |= VMState.FAULT
                     return False
 
                 if not self.CheckInvocationStack():
                     logger.error("INVOCATION SIZE TO BIIG")
+                    self._VMState |= VMState.FAULT
                     return False
 
                 if not self.CheckDynamicInvoke():
                     logger.error("Dynamic invoke without proper contract")
+                    self._VMState |= VMState.FAULT
                     return False
 
                 self.StepInto()

--- a/neo/SmartContract/tests/test_gas_costs.py
+++ b/neo/SmartContract/tests/test_gas_costs.py
@@ -179,7 +179,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
 
         arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", "True", "False", "put_5", "key1", self.big_str]
 
-        tx, result, total_ops, engine = BuildAndRun(arguments, wallet, False,invocation_test_mode=False)
+        tx, result, total_ops, engine = BuildAndRun(arguments, wallet, False, invocation_test_mode=False)
 
 #       expected_cost = Fixed8(1046600000)
 #        expected_gas = Fixed8.FromDecimal(1.0)

--- a/neo/SmartContract/tests/test_gas_costs.py
+++ b/neo/SmartContract/tests/test_gas_costs.py
@@ -157,3 +157,30 @@ class UserWalletTestCase(WalletFixtureTestCase):
         expected_gas = Fixed8.FromDecimal(.0001)
         self.assertEqual(expected_cost, engine.GasConsumed())
         self.assertEqual(tx.Gas, expected_gas)
+
+    def test_build_contract_7(self):
+        """
+        return from JSON-RPC is:
+        {'state': 'HALT, BREAK', 'script': '4d0004ababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababa
+        bababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab
+        abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababa
+        bababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab
+        abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababa
+        bababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab
+        abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababa
+        bababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab
+        abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababa
+        bababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab
+        abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababa
+        babababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab046b657931057075745f356780a1a5b87921dda4603b502ada749890cb
+        ca3434', 'stack': [{'type': 'Integer', 'value': '1'}], 'gas_consumed': '11.151'}
+        """
+        wallet = self.GetWallet1()
+
+        arguments = ["neo/SmartContract/tests/StorageTest.py", "test", "070705", "05", "True", "False", "put_5", "key1", self.big_str]
+
+        tx, result, total_ops, engine = BuildAndRun(arguments, wallet, False,invocation_test_mode=False)
+
+#       expected_cost = Fixed8(1046600000)
+#        expected_gas = Fixed8.FromDecimal(1.0)
+        self.assertEqual(engine, None)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- @MediaServe brought to our attention [this TX](https://neoscan.io/transaction/c20359f4694dd7078f1f3d246430a92ca53d7c1acfc86b602ad9f2eec3fd1b51) which contains 6 transfers of tokens.  After this TX, there is a discrepancy between `neo-python` balance and `neo-cli` balance.  This string of invokes should run out of gas and not persist any changes, but it processes 3 of them and returns as if a successful invoke.

- currently if a smart contract execution encounters errors or runs out of gas, the engine doesn't fail. 

**How did you solve this problem?**
- update `VMState` to `Fault` upon running out of gas or encountering other issues.

**How did you make sure your solution works?**
- added a test

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
