### PR TITLE
Remove redundant inheritance from object and redundant empty inheritance parentheses 

### DIFF
--- a/neo/Core/AssetType.py
+++ b/neo/Core/AssetType.py
@@ -6,7 +6,7 @@ Usage:
 """
 
 
-class AssetType(object):
+class AssetType:
     CreditFlag = 0x40
     DutyFlag = 0x80
 

--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -20,7 +20,7 @@ from neocore.UInt256 import UInt256
 from functools import lru_cache
 
 
-class Blockchain(object):
+class Blockchain:
     SECONDS_PER_BLOCK = 15
 
     DECREMENT_INTERVAL = 2000000

--- a/neo/Core/CoinReference.py
+++ b/neo/Core/CoinReference.py
@@ -1,7 +1,7 @@
 import sys
 
 
-class CoinReference(object):
+class CoinReference:
     PrevHash = None
 
     PrevIndex = None

--- a/neo/Core/Helper.py
+++ b/neo/Core/Helper.py
@@ -12,7 +12,7 @@ from neo.Settings import settings
 from neo.EventHub import events
 
 
-class Helper(object):
+class Helper:
 
     @staticmethod
     def WeightedFilter(list):

--- a/neo/Core/Mixins.py
+++ b/neo/Core/Mixins.py
@@ -39,7 +39,7 @@ class VerifiableMixin(SerializableMixin):
         pass
 
 
-class EquatableMixin():
+class EquatableMixin:
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__

--- a/neo/Core/Mixins.py
+++ b/neo/Core/Mixins.py
@@ -1,12 +1,12 @@
 from neocore.IO.Mixins import SerializableMixin
 
 
-class ClonableMixin(object):
+class ClonableMixin:
     def clone(self):
         pass
 
 
-class CodeMixin(object):
+class CodeMixin:
     scripts = []
     parameter_list = []
     return_type = None

--- a/neo/Core/State/SpentCoinState.py
+++ b/neo/Core/State/SpentCoinState.py
@@ -4,7 +4,7 @@ from neocore.IO.BinaryReader import BinaryReader
 from neo.IO.MemoryStream import StreamManager
 
 
-class SpentCoinItem():
+class SpentCoinItem:
     index = None
     height = None
 
@@ -20,7 +20,7 @@ class SpentCoinItem():
         self.height = height
 
 
-class SpentCoin():
+class SpentCoin:
     Output = None
     StartHeight = None
     EndHeight = None

--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -47,7 +47,7 @@ class TransactionResult(EquatableMixin):
         return "%s -> %s " % (self.AssetId.ToString(), self.Amount.value)
 
 
-class TransactionType(object):
+class TransactionType:
     MinerTransaction = b'\x00'
     IssueTransaction = b'\x01'
     ClaimTransaction = b'\x02'

--- a/neo/Core/TX/TransactionAttribute.py
+++ b/neo/Core/TX/TransactionAttribute.py
@@ -9,7 +9,7 @@ from neocore.IO.Mixins import SerializableMixin
 from neocore.UIntBase import UIntBase
 
 
-class TransactionAttributeUsage(object):
+class TransactionAttributeUsage:
     ContractHash = int.from_bytes(b'\x00', 'little')
 
     ECDH02 = int.from_bytes(b'\x02', 'little')

--- a/neo/Core/VerificationCode.py
+++ b/neo/Core/VerificationCode.py
@@ -5,7 +5,7 @@ import binascii
 from logzero import logger
 
 
-class VerificationCode():
+class VerificationCode:
 
     Script = None
 

--- a/neo/IO/Helper.py
+++ b/neo/IO/Helper.py
@@ -5,7 +5,7 @@ from neocore.IO.BinaryReader import BinaryReader
 from neo.Core.TX.Transaction import Transaction
 
 
-class Helper(object):
+class Helper:
 
     @staticmethod
     def AsSerializableWithType(buffer, class_name):

--- a/neo/IO/MemoryStream.py
+++ b/neo/IO/MemoryStream.py
@@ -12,7 +12,7 @@ __mstreams__ = []
 __mstreams_available__ = []
 
 
-class StreamManager(object):
+class StreamManager:
 
     @staticmethod
     def TotalBuffers():

--- a/neo/Implementations/Blockchains/LevelDB/DBCollection.py
+++ b/neo/Implementations/Blockchains/LevelDB/DBCollection.py
@@ -2,7 +2,7 @@ import binascii
 from logzero import logger
 
 
-class DBCollection():
+class DBCollection:
 
     DB = None
 #    SN = None

--- a/neo/Implementations/Blockchains/LevelDB/DebugStorage.py
+++ b/neo/Implementations/Blockchains/LevelDB/DebugStorage.py
@@ -5,7 +5,7 @@ from logzero import logger
 from neo.Settings import settings
 
 
-class DebugStorage():
+class DebugStorage:
 
     __instance = None
 

--- a/neo/Implementations/Blockchains/RPC/RpcBlockchain.py
+++ b/neo/Implementations/Blockchains/RPC/RpcBlockchain.py
@@ -10,7 +10,7 @@ from neo.Network.RPC.RpcClient import RpcClient
 from neo.Defaults import TEST_NODE
 
 
-class RpcBlockchain(object):
+class RpcBlockchain:
     """docstring for RpcBlockchain"""
 
     def __init__(self, url=TEST_NODE):

--- a/neo/Implementations/Notifications/LevelDB/NotificationDB.py
+++ b/neo/Implementations/Notifications/LevelDB/NotificationDB.py
@@ -9,7 +9,7 @@ from neo.Core.Helper import Helper
 from neocore.UInt160 import UInt160
 
 
-class NotificationPrefix():
+class NotificationPrefix:
     """
     Byte Prefixes to use for writing event data to disk
     """
@@ -22,7 +22,7 @@ class NotificationPrefix():
     PREFIX_TOKEN = b'\xCE'
 
 
-class NotificationDB():
+class NotificationDB:
 
     __instance = None
 

--- a/neo/Implementations/Wallets/peewee/PWDatabase.py
+++ b/neo/Implementations/Wallets/peewee/PWDatabase.py
@@ -6,7 +6,7 @@ logger = logging.getLogger('peewee')
 logger.setLevel(logging.ERROR)
 
 
-class PWDatabase(object):
+class PWDatabase:
 
     __proxy = None
 

--- a/neo/Network/InventoryType.py
+++ b/neo/Network/InventoryType.py
@@ -6,7 +6,7 @@ Usage:
 """
 
 
