### PR TITLE
Support pip version 10.0 and greater

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -236,3 +236,4 @@ All notable changes to this project are documented in this file.
 - added additional SC Api ( ``Neo.Runtime.GetTime``, ``Neo.Transaction.GetUnspentCoins``, ``Neo.Header.GetIndex``)
 - added support for dynamically defined smart contract execution
 - added ability to alias an address in the wallet
+- added support for pip versions >= 10.0

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,12 @@
 """The setup script."""
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
-from pip.download import PipSession
+try:  # pip version >= 10.0
+    from pip._internal.req import parse_requirements
+    from pip._internal.download import PipSession
+except ImportError:  # pip version < 10.0
+    from pip.req import parse_requirements
+    from pip.download import PipSession
 
 
 with open('README.rst') as readme_file:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
`setup.py` currently fails with pip version >= 10.0

**How did you solve this problem?**
Add code for correct import path in pip verisons >= 10.0

**How did you make sure your solution works?**
```python
pip install pip==10.0
python ./setup.py  # no import error in branch, fails on development/master

pip install pip==9.0.3
python ./setup.py  # no import error in branch, successful on development/master
```

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [ ] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
