### PR TITLE
RandomAccessStack performance improvements

### DIFF
--- a/neo/Core/TX/RegisterTransaction.py
+++ b/neo/Core/TX/RegisterTransaction.py
@@ -26,12 +26,12 @@ class RegisterTransaction(Transaction):
 
 In English:
          # Total number of releases, there are 2 modes:
-                  # 1. Limited amount: When Amount is positive, it means that the maximum amount of current assets is Amount and can not be modified (the equity may support the expansion or issuance in the future, will consider the need for company signature or a certain percentage of shareholder signature recognition ).
-                  # 2. Unlimited mode: When Amount is equal to -1, it means that the current asset can be issued by the creator unlimited. This mode of freedom is the largest, but the credibility of the lowest, not recommended.
-                  # In the use of the process, according to the different types of assets, can use the total amount of different models, the specific rules are as follows:
-                  # 1. For equity, use only limited models;
-                  # 2. For currencies, use only unlimited models;
-                  # 3. For point coupons, you can use any pattern;
+                                    # 1. Limited amount: When Amount is positive, it means that the maximum amount of current assets is Amount and can not be modified (the equity may support the expansion or issuance in the future, will consider the need for company signature or a certain percentage of shareholder signature recognition ).
+                                    # 2. Unlimited mode: When Amount is equal to -1, it means that the current asset can be issued by the creator unlimited. This mode of freedom is the largest, but the credibility of the lowest, not recommended.
+                                    # In the use of the process, according to the different types of assets, can use the total amount of different models, the specific rules are as follows:
+                                    # 1. For equity, use only limited models;
+                                    # 2. For currencies, use only unlimited models;
+                                    # 3. For point coupons, you can use any pattern;
 """
 
     def __init__(self, inputs=None,

--- a/neo/Core/TX/RegisterTransaction.py
+++ b/neo/Core/TX/RegisterTransaction.py
@@ -26,12 +26,12 @@ class RegisterTransaction(Transaction):
 
 In English:
          # Total number of releases, there are 2 modes:
-                                                                        # 1. Limited amount: When Amount is positive, it means that the maximum amount of current assets is Amount and can not be modified (the equity may support the expansion or issuance in the future, will consider the need for company signature or a certain percentage of shareholder signature recognition ).
-                                                                        # 2. Unlimited mode: When Amount is equal to -1, it means that the current asset can be issued by the creator unlimited. This mode of freedom is the largest, but the credibility of the lowest, not recommended.
-                                                                        # In the use of the process, according to the different types of assets, can use the total amount of different models, the specific rules are as follows:
-                                                                        # 1. For equity, use only limited models;
-                                                                        # 2. For currencies, use only unlimited models;
-                                                                        # 3. For point coupons, you can use any pattern;
+                                                                                                                                                # 1. Limited amount: When Amount is positive, it means that the maximum amount of current assets is Amount and can not be modified (the equity may support the expansion or issuance in the future, will consider the need for company signature or a certain percentage of shareholder signature recognition ).
+                                                                                                                                                # 2. Unlimited mode: When Amount is equal to -1, it means that the current asset can be issued by the creator unlimited. This mode of freedom is the largest, but the credibility of the lowest, not recommended.
+                                                                                                                                                # In the use of the process, according to the different types of assets, can use the total amount of different models, the specific rules are as follows:
+                                                                                                                                                # 1. For equity, use only limited models;
+                                                                                                                                                # 2. For currencies, use only unlimited models;
+                                                                                                                                                # 3. For point coupons, you can use any pattern;
 """
 
     def __init__(self, inputs=None,

--- a/neo/Core/TX/RegisterTransaction.py
+++ b/neo/Core/TX/RegisterTransaction.py
@@ -26,12 +26,12 @@ class RegisterTransaction(Transaction):
 
 In English:
          # Total number of releases, there are 2 modes:
-                                    # 1. Limited amount: When Amount is positive, it means that the maximum amount of current assets is Amount and can not be modified (the equity may support the expansion or issuance in the future, will consider the need for company signature or a certain percentage of shareholder signature recognition ).
-                                    # 2. Unlimited mode: When Amount is equal to -1, it means that the current asset can be issued by the creator unlimited. This mode of freedom is the largest, but the credibility of the lowest, not recommended.
-                                    # In the use of the process, according to the different types of assets, can use the total amount of different models, the specific rules are as follows:
-                                    # 1. For equity, use only limited models;
-                                    # 2. For currencies, use only unlimited models;
-                                    # 3. For point coupons, you can use any pattern;
+                                                                        # 1. Limited amount: When Amount is positive, it means that the maximum amount of current assets is Amount and can not be modified (the equity may support the expansion or issuance in the future, will consider the need for company signature or a certain percentage of shareholder signature recognition ).
+                                                                        # 2. Unlimited mode: When Amount is equal to -1, it means that the current asset can be issued by the creator unlimited. This mode of freedom is the largest, but the credibility of the lowest, not recommended.
+                                                                        # In the use of the process, according to the different types of assets, can use the total amount of different models, the specific rules are as follows:
+                                                                        # 1. For equity, use only limited models;
+                                                                        # 2. For currencies, use only unlimited models;
+                                                                        # 3. For point coupons, you can use any pattern;
 """
 
     def __init__(self, inputs=None,

--- a/neo/Implementations/Notifications/LevelDB/NotificationDB.py
+++ b/neo/Implementations/Notifications/LevelDB/NotificationDB.py
@@ -297,6 +297,8 @@ class NotificationDB():
         results = []
         for val in tokens_snapshot.iterator(include_key=False):
             event = SmartContractEvent.FromByteArray(val)
+            # for get_tokens calls, we dont want to send the whole script
+            event.contract.Code.Script = bytearray()
             results.append(event)
         return results
 

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -95,18 +95,7 @@ class NodeLeader():
 
     def SetupConnection(self, host, port, timeout=10):
         if len(self.Peers) < settings.CONNECTED_PEER_MAX:
-            #            factory = Factory.forProtocol(NeoNode)
-            #            factory = ReconnectingClientFactory.forProtocol(NeoNode)
-            #            factory.ma
-            factory = NeoClientFactory()
-            endpoint = clientFromString(reactor, "tcp:host=%s:port=%s:timeout=%s" % (host, port, timeout))
-
-            connectingService = ClientService(
-                endpoint,
-                factory,
-                retryPolicy=backoffPolicy(.5, factor=3.0)
-            )
-            connectingService.startService()
+            reactor.connectTCP(host, int(port), NeoClientFactory())
 
     def OnUpdatedMaxPeers(self, old_value, new_value):
         if new_value < old_value:

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -96,7 +96,7 @@ class NodeLeader():
             connectingService = ClientService(
                 endpoint,
                 factory,
-                retryPolicy=backoffPolicy(2, 10, factor=3.0)
+                retryPolicy=backoffPolicy(.5,factor=3.0)
             )
             connectingService.startService()
 

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -101,6 +101,8 @@ class SettingsHolder:
     USE_DEBUG_STORAGE = False
     DEBUG_STORAGE_PATH = 'Chains/debugstorage'
 
+    CONNECTED_PEER_MAX = 5
+
     VERSION_NAME = "/NEO-PYTHON:%s/" % __version__
 
     # Logging settings
@@ -231,6 +233,12 @@ class SettingsHolder:
             self.DATA_DIR_PATH = os.getcwd()
         else:
             self.DATA_DIR_PATH = path
+
+    def set_max_peers(self, num_peers):
+        try:
+            self.CONNECTED_PEER_MAX = int(num_peers)
+        except Exception as e:
+            logzero.logger.error("Please supply an integer number for max peers")
 
     def set_log_smart_contract_events(self, is_enabled=True):
         self.log_smart_contract_events = is_enabled

--- a/neo/VM/RandomAccessStack.py
+++ b/neo/VM/RandomAccessStack.py
@@ -4,16 +4,18 @@ from neo.VM.InteropService import StackItem
 class RandomAccessStack():
 
     _list = []
+    _size = 0  # cache the size for performance
 
     _name = 'Stack'
 
     def __init__(self, name='Stack'):
         self._list = []
+        self._size = 0
         self._name = name
 
     @property
     def Count(self):
-        return len(self._list)
+        return self._size
 
     @property
     def Items(self):
@@ -21,6 +23,7 @@ class RandomAccessStack():
 
     def Clear(self):
         self._list = []
+        self._size = 0
 
     def GetEnumerator(self):
         return enumerate(self._list)
@@ -28,18 +31,19 @@ class RandomAccessStack():
     def Insert(self, index, item):
         index = int(index)
 
-        if index < 0 or index > self.Count:
+        if index < 0 or index > self._size:
             raise Exception("Invalid list operation")
 
         self._list.insert(index, item)
+        self._size += 1
 
     # @TODO can be optimized
     def Peek(self, index=0):
         index = int(index)
-        if index >= self.Count:
+        if index >= self._size:
             raise Exception("Invalid list operation")
 
-        return self._list[self.Count - 1 - index]
+        return self._list[self._size - 1 - index]
 
     def Pop(self):
         #        self.PrintList("POPSTACK <- ")
@@ -50,25 +54,27 @@ class RandomAccessStack():
             item = StackItem.New(item)
 
         self._list.append(item)
+        self._size += 1
 
     # @TODO can be optimized
     def Remove(self, index):
         index = int(index)
 
-        if index < 0 or index >= self.Count:
+        if index < 0 or index >= self._size:
             raise Exception("Invalid list operation")
 
-        item = self._list.pop(self.Count - 1 - index)
+        item = self._list.pop(self._size - 1 - index)
+        self._size -= 1
 
         return item
 
     def Set(self, index, item):
         index = int(index)
 
-        if index < 0 or index > self.Count:
+        if index < 0 or index > self._size:
             raise Exception("Invalid list operation")
 
         if not type(item) is StackItem and not issubclass(type(item), StackItem):
             item = StackItem.New(item)
 
-        self._list[self.Count - index - 1] = item
+        self._list[self._size - index - 1] = item

--- a/neo/api/REST/RestApi.py
+++ b/neo/api/REST/RestApi.py
@@ -228,7 +228,7 @@ class RestApi(object):
         notifications = notifications[start:end]
 
         return json.dumps({
-            'current_height': Blockchain.Default().Height,
+            'current_height': Blockchain.Default().Height + 1,
             'message': message,
             'total': notif_len,
             'results': None if show_none else [n.ToJson() for n in notifications],
@@ -238,7 +238,7 @@ class RestApi(object):
 
     def format_message(self, message):
         return json.dumps({
-            'current_height': Blockchain.Default().Height,
+            'current_height': Blockchain.Default().Height + 1,
             'message': message,
             'total': 0,
             'results': None,

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -112,6 +112,9 @@ def main():
     # Where to store stuff
     parser.add_argument("--datadir", action="store",
                         help="Absolute path to use for database directories")
+    # peers
+    parser.add_argument("--maxpeers", action="store", default=5,
+                        help="Max peers to use for P2P Joining")
 
     # Now parse
     args = parser.parse_args()
@@ -146,6 +149,8 @@ def main():
 
     if args.datadir:
         settings.set_data_dir(args.datadir)
+    if args.maxpeers:
+        settings.set_max_peers(args.maxpeers)
 
     if args.syslog or args.syslog_local is not None:
         # Setup the syslog facility

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -112,6 +112,7 @@ class PromptInterface(object):
                 'state',
                 'config debug {on/off}',
                 'config sc-events {on/off}',
+                'config maxpeers {num_peers}',
                 'build {path/to/file.py} (test {params} {returntype} {needs_storage} {needs_dynamic_invoke} {test_params})',
                 'load_run {path/to/file.avm} (test {params} {returntype} {needs_storage} {needs_dynamic_invoke} {test_params})',
                 'import wif {wif}',
@@ -605,7 +606,7 @@ class PromptInterface(object):
 
     def show_nodes(self):
         if len(NodeLeader.Instance().Peers) > 0:
-            out = ""
+            out = "Total Connected: %s " % len(NodeLeader.Instance().Peers)
             for peer in NodeLeader.Instance().Peers:
                 out += "Peer %s - IO: %s\n" % (peer.Name(), peer.IOStats())
             print_tokens([(Token.Number, out)], self.token_style)
@@ -897,6 +898,20 @@ class PromptInterface(object):
             else:
                 print("Cannot configure VM instruction logging. Please specify on|off")
 
+        elif what == 'maxpeers':
+            try:
+                c1 = int(get_arg(args, 1).lower())
+                num_peers = int(c1)
+                if num_peers > 0:
+                    old_max_peers = settings.CONNECTED_PEER_MAX
+                    settings.set_max_peers(num_peers)
+                    NodeLeader.Instance().OnUpdatedMaxPeers(old_max_peers, num_peers)
+                    print("set max peers to %s " % num_peers)
+                else:
+                    print("Please specify integer greater than zero")
+            except Exception as e:
+                print("Cannot configure max peers. Please specify an integer greater than 0")
+
         else:
             print(
                 "Cannot configure %s try 'config sc-events on|off', 'config debug on|off', 'config sc-debug-notify on|off' or 'config vm-log on|off'" % what)
@@ -1026,6 +1041,10 @@ def main():
     parser.add_argument("--datadir", action="store",
                         help="Absolute path to use for database directories")
 
+    # peers
+    parser.add_argument("--maxpeers", action="store", default=5,
+                        help="Max peers to use for P2P Joining")
+
     # Show the neo-python version
     parser.add_argument("--version", action="version",
                         version="neo-python v{version}".format(version=__version__))
@@ -1055,6 +1074,9 @@ def main():
     if args.datadir:
         settings.set_data_dir(args.datadir)
 
+    if args.maxpeers:
+        settings.set_max_peers(args.maxpeers)
+
     # Instantiate the blockchain and subscribe to notifications
     blockchain = LevelDBBlockchain(settings.chain_leveldb_path)
     Blockchain.RegisterBlockchain(blockchain)
@@ -1067,7 +1089,7 @@ def main():
     cli = PromptInterface()
 
     # Run things
-    reactor.suggestThreadPoolSize(15)
+#    reactor.suggestThreadPoolSize(15)
     reactor.callInThread(cli.run)
     NodeLeader.Instance().Start()
 

--- a/neo/data/protocol.mainnet.json
+++ b/neo/data/protocol.mainnet.json
@@ -15,6 +15,12 @@
       "13.58.252.110:10333",
       "18.216.146.68:10333",
       "172.31.4.71:10333",
+      "172.31.1.3:10333",
+      "172.31.4.218:10333",
+      "seed1.redupulse.com:10333",
+      "seed2.redupulse.com:10333",
+      "seed7.bridgeprotocol.io:10333",
+      "seed8.bridgeprotocol.io:10333",
       "seed1.neo.org:10333",
       "seed2.neo.org:10333",
       "seed3.neo.org:10333"


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Addressing major performance bottleneck in `RandomAccessStack`.

**How did you solve this problem?**

Implemented a `_size` cache so that the size of the list doesn't have to be calculated all the time.

**How did you make sure your solution works?**

`make test`. Tested it on our production neo-python node. Compared `cProfile` outputs before and after. The `len()` bottleneck disappeared. Performance was noticeably better, but there are definitely still spikes of 100% CPU, so more iterations needed.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