-class InventoryType(object):
+class InventoryType:
     TX = b'\x01'  # Transaction
     Block = b'\x02'  # Block
     Consensus = b'\xe0'  # Consensus information

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -23,7 +23,7 @@ class NeoClientFactory(ReconnectingClientFactory):
                 peer.connectionLost()
 
 
-class NodeLeader():
+class NodeLeader:
     __LEAD = None
 
     Peers = []

--- a/neo/Network/test_node.py
+++ b/neo/Network/test_node.py
@@ -7,7 +7,7 @@ from neo.IO.MemoryStream import StreamManager
 from neocore.IO.BinaryWriter import BinaryWriter
 
 
-class Endpoint():
+class Endpoint:
     def __init__(self, host, port):
         self.host = host
         self.port = port

--- a/neo/Network/test_node_leader.py
+++ b/neo/Network/test_node_leader.py
@@ -13,7 +13,7 @@ from neo.Core.TX.Transaction import ContractTransaction, TransactionOutput
 from neo.Core.TX.MinerTransaction import MinerTransaction
 
 
-class Endpoint():
+class Endpoint:
     def __init__(self, host, port):
         self.host = host
         self.port = port

--- a/neo/Prompt/InputParser.py
+++ b/neo/Prompt/InputParser.py
@@ -1,7 +1,7 @@
 from pyparsing import ZeroOrMore, Regex
 
 
-class InputParser(object):
+class InputParser:
     parser = ZeroOrMore(Regex(r'\[[^]]*\]') | Regex(r'"[^"]*"') | Regex(r'\'[^\']*\'') | Regex(r'[^ ]+'))
 
     def parse_input(self, user_input):

--- a/neo/Prompt/vm_debugger.py
+++ b/neo/Prompt/vm_debugger.py
@@ -10,7 +10,7 @@ import json
 from logzero import logger
 
 
-class DebugContext():
+class DebugContext:
 
     start = None
     end = None
@@ -77,7 +77,7 @@ class DebugContext():
         dis.dis(self.method.code_object)
 
 
-class VMDebugger():
+class VMDebugger:
 
     engine = None
     parser = None

--- a/neo/SmartContract/Contract.py
+++ b/neo/SmartContract/Contract.py
@@ -15,7 +15,7 @@ from neocore.Cryptography.Helper import *
 from neocore.Cryptography.ECCurve import ECDSA
 
 
-class ContractType():
+class ContractType:
     SignatureContract = 0
     MultiSigContract = 1
     CustomContract = 2

--- a/neo/SmartContract/ContractParameter.py
+++ b/neo/SmartContract/ContractParameter.py
@@ -6,7 +6,7 @@ from neocore.BigInteger import BigInteger
 from neocore.Cryptography.ECCurve import ECDSA
 
 
