### PR TITLE
fix StateReader.Blockchain_GetContract/GetAsset to bring in line with c#

### DIFF
--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -481,7 +481,8 @@ class StateReader(InteropService):
 
         if Blockchain.Default() is not None:
             asset = Blockchain.Default().GetAssetState(UInt256(data=data))
-
+        if asset is None:
+            return False
         engine.EvaluationStack.PushT(StackItem.FromInterface(asset))
         return True
 
@@ -491,7 +492,8 @@ class StateReader(InteropService):
 
         if Blockchain.Default() is not None:
             contract = Blockchain.Default().GetContract(hash)
-
+        if contract is None:
+            return False
         engine.EvaluationStack.PushT(StackItem.FromInterface(contract))
         return True
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- bring implementation into line with c# ( https://github.com/neo-project/neo/blob/master/neo/SmartContract/StateReader.cs#L485)

**How did you solve this problem?**
- change code

**How did you make sure your solution works?**
- ran tests

**Are there any special changes in the code that we should be aware of?**
- no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
