### PR TITLE
IsWalletTransaction fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.6.5-dev] in progress
 -----------------------
+- Fixed IsWalletTransaction to make it compare scripts in transactions to scripts (instead of scripthashes) in wallet contracts and scripthashes of transactions (instead of scripts) to scripthashes of watch-only addresses
 - Changed the ``eval()`` call when parsing the `--tx-attr` param to parse only json. Reduced the surface and options available on the other 2 eval calls to improve security.
 - fix wallet rebuild database lock errors (`PR #365 <https://github.com/CityOfZion/neo-python/pull/365>`_)
 - Fixed `synced_watch_only_balances` being always zero issue (`#209  <https://github.com/CityOfZion/neo-python/issues/209>`_)

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -796,7 +796,7 @@ class Wallet(object):
             for script in tx.scripts:
 
                 if script.VerificationScript:
-                    if bytes(contract.ScriptHash.Data) == script.VerificationScript:
+                    if bytes(contract.Script) == script.VerificationScript:
                         return True
 
         for watch_script_hash in self._watch_only:
@@ -804,7 +804,7 @@ class Wallet(object):
                 if output.ScriptHash == watch_script_hash:
                     return True
             for script in tx.scripts:
-                if script.VerificationScript == watch_script_hash.ToBytes():
+                if Crypto.ToScriptHash(script.VerificationScript, unhex=False) == watch_script_hash:
                     return True
 
         return False


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

In IsWalletTransaction in neo/Wallets/Wallet.py, as part of evaluating whether a transaction belongs to a wallet or not, neo-python is currently comparing the VerificationScript to all the contract scripthashes in the wallet. However this will never return true, because a scripthash is by definition a hash of a script so it has already gone through the hashing process before the comparison, even if they were the same scripts to start with. As a result, ```wallet verbose``` was not showing the complete set of transactions for added contract addresses and watch-only addresses (outbound transactions were missing)

**How did you solve this problem?**

Changed the comparisons to compare script to script for contracts, and scripthash to scripthash for watch_only addresses where we don't know what the original VerificationScript looks like.

**How did you make sure your solution works?**

Tested it manually on a local wallet

**Are there any special changes in the code that we should be aware of?**

No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
