### PR TITLE
Development

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ All notable changes to this project are documented in this file.
 
 [0.6.8-dev] in progress
 -----------------------
+- fixed sc-events and notification DB showing previous block height instead of final block height of event
+- persist refund() notify events in notification DB
 
 
 [0.6.7] 2018-04-06

--- a/neo/Implementations/Notifications/LevelDB/NotificationDB.py
+++ b/neo/Implementations/Notifications/LevelDB/NotificationDB.py
@@ -117,8 +117,9 @@ class NotificationDB():
         if not isinstance(sc_event, NotifyEvent):
             logger.info("Not Notify Event instance")
             return
-        if sc_event.ShouldPersist and sc_event.notify_type == NotifyType.TRANSFER:
-            self._events_to_write.append(sc_event)
+        if sc_event.ShouldPersist:
+            if sc_event.notify_type == NotifyType.TRANSFER or sc_event.notify_type == NotifyType.REFUND:
+                self._events_to_write.append(sc_event)
 
     def on_persist_completed(self, block):
         """

--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -340,7 +340,7 @@ class StateMachine(StateReader):
 
         self.events_to_dispatch.append(
             SmartContractEvent(SmartContractEvent.CONTRACT_CREATED, [contract],
-                               hash, Blockchain.Default().Height,
+                               hash, Blockchain.Default().Height + 1,
                                engine.ScriptContainer.Hash if engine.ScriptContainer else None,
                                test_mode=engine.testMode))
         return True
@@ -410,7 +410,7 @@ class StateMachine(StateReader):
 
         self.events_to_dispatch.append(
             SmartContractEvent(SmartContractEvent.CONTRACT_MIGRATED, [contract],
-                               hash, Blockchain.Default().Height,
+                               hash, Blockchain.Default().Height + 1,
                                engine.ScriptContainer.Hash if engine.ScriptContainer else None,
                                test_mode=engine.testMode))
 
@@ -452,7 +452,7 @@ class StateMachine(StateReader):
 
         self.events_to_dispatch.append(
             SmartContractEvent(SmartContractEvent.CONTRACT_DESTROY, [contract],
-                               hash, Blockchain.Default().Height,
+                               hash, Blockchain.Default().Height + 1,
                                engine.ScriptContainer.Hash if engine.ScriptContainer else None,
                                test_mode=engine.testMode))
         return True
@@ -498,7 +498,7 @@ class StateMachine(StateReader):
 
         self.events_to_dispatch.append(
             SmartContractEvent(SmartContractEvent.STORAGE_GET, ['%s -> %s' % (keystr, valStr)],
-                               context.ScriptHash, Blockchain.Default().Height,
+                               context.ScriptHash, Blockchain.Default().Height + 1,
                                engine.ScriptContainer.Hash if engine.ScriptContainer else None,
                                test_mode=engine.testMode))
 
@@ -540,7 +540,7 @@ class StateMachine(StateReader):
 
         self.events_to_dispatch.append(
             SmartContractEvent(SmartContractEvent.STORAGE_PUT, ['%s -> %s' % (keystr, valStr)],
-                               context.ScriptHash, Blockchain.Default().Height,
+                               context.ScriptHash, Blockchain.Default().Height + 1,
                                engine.ScriptContainer.Hash if engine.ScriptContainer else None,
                                test_mode=engine.testMode))
 
@@ -561,7 +561,7 @@ class StateMachine(StateReader):
             keystr = Crypto.ToAddress(UInt160(data=key))
 
             self.events_to_dispatch.append(SmartContractEvent(SmartContractEvent.STORAGE_DELETE, [keystr],
-                                                              context.ScriptHash, Blockchain.Default().Height,
+                                                              context.ScriptHash, Blockchain.Default().Height + 1,
                                                               engine.ScriptContainer.Hash if engine.ScriptContainer else None,
                                                               test_mode=engine.testMode))
 

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -180,7 +180,7 @@ class StateReader(InteropService):
 
     def ExecutionCompleted(self, engine, success, error=None):
 
-        height = Blockchain.Default().Height
+        height = Blockchain.Default().Height + 1
         tx_hash = None
 
         if engine.ScriptContainer:
@@ -297,7 +297,7 @@ class StateReader(InteropService):
         if settings.emit_notify_events_on_sc_execution_error:
             # emit Notify events even if the SC execution might fail.
             tx_hash = engine.ScriptContainer.Hash
-            height = Blockchain.Default().Height
+            height = Blockchain.Default().Height + 1
             success = None
             self.events_to_dispatch.append(NotifyEvent(SmartContractEvent.RUNTIME_NOTIFY, args.State,
                                                        args.ScriptHash, height, tx_hash,
@@ -320,7 +320,7 @@ class StateReader(InteropService):
         self.events_to_dispatch.append(SmartContractEvent(SmartContractEvent.RUNTIME_LOG,
                                                           [message],
                                                           hash,
-                                                          Blockchain.Default().Height,
+                                                          Blockchain.Default().Height + 1,
                                                           tx_hash,
                                                           test_mode=engine.testMode))
 
@@ -896,6 +896,6 @@ class StateReader(InteropService):
             engine.EvaluationStack.PushT(bytearray(0))
 
         self.events_to_dispatch.append(SmartContractEvent(SmartContractEvent.STORAGE_GET, ['%s -> %s' % (keystr, valStr)],
-                                                          context.ScriptHash, Blockchain.Default().Height, engine.ScriptContainer.Hash, test_mode=engine.testMode))
+                                                          context.ScriptHash, Blockchain.Default().Height + 1, engine.ScriptContainer.Hash, test_mode=engine.testMode))
 
         return True


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
The notification DB were showing the previous block height instead of the actual block height the notification tx was part of. Also, refund() notifications were not being persisted in the notification DB, which would be useful information for anyone running a token crowdsale.

**How did you solve this problem?**
I added a check for NotifyType.REFUND to the notification DB persist code, and incremented the block height argument value by one when creating SmartContractEvents in the StateReader/StateMachine code.

**How did you make sure your solution works?**
Ran np-prompt for a while on mainnet and manually compared reported event block heights with the height of the reported transaction, also cross-checking against stored notifications for that block to make sure height was properly persisted matching the transaction height as well.

**Are there any special changes in the code that we should be aware of?**
No, but the *_Notif bootstrap files should probably be rebuilt after merging so that event block heights will be correctly stored for historical events

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
