### PR TITLE
Fix document to indicate the new way to start prompt

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@
 #
 #    $ docker run --rm -it -v $(pwd):/neo-python/sc --net=host -h neopython --name neopython neopython /bin/bash
 #
-# Once you are inside the container, you can start neo-python with `python3 prompt.py -p` (using -p to connect to a private net).
+# Once you are inside the container, you can start neo-python with `np-prompt` (using -p to connect to a private net).
 # To update neo-python, just run `git pull` and `pip install -e .`
 FROM ubuntu:17.10
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,9 +31,8 @@ Start a container interactively, opening a bash in `/neo-python`, and mounting t
 
     $ docker run --rm -it -v $(pwd):/neo-python/sc --net=host -h neopython --name neopython neopython /bin/bash
 
-Once you are inside the container, you can start neo-python with `python3 prompt.py -p` (using -p to connect to a private net).
+Once you are inside the container, you can start neo-python with `np-prompt -p` (using -p to connect to a private net).
 To update neo-python, just run `git pull` and `pip install -e .`
-
 
 ## NeoScan and the private network
 

--- a/docs/source/basicusage.rst
+++ b/docs/source/basicusage.rst
@@ -1,13 +1,13 @@
 Basic Usage
 -----------
 
-There are two main ways to use neo-python: ``prompt.py`` and running just the node with custom
+There are two main ways to use neo-python: ``np-prompt`` and running just the node with custom
 code.
 
-prompt.py
+np-prompt
 """""""""
 
-Start prompt.py on TestNet:
+Start np-prompt on TestNet:
 
 ::
 
@@ -17,7 +17,7 @@ Show help with all available arguments:
 
 ::
 
-    $ python prompt.py -h
+    $ python np-prompt -h
     usage: np-prompt [-h] [-m | -p [host] | --coznet | -c CONFIG]
                      [-t {dark,light}] [-v] [--datadir DATADIR] [--version]
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -26,7 +26,7 @@ Getting started
 ^^^^^^^^^^^^^^^
 Please follow directions in `the install section <install.html>`_
 
-The main functionality for this project is contained within the cli application ``prompt.py``.  You can `view usage details here <prompt.html>`_
+The main functionality for this project is contained within the cli application ``np-prompt``.  You can `view usage details here <prompt.html>`_
 
 We have published a Youtube `video <https://youtu.be/oy6Z_zd42-4>`_ to help get you started with this library. There are other videos under the `CityOfZion <(https://www.youtube.com/channel/UCzlQUNLrRa8qJkz40G91iJg>`_ Youtube channel.
 

--- a/docs/source/prompt.rst
+++ b/docs/source/prompt.rst
@@ -7,7 +7,7 @@ This is the default interface for running and interacting with the NEO blockchai
 
 Usage::
 
-    $ python prompt.py
+    $ np-prompt
     NEO cli. Type 'help' to get started
 
     neo>


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Documentation still points to the old way of starting prompt

**How did you solve this problem?**
Changed prompt.py to np-prompt

**How did you make sure your solution works?**
It is documentation changes

**Are there any special changes in the code that we should be aware of?**
None

**Please check the following, if applicable:**

- [ ] Did you add any tests? No
- [ ] Did you run `make lint`? No 
- [ ] Did you run `make test`? No
- [ ] Are you making a PR to a feature branch or development rather than master? No 
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do) 
