### PR TITLE
Fix for deleted NEP-5 tokens persisting in wallet file after re-open

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.6.8-dev] in progress
 -----------------------
+- fix for token_delete command not removing tokens from wallet file
 - fixed sc-events and notification DB showing previous block height instead of final block height of event
 - persist refund() notify events in notification DB
 

--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -480,16 +480,17 @@ class UserWallet(Wallet):
 
         return jsn
 
-    def DeleteNEP5Token(self, token):
+    def DeleteNEP5Token(self, script_hash):
 
-        success = super(UserWallet, self).DeleteNEP5Token(token)
+        token = super(UserWallet, self).DeleteNEP5Token(script_hash)
 
         try:
             db_token = NEP5Token.get(ContractHash=token.ScriptHash.ToBytes())
             db_token.delete_instance()
         except Exception as e:
-            pass
-        return success
+            return False
+
+        return True
 
     def DeleteAddress(self, script_hash):
         success, coins_toremove = super(UserWallet, self).DeleteAddress(script_hash)

--- a/neo/Implementations/Wallets/peewee/test_user_wallet.py
+++ b/neo/Implementations/Wallets/peewee/test_user_wallet.py
@@ -150,13 +150,13 @@ class UserWalletTestCase(WalletFixtureTestCase):
 
         wallet.AddNEP5Token(token)
 
-        wallet = self.GetWallet1(recreate=True) # re-open wallet
+        wallet = self.GetWallet1(recreate=True)  # re-open wallet
 
         self.assertEqual(len(wallet.GetTokens()), 1)
 
         wallet.DeleteNEP5Token(token.ScriptHash)
 
-        wallet = self.GetWallet1(recreate=True) # re-open wallet
+        wallet = self.GetWallet1(recreate=True)  # re-open wallet
 
         self.assertEqual(len(wallet.GetTokens()), 0)
 

--- a/neo/Implementations/Wallets/peewee/test_user_wallet.py
+++ b/neo/Implementations/Wallets/peewee/test_user_wallet.py
@@ -150,7 +150,15 @@ class UserWalletTestCase(WalletFixtureTestCase):
 
         wallet.AddNEP5Token(token)
 
+        wallet = self.GetWallet1(recreate=True) # re-open wallet
+
         self.assertEqual(len(wallet.GetTokens()), 1)
+
+        wallet.DeleteNEP5Token(token.ScriptHash)
+
+        wallet = self.GetWallet1(recreate=True) # re-open wallet
+
+        self.assertEqual(len(wallet.GetTokens()), 0)
 
     def test_8_named_addr(self):
 

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -199,7 +199,7 @@ class Wallet(object):
             token (UInt160): Token Contract script hash
 
         Returns:
-            bool: success status.
+            NEP5Token: the token object removed from the wallet
         """
         return self._tokens.pop(script_hash.ToBytes())
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
When using the `wallet delete_token` command, tokens were removed from the in-memory wallet object but remained in the wallet file, appearing again in memory after the wallet was closed and re-opened. This is because the DeleteNEP5Token function is passed a scripthash instead of a token object, and the wallet db query fails silently while trying to dereference the scripthash from the non-existent object.

**How did you solve this problem?**
I changed the code to pass the NEP5Token object to the db Get function, as a copy was conveniently available as the return from the `super` call right above it.

**How did you make sure your solution works?**
Tested it manually and also modified the existing import_token unit test to verify both importing and removal of a token from a wallet file

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
