### PR TITLE
"getpeers" JSON RPC method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 - fix engine error states
 - update mainnet bootstrap files
 - performance fix for VM engine execution logging (`PR #354 <https://github.com/CityOfZion/neo-python/pull/354>`_)
+- Added 'getpeers' to the JSON RPC API (only containing the available functionality)
 
 
 [0.6.3] 2018-03-21

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -311,7 +311,7 @@ class JsonRpcApi(object):
     def get_peers(self):
         """Get all known nodes and their "state"
 
-        Given the current implementation of NodeLeader there is no way
+        In the current implementation of NodeLeader there is no way
         to know which nodes are bad.
         """
         node = NodeLeader.Instance()
@@ -324,7 +324,7 @@ class JsonRpcApi(object):
             connected_peers.append("{}:{}".format(peer.host, peer.port))
 
         # "UnconnectedPeers" is never used. So a check is needed to
-        # verify a given address:port does not belong to a connect peer
+        # verify that a given address:port does not belong to a connected peer
         for peer in node.ADDRS:
             addr, port = peer.split(':')
             if peer not in connected_peers:

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -242,7 +242,7 @@ class JsonRpcApi(object):
             return self.validateaddress(params)
 
         elif method == "getpeers":
-            raise NotImplementedError()
+            return self.get_peers()
 
         raise JsonRpcError.methodNotFound()
 
@@ -307,3 +307,28 @@ class JsonRpcApi(object):
             pass
 
         return {"address": params[0], "isvalid": isValid}
+
+    def get_peers(self):
+        """Get all known nodes and their "state"
+
+        Given the current implementation of NodeLeader there is no way
+        to know which nodes are bad.
+        """
+        node = NodeLeader.Instance()
+        result = {"connected": [], "unconnected": [], "bad": []}
+        connected_peers = []
+
+        for peer in node.Peers:
+            result['connected'].append({"address": peer.host,
+                                        "port": peer.port})
+            connected_peers.append("{}:{}".format(peer.host, peer.port))
+
+        # "UnconnectedPeers" is never used. So a check is needed to
+        # verify a given address:port does not belong to a connect peer
+        for peer in node.ADDRS:
+            addr, port = peer.split(':')
+            if peer not in connected_peers:
+                result['unconnected'].append({"address": addr,
+                                              "port": int(port)})
+
+        return result

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -479,9 +479,6 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
 
-        print("===========")
-        print(res)
-
         self.assertEqual(len(node.Peers), len(res['result']['connected']))
         self.assertEqual(len(res['result']['unconnected']),
                          len(node.ADDRS) - len(node.Peers))

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -17,6 +17,8 @@ from neocore.UInt160 import UInt160
 from neocore.UInt256 import UInt256
 from neo.Blockchain import GetBlockchain
 from neo.Settings import settings
+from neo.Network.NodeLeader import NodeLeader
+from neo.Network.NeoNode import NeoNode
 
 
 def mock_request(body):
@@ -462,3 +464,27 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         except ValueError:
             valid_json = False
         self.assertTrue(valid_json)
+
+    def test_getpeers(self):
+        # Given this is an isolated environment and there is no peers
+        # lets simulate that at least some addresses are known
+        node = NodeLeader.Instance()
+        node.ADDRS = ["127.0.0.1:20333", "127.0.0.2:20334"]
+        test_node = NeoNode()
+        test_node.host = "127.0.0.1"
+        test_node.port = 20333
+        node.Peers.append(test_node)
+
+        req = self._gen_rpc_req("getpeers", params=[])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+
+        print("===========")
+        print(res)
+
+        self.assertEqual(len(node.Peers), len(res['result']['connected']))
+        self.assertEqual(len(res['result']['unconnected']),
+                         len(node.ADDRS) - len(node.Peers))
+        # To avoid messing up the next tests
+        node.Peers = []
+        node.ADDRS = []


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
According to issue #189, `getpeers` RPC method was not yet implemented. I added the possible functionality for it.
**How did you solve this problem?**
I added the functionality based on the methods used by the equivalent commands on the `prompt`.
**How did you make sure your solution works?**
Manually, plus automated tests 
**Are there any special changes in the code that we should be aware of?**
No
**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
