### PR TITLE
replace "from peewee import *" to explicit imports in Models.py and P…

### DIFF
--- a/neo/Implementations/Wallets/peewee/Models.py
+++ b/neo/Implementations/Wallets/peewee/Models.py
@@ -1,5 +1,5 @@
 
-from peewee import *
+from peewee import Model, PrimaryKeyField, CharField, BooleanField, ForeignKeyField, IntegerField, DateTimeField
 from .PWDatabase import PWDatabase
 from neocore.Cryptography.Crypto import Crypto
 from neocore.UInt256 import UInt256

--- a/neo/Implementations/Wallets/peewee/PWDatabase.py
+++ b/neo/Implementations/Wallets/peewee/PWDatabase.py
@@ -1,5 +1,5 @@
 import logging
-from peewee import *
+from peewee import Proxy, SqliteDatabase
 from logzero import logger
 
 logger = logging.getLogger('peewee')


### PR DESCRIPTION
"import *" has the adverse effect of polluting the file namespace ("from peewee import *" imports more than 200 names)