### PR TITLE
Blockchain Persist performance tweak

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ All notable changes to this project are documented in this file.
 - add Runtime.Serialize/Deserialize support for MAP
 - fix for debug breakpoints not being cleared.
 - add VERIFY op to ExecutionEngine
+- add caching to systemshare and systemcoin creation to help in block persistence.
 
 [0.6.7] 2018-04-06
 -----------------------

--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -17,6 +17,7 @@ from collections import Counter
 from neocore.Fixed8 import Fixed8
 from neocore.Cryptography.ECCurve import ECDSA
 from neocore.UInt256 import UInt256
+from functools import lru_cache
 
 
 class Blockchain(object):
@@ -58,6 +59,7 @@ class Blockchain(object):
         return Blockchain.__validators
 
     @staticmethod
+    @lru_cache(maxsize=2)
     def SystemShare():
         """
         Register AntShare.
@@ -73,6 +75,7 @@ class Blockchain(object):
                                    amount, 0, owner, admin)
 
     @staticmethod
+    @lru_cache(maxsize=2)
     def SystemCoin():
         """
         Register AntCoin


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
The `Persist()` call in `LevelDBBlockchain.py` loops over the inputs and unnecessary recalculates the `systemshare` every time

https://github.com/CityOfZion/neo-python/blob/ea794abbf941638fbe957d511614f3d66a7c2ef1/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py#L677


**How did you solve this problem?**
add a small cache
**Before**
> (venv) Eriks-Air:neo-python erik$ python -m timeit -s 'from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain' 'LevelDBBlockchain.SystemShare().Hash.ToBytes()'
10000 loops, best of 3: 130 usec per loop

**After**
> (venv) Eriks-Air:neo-python erik$ python -m timeit -s 'from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain' 'LevelDBBlockchain.SystemShare().Hash.ToBytes()'
100000 loops, best of 3: 3.01 usec per loop

**How did you make sure your solution works?**
`timeit` test

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
