### PR TITLE
add VERIFY opcode to execution engine

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - persist refund() notify events in notification DB
 - add Runtime.Serialize/Deserialize support for MAP
 - fix for debug breakpoints not being cleared.
+- add VERIFY op to ExecutionEngine
 
 [0.6.7] 2018-04-06
 -----------------------

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -589,16 +589,23 @@ class ExecutionEngine():
 
                 pubkey = estack.Pop().GetByteArray()
                 sig = estack.Pop().GetByteArray()
-
                 try:
-
                     res = self.Crypto.VerifySignature(self.ScriptContainer.GetMessage(), sig, pubkey)
                     estack.PushT(res)
-
                 except Exception as e:
                     estack.PushT(False)
                     logger.error("Could not checksig: %s " % e)
-                return
+
+            elif opcode == VERIFY:
+                pubkey = estack.Pop().GetByteArray()
+                sig = estack.Pop().GetByteArray()
+                message = estack.Pop().GetString()
+                try:
+                    res = self.Crypto.VerifySignature(message, sig, pubkey)
+                    estack.PushT(res)
+                except Exception as e:
+                    estack.PushT(False)
+                    logger.error("Could not checksig: %s " % e)
 
             elif opcode == CHECKMULTISIG:
 

--- a/neo/VM/OpCode.py
+++ b/neo/VM/OpCode.py
@@ -183,6 +183,7 @@ SHA256 = b'\xA8'  # The input is hashed using SHA-256.
 HASH160 = b'\xA9'
 HASH256 = b'\xAA'
 CHECKSIG = b'\xAC'
+VERIFY = b'\xAD'
 CHECKMULTISIG = b'\xAE'
 
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- add VERIFY opcode to allow arbitrary verification of pubkey, sig, message 
- brings VM into feature parity with this https://github.com/neo-project/neo-vm/pull/38

**How did you solve this problem?**
- updated ExecutionEngine

**How did you make sure your solution works?**
- added test

**Are there any special changes in the code that we should be aware of?**
- no
**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
