### PR TITLE
Feature add map serialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ All notable changes to this project are documented in this file.
 - fix for token_delete command not removing tokens from wallet file
 - fixed sc-events and notification DB showing previous block height instead of final block height of event
 - persist refund() notify events in notification DB
-
+- add Runtime.Serialize/Deserialize support for MAP
 
 [0.6.7] 2018-04-06
 -----------------------

--- a/neo/VM/tests/test_interop_serialize.py
+++ b/neo/VM/tests/test_interop_serialize.py
@@ -170,6 +170,36 @@ class InteropSerializeDeserializeTestCase(TestCase):
         deserialized = self.engine.EvaluationStack.Pop()
         self.assertEqual(deserialized.GetBigInteger(), 0)
 
+    def test_serialize_map(self):
+        map2 = Map({
+            StackItem.New(b'a'): StackItem.New(1),
+            StackItem.New(b'b'): StackItem.New(2),
+            StackItem.New(b'c'): StackItem.New(3),
+        })
+
+        self.engine.EvaluationStack.PushT(map2)
+
+        self.state_reader.Runtime_Serialize(self.engine)
+        self.state_reader.Runtime_Deserialize(self.engine)
+
+        deserialized = self.engine.EvaluationStack.Pop()
+        self.assertEqual(deserialized, map2)
+
+        map3 = Map({
+            StackItem.New(b'j'): StackItem.New(8),
+            StackItem.New(b'k'): StackItem.New(2222),
+        })
+
+        map2.SetItem(StackItem.New(b'mymap'), map3)
+
+        self.engine.EvaluationStack.PushT(map2)
+
+        self.state_reader.Runtime_Serialize(self.engine)
+        self.state_reader.Runtime_Deserialize(self.engine)
+
+        deserialized = self.engine.EvaluationStack.Pop()
+        self.assertEqual(deserialized, map2)
+
     @patch('logzero.logger.error')
     def test_cant_serialize_iop_item(self, mocked_logger):
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- add ability for VM to serialize and deserialize MAP objects
- brings feature parity with C# node according to this: https://github.com/neo-project/neo/pull/215

**How did you solve this problem?**
- code

**How did you make sure your solution works?**
- added tests

**Are there any special changes in the code that we should be aware of?**
- no

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
