### PR TITLE
removing all occurrences of: "# -*- coding:utf-8 -*-"

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # neo-boa documentation build configuration file, created by
 # sphinx-quickstart on Tue Oct 17 18:58:03 2017.

--- a/neo/Core/AssetType.py
+++ b/neo/Core/AssetType.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     Asset Type in neo

--- a/neo/Core/CoinReference.py
+++ b/neo/Core/CoinReference.py
@@ -1,5 +1,3 @@
-# -*- coding: UTF-8 -*-
-
 import sys
 
 

--- a/neo/Core/Header.py
+++ b/neo/Core/Header.py
@@ -1,5 +1,3 @@
-# -*- coding: UTF-8 -*-
-
 from neo.Core.BlockBase import BlockBase
 from neocore.IO.BinaryReader import BinaryReader
 from neo.IO.MemoryStream import StreamManager

--- a/neo/Core/Mixins.py
+++ b/neo/Core/Mixins.py
@@ -1,5 +1,3 @@
-# -*- coding: UTF-8 -*-
-
 from neocore.IO.Mixins import SerializableMixin
 
 

--- a/neo/Core/TX/IssueTransaction.py
+++ b/neo/Core/TX/IssueTransaction.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     Issue Transaction

--- a/neo/Core/TX/RegisterTransaction.py
+++ b/neo/Core/TX/RegisterTransaction.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     Register Transaction

--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     Transaction Basic Class

--- a/neo/Core/TX/TransactionAttribute.py
+++ b/neo/Core/TX/TransactionAttribute.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     Transaction Attribute

--- a/neo/IO/MemoryStream.py
+++ b/neo/IO/MemoryStream.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     MemoryStream

--- a/neo/Implementations/Blockchains/RPC/RpcBlockchain.py
+++ b/neo/Implementations/Blockchains/RPC/RpcBlockchain.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     RpcBlockchain Methods

--- a/neo/Network/InventoryType.py
+++ b/neo/Network/InventoryType.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     Inventory Type

--- a/neo/SmartContract/Contract.py
+++ b/neo/SmartContract/Contract.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     Contract class in neo.Wallets

--- a/neo/SmartContract/ContractParameterType.py
+++ b/neo/SmartContract/ContractParameterType.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     Contract Parameter Type in neo.Wallets

--- a/neo/VM/ScriptBuilder.py
+++ b/neo/VM/ScriptBuilder.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     ScriptBuilder in neo, to create scripts

--- a/neo/Wallets/Coin.py
+++ b/neo/Wallets/Coin.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     define the data struct of coin

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -1,4 +1,3 @@
-# -*- coding:utf-8 -*-
 """
 Description:
     Wallet

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 """The setup script."""
 
 from setuptools import setup, find_packages


### PR DESCRIPTION
This header string was introduced in PEP 263 for python version 2.3 in 2001, in order to be able to put non-ascii character is a python source file. Since UTF-8 is the default source encoding
in Python 3 (PEP 3120), this string is redundant 