### PR TITLE
Fixing Contact.Migrate by storing state prefixed with contract script…

### DIFF
--- a/neo/Core/State/StorageKey.py
+++ b/neo/Core/State/StorageKey.py
@@ -46,6 +46,9 @@ class StorageKey(SerializableMixin):
         bigint = BigInteger(self.GetHashCode())
         return bigint.ToByteArray()
 
+    def GetPrefixedKey(self):
+        return self.ScriptHash.ToBytes() + self.Key
+
     def Deserialize(self, reader):
         """
         Deserialize full object.

--- a/neo/Implementations/Blockchains/LevelDB/DBCollection.py
+++ b/neo/Implementations/Blockchains/LevelDB/DBCollection.py
@@ -144,6 +144,9 @@ class DBCollection():
 
         return None
 
+    def DeserializeFromDB(self, buffer):
+        return self.ClassRef.DeserializeFromDB(binascii.unhexlify(buffer))
+
     def Add(self, keyval, item):
         self.Collection[keyval] = item
         self.MarkChanged(keyval)
@@ -161,6 +164,7 @@ class DBCollection():
         key_prefix = self.Prefix + key_prefix
         res = []
         for key, val in self.DB.iterator(prefix=key_prefix):
+            val = self.DeserializeFromDB(val)
             res.append({key: val})
         return res
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Currently Contract.Migrate does not work on neo-python. My change fixes it.

**How did you solve this problem?**
I added the contract script hash as a prefix to storage keys so they can be migrated to the newly created contract.

**How did you make sure your solution works?**
Tested locally by implementing a Migrate feature to a smart contract

**Are there any special changes in the code that we should be aware of?**
The new type of keys for storage might impact performance.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
