### PR TITLE
Feature update bootstrap

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ All notable changes to this project are documented in this file.
 - Add GZIP compression to RPC server responses if the caller supports it.
 - Change VM fault reporting to only happen when debug logging is enabled
 - fix engine error states
-
+- update mainnet bootstrap files
 
 [0.6.3] 2018-03-21
 -----------------------

--- a/neo/data/protocol.mainnet.json
+++ b/neo/data/protocol.mainnet.json
@@ -41,8 +41,8 @@
     "UriPrefix": [ "http://*:10332" ],
     "SslCert": "",
     "SslCertPassword": "",
-    "BootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/Main2003100.tar.gz",
-    "NotificationBootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/Main2003100_Notifications.tar.gz",
+    "BootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/Main206xxxx.tar.gz",
+    "NotificationBootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/MainNotif206xxxx.tar.gz",
     "DebugStorage":1
   }
 }


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- adds new bootstrap files for mainnet

**Are there any special changes in the code that we should be aware of?**
- clients/RPC servers should use this bootstrap before proceeding ( or resync from scratch ) otherwise they may be serving/using incorrect data

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
