### PR TITLE
#375 Exception during Contract.Migrate

### DIFF
--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -396,7 +396,7 @@ class StateMachine(StateReader):
 
             self._contracts.Add(hash.ToBytes(), contract)
 
-            self._contracts_created[hash.ToBytes()] = UInt160(data=engine.CurrentContext.ScriptHash)
+            self._contracts_created[hash.ToBytes()] = UInt160(data=engine.CurrentContext.ScriptHash())
 
             if contract.HasStorage:
 


### PR DESCRIPTION
Tested it with my testnet and it works fine after the fix. i could see all the data that was in old-contract in the new-contract and the old-contract was also dropped.