### PR TITLE
Fix rounding error for small amounts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ All notable changes to this project are documented in this file.
 - add Runtime.Serialize/Deserialize support for MAP
 - fix for debug breakpoints not being cleared.
 - add VERIFY op to ExecutionEngine
+- fix asset amount rounding for very small amounts
 
 [0.6.7] 2018-04-06
 -----------------------

--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 
 
 def token_send(wallet, args, prompt_passwd=True):
-
     if len(args) != 4:
         print("please provide a token symbol, from address, to address, and amount")
         return False
@@ -61,7 +60,6 @@ def token_send_from(wallet, args, prompt_passwd=True):
 
 
 def token_approve_allowance(wallet, args, prompt_passwd=True):
-
     if len(args) != 4:
         print("please provide a token symbol, from address, to address, and amount")
         return False
@@ -95,7 +93,6 @@ def token_approve_allowance(wallet, args, prompt_passwd=True):
 
 
 def token_get_allowance(wallet, args, verbose=False):
-
     if len(args) != 3:
         print("please provide a token symbol, from address, to address")
         return
@@ -120,7 +117,6 @@ def token_get_allowance(wallet, args, verbose=False):
 
 
 def token_mint(wallet, args, prompt_passwd=True):
-
     token = get_asset_id(wallet, args[0])
     mint_to_addr = args[1]
 
@@ -185,7 +181,6 @@ def token_crowdsale_register(wallet, args, prompt_passwd=True):
 
 
 def do_token_transfer(token, wallet, from_address, to_address, amount, prompt_passwd=True):
-
     if from_address is None:
         print("Please specify --from-addr={addr} to send NEP5 tokens")
         return False
@@ -214,15 +209,13 @@ def do_token_transfer(token, wallet, from_address, to_address, amount, prompt_pa
 
 
 def amount_from_string(token, amount_str):
-
     precision_mult = pow(10, token.decimals)
-    amount = float(amount_str) * precision_mult
+    amount = Decimal(amount_str) * precision_mult
 
     return int(amount)
 
 
 def string_from_amount(token, amount):
-
     precision_mult = pow(10, token.decimals)
     amount = Decimal(amount) / Decimal(precision_mult)
     formatter_str = '.%sf' % token.decimals


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
when sending tokens the `amount` argument has a rounding error

```
neo> wallet tkn_send PCG1 AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y AZQyxPDwXhiNyvzXx6sLyW1LcbotpeQjp1 0.00000012
Used 3.353 Gas

-----------------------------------------------------------
Will transfer 0.00000011 PCG1 from AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y to AZQyxPDwXhiNyvzXx6sLyW1LcbotpeQjp1
Transfer fee: 0.0001
-------------------------------------------------------------
```
Note the value difference in "will transfer" from what is specified on the cli

**How did you solve this problem?**
use the `Decimal` class instead of `float`.

**How did you make sure your solution works?**
manual testing

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
