### PR TITLE
Fix Wallet Rebuild Contention

### DIFF
--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -106,13 +106,15 @@ class UserWallet(Wallet):
     def Rebuild(self):
         super(UserWallet, self).Rebuild()
 
+        logger.debug("wallet rebuild: deleting %s coins and %s transactions" %
+                     (Coin.select().count(), Transaction.select().count()))
+
         for c in Coin.select():
             c.delete_instance()
         for tx in Transaction.select():
             tx.delete_instance()
 
-        logger.debug("wallet rebuild: deleted coins and transactions %s %s " %
-                     (Coin.select().count(), Transaction.select().count()))
+        logger.debug("wallet rebuild complete")
 
     def Close(self):
         if self._db:
@@ -541,7 +543,6 @@ class UserWallet(Wallet):
                 if addr.IsWatchOnly:
                     has_watch_addr = True
             else:
-                token_balances = self.TokenBalancesForAddress(addr_str)
                 script_hash = binascii.hexlify(addr.ScriptHash)
                 json = {'address': addr_str, 'script_hash': script_hash.decode('utf8'), 'tokens': token_balances}
                 addresses.append(json)

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -8,6 +8,7 @@ import psutil
 import traceback
 import logging
 import sys
+from time import sleep
 from logzero import logger
 from prompt_toolkit import prompt
 from prompt_toolkit.contrib.completers import WordCompleter
@@ -243,8 +244,7 @@ class PromptInterface(object):
                 try:
                     self.Wallet = UserWallet.Open(path, password_key)
 
-                    self._walletdb_loop = task.LoopingCall(self.Wallet.ProcessBlocks)
-                    self._walletdb_loop.start(1)
+                    self.start_wallet_loop()
                     print("Opened wallet at %s" % path)
                 except Exception as e:
                     print("Could not open wallet: %s" % e)
@@ -294,17 +294,23 @@ class PromptInterface(object):
                     return
 
                 if self.Wallet:
-                    self._walletdb_loop = task.LoopingCall(self.Wallet.ProcessBlocks)
-                    self._walletdb_loop.start(1)
+                    self.start_wallet_loop()
 
             else:
                 print("Please specify a path")
 
+    def start_wallet_loop(self):
+        self._walletdb_loop = task.LoopingCall(self.Wallet.ProcessBlocks)
+        self._walletdb_loop.start(1)
+
+    def stop_wallet_loop(self):
+        self._walletdb_loop.stop()
+        self._walletdb_loop = None
+
     def do_close_wallet(self):
         if self.Wallet:
             path = self.Wallet._path
-            self._walletdb_loop.stop()
-            self._walletdb_loop = None
+            self.stop_wallet_loop()
             self.Wallet.Close()
             self.Wallet = None
             print("Closed wallet %s" % path)
@@ -532,7 +538,14 @@ class PromptInterface(object):
         elif item == 'claim':
             ClaimGas(self.Wallet, True, arguments[1:])
         elif item == 'rebuild':
-            self.Wallet.Rebuild()
+            self.stop_wallet_loop()
+            # in order to ensure sufficient time for the wallet db loop to stop, wait 5 seconds to ensure
+            # the latest chunk of 1k blocks has been processed
+            sleep(5)
+            try:
+                self.Wallet.Rebuild()
+            finally:
+                self.start_wallet_loop()
             try:
                 item2 = int(get_arg(arguments, 1))
                 if item2 and item2 > 0:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Fixes #364.

**How did you solve this problem?**

Implemented a fix to ensure the `Wallet.ProcessBlocks` `LoopingCall` doesn't run during a `wallet rebuild`.

**How did you make sure your solution works?**

Tested it. `wallet rebuild` never worked with my wallet previously. Tested quite a few different scenarios to make sure this solved it. The only potential variance is the somewhat arbitrary `sleep`. There's not a good way that I can identify to tell when the `ProcessBlocks` `LoopingCall` actually ends, so this `sleep` attempts to work around that. Seems to work just fine in my testing. Slower computers could potentially have an issue?

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