-class ContractParameter():
+class ContractParameter:
     """Contract Parameter used for parsing parameters sent to and from smart contract invocations"""
 
     Type = None

--- a/neo/SmartContract/ContractParameterContext.py
+++ b/neo/SmartContract/ContractParameterContext.py
@@ -14,7 +14,7 @@ from neo.VM import OpCode
 from neo.Core.Witness import Witness
 
 
-class ContractParamater():
+class ContractParamater:
 
     Type = None
     Value = None
@@ -33,7 +33,7 @@ class ContractParamater():
         return jsn
 
 
-class ContextItem():
+class ContextItem:
 
     Script = None
     ContractParameters = None
@@ -67,7 +67,7 @@ class ContextItem():
         return jsn
 
 
-class ContractParametersContext():
+class ContractParametersContext:
 
     Verifiable = None
 

--- a/neo/VM/ExecutionContext.py
+++ b/neo/VM/ExecutionContext.py
@@ -3,7 +3,7 @@ from neocore.IO.BinaryReader import BinaryReader
 from neocore.UInt160 import UInt160
 
 
-class ExecutionContext():
+class ExecutionContext:
 
     _Engine = None
 

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -14,7 +14,7 @@ from neo.Prompt.vm_debugger import VMDebugger
 from logging import DEBUG as LOGGING_LEVEL_DEBUG
 
 
-class ExecutionEngine():
+class ExecutionEngine:
     _Table = None
     _Service = None
 

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -6,7 +6,7 @@ from neocore.BigInteger import BigInteger
 from neo.SmartContract import StackItemType
 
 
-class CollectionMixin():
+class CollectionMixin:
 
     IsSynchronized = False
     SyncRoot = None
@@ -497,7 +497,7 @@ class Map(StackItem, CollectionMixin):
         raise Exception("Not supported- Cant get byte array for item %s %s " % (type(self), self._dict))
 
 
-class InteropService():
+class InteropService:
 
     _dictionary = {}
 

--- a/neo/VM/Mixins.py
+++ b/neo/VM/Mixins.py
@@ -1,15 +1,15 @@
 
-class EquatableMixin():
+class EquatableMixin:
 
     def Equals(self, other):
         pass
 
 
-class InteropMixin():
+class InteropMixin:
     pass
 
 
-class ScriptTableMixin():
+class ScriptTableMixin:
 
     def GetScript(self, script_hash):
         pass
@@ -21,7 +21,7 @@ class ScriptContainerMixin(InteropMixin):
         pass
 
 
-class CryptoMixin():
+class CryptoMixin:
 
     def Hash160(self, message):
         pass

--- a/neo/VM/RandomAccessStack.py
+++ b/neo/VM/RandomAccessStack.py
@@ -1,7 +1,7 @@
 from neo.VM.InteropService import StackItem
 
 
-class RandomAccessStack():
+class RandomAccessStack:
 
     _list = []
     _size = 0  # cache the size for performance

--- a/neo/VM/ScriptBuilder.py
+++ b/neo/VM/ScriptBuilder.py
@@ -11,7 +11,7 @@ from neocore.BigInteger import BigInteger
 import struct
 
 
-class ScriptBuilder(object):
+class ScriptBuilder:
     """docstring for ScriptBuilder"""
 
     def __init__(self):

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -33,7 +33,7 @@ from neo.Core.Helper import Helper
 from neo.Wallets.utils import to_aes_key
 
 
-class Wallet(object):
+class Wallet:
     AddressVersion = None
 
     _path = ''

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -69,7 +69,7 @@ class JsonRpcError(Exception):
         return JsonRpcError(-32603, message or "Internal error")
 
 
-class JsonRpcApi(object):
+class JsonRpcApi:
     app = Klein()
     port = None
 

--- a/neo/api/REST/RestApi.py
+++ b/neo/api/REST/RestApi.py
@@ -20,7 +20,7 @@ from neo.api.utils import cors_header
 API_URL_PREFIX = "/v1"
 
 
-class RestApi(object):
+class RestApi:
     app = Klein()
     notif = None
 

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -88,7 +88,7 @@ class PromptFileHistory(FileHistory):
         return string
 
 
-class PromptInterface(object):
+class PromptInterface:
     go_on = True
 
     _walletdb_loop = None


### PR DESCRIPTION
Since we are in Python 3.x there is no need for inheriting explicitly from object (old-style classes of Python 2.x are gone)
In addition, there is no need for empty parentheses after a class declaration  
