### PR TITLE
Replace import star with explicit imports

### DIFF
--- a/neo/Core/BlockBase.py
+++ b/neo/Core/BlockBase.py
@@ -1,6 +1,7 @@
 import ctypes
 from .Mixins import VerifiableMixin
-from neocore.Cryptography.Helper import *
+from neocore.Cryptography.Helper import bin_dbl_sha256
+import binascii
 from neo.Core.Helper import Helper
 from neo.Blockchain import GetBlockchain, GetGenesis
 from neo.Core.Witness import Witness

--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -10,7 +10,7 @@ from neo.Core.TX.RegisterTransaction import RegisterTransaction
 from neo.Core.TX.MinerTransaction import MinerTransaction
 from neo.Core.TX.IssueTransaction import IssueTransaction
 from neo.Core.Witness import Witness
-from neo.VM.OpCode import *
+from neo.VM.OpCode import PUSHF, PUSHT
 from neo.Core.State.SpentCoinState import SpentCoin
 from neo.SmartContract.Contract import Contract
 from neo.Settings import settings

--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -11,7 +11,6 @@ from neo.VM.OpCode import *
 from neo.Core.State.SpentCoinState import SpentCoin
 from neo.SmartContract.Contract import Contract
 from neo.Settings import settings
-from neocore.Cryptography.Crypto import *
 from collections import Counter
 from neocore.Fixed8 import Fixed8
 from neocore.Cryptography.ECCurve import ECDSA

--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -12,7 +12,6 @@ from neo.Core.State.SpentCoinState import SpentCoin
 from neo.SmartContract.Contract import Contract
 from neo.Settings import settings
 from neocore.Cryptography.Crypto import *
-from neocore.Cryptography.Helper import *
 from collections import Counter
 from neocore.Fixed8 import Fixed8
 from neocore.Cryptography.ECCurve import ECDSA

--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -1,8 +1,11 @@
 import pytz
+from itertools import groupby
 from datetime import datetime
 from events import Events
 from neo.Core.Block import Block
-from neo.Core.TX.Transaction import *
+from neo.Core.TX.Transaction import TransactionOutput
+from neo.Core.AssetType import AssetType
+from neocore.Cryptography.Crypto import Crypto
 from neo.Core.TX.RegisterTransaction import RegisterTransaction
 from neo.Core.TX.MinerTransaction import MinerTransaction
 from neo.Core.TX.IssueTransaction import IssueTransaction

--- a/neo/Core/Helper.py
+++ b/neo/Core/Helper.py
@@ -1,6 +1,8 @@
 from base58 import b58decode
+from logzero import logger
+import binascii
 from neo.Blockchain import GetBlockchain, GetStateReader
-from neocore.Cryptography.Crypto import *
+from neocore.Cryptography.Crypto import Crypto
 from neocore.IO.BinaryWriter import BinaryWriter
 from neocore.UInt160 import UInt160
 from neo.IO.MemoryStream import StreamManager

--- a/neo/Core/TX/ClaimTransaction.py
+++ b/neo/Core/TX/ClaimTransaction.py
@@ -1,4 +1,7 @@
-from neo.Core.TX.Transaction import *
+import sys
+from itertools import groupby
+from logzero import logger
+from neo.Core.TX.Transaction import TransactionType, Transaction
 from neocore.Fixed8 import Fixed8
 from neo.Core.Blockchain import Blockchain
 from neo.Core.CoinReference import CoinReference

--- a/neo/Core/TX/StateTransaction.py
+++ b/neo/Core/TX/StateTransaction.py
@@ -1,4 +1,4 @@
-from neo.Core.TX.Transaction import *
+from neo.Core.TX.Transaction import Transaction, TransactionType
 from neocore.Fixed8 import Fixed8
 
 

--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -7,9 +7,10 @@ Usage:
 import sys
 from itertools import groupby
 import binascii
+from logzero import logger
 from neocore.UInt160 import UInt160
 from neo.Blockchain import *
-from neo.Core.TX.TransactionAttribute import *
+from neo.Core.TX.TransactionAttribute import TransactionAttributeUsage
 from neocore.Fixed8 import Fixed8
 
 from neo.Network.InventoryType import InventoryType

--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -9,7 +9,7 @@ from itertools import groupby
 import binascii
 from logzero import logger
 from neocore.UInt160 import UInt160
-from neo.Blockchain import *
+from neo.Blockchain import GetBlockchain
 from neo.Core.TX.TransactionAttribute import TransactionAttributeUsage
 from neocore.Fixed8 import Fixed8
 

--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -4,14 +4,17 @@ Description:
 Usage:
     from neo.Core.Transaction import Transaction
 """
+import sys
 from itertools import groupby
+import binascii
+from neocore.UInt160 import UInt160
 from neo.Blockchain import *
 from neo.Core.TX.TransactionAttribute import *
 from neocore.Fixed8 import Fixed8
 
 from neo.Network.InventoryType import InventoryType
 from neo.Network.Mixins import InventoryMixin
-from neocore.Cryptography.Crypto import *
+from neocore.Cryptography.Crypto import Crypto
 from neocore.IO.Mixins import SerializableMixin
 from neo.IO.MemoryStream import StreamManager
 from neocore.IO.BinaryReader import BinaryReader

--- a/neo/Core/test_block_hash.py
+++ b/neo/Core/test_block_hash.py
@@ -1,5 +1,6 @@
 from neo.Utils.NeoTestCase import NeoTestCase
-from neocore.Cryptography.Helper import *
+from neocore.Cryptography.Helper import bin_dbl_sha256
+import binascii
 
 
 class BlockHashTest(NeoTestCase):

--- a/neo/Core/test_genesis_block.py
+++ b/neo/Core/test_genesis_block.py
@@ -2,7 +2,8 @@ from neo.Utils.VerifiableTestCase import VerifiableTestCase
 from neo.Core.TX.RegisterTransaction import RegisterTransaction
 from neo.Core.TX.MinerTransaction import MinerTransaction
 from neo.Core.TX.IssueTransaction import IssueTransaction
-from neo.Core.TX.Transaction import *
+from neo.Core.TX.Transaction import TransactionOutput
+from neo.Blockchain import GetSystemShare, GetGenesis, GetSystemCoin
 from neo.SmartContract.Contract import Contract
 from neo.Core.Blockchain import Blockchain
 from neo.Core.Witness import Witness

--- a/neo/Core/test_genesis_block.py
+++ b/neo/Core/test_genesis_block.py
@@ -7,7 +7,7 @@ from neo.Blockchain import GetSystemShare, GetGenesis, GetSystemCoin
 from neo.SmartContract.Contract import Contract
 from neo.Core.Blockchain import Blockchain
 from neo.Core.Witness import Witness
-from neo.VM.OpCode import *
+from neo.VM.OpCode import PUSHT
 from neo.Settings import settings
 from neocore.Cryptography.Crypto import Crypto
 

--- a/neo/Network/Message.py
+++ b/neo/Network/Message.py
@@ -1,9 +1,10 @@
 import ctypes
+import binascii
+from logzero import logger
 from neocore.IO.Mixins import SerializableMixin
 from neo.Settings import settings
 from neo.Core.Helper import Helper
-from neocore.Cryptography.Helper import *
-from logzero import logger
+from neocore.Cryptography.Helper import bin_dbl_sha256
 
 
 class ChecksumException(Exception):

--- a/neo/Network/Payloads/ConsensusPayload.py
+++ b/neo/Network/Payloads/ConsensusPayload.py
@@ -1,5 +1,5 @@
 from neocore.IO.Mixins import SerializableMixin
-from neocore.Cryptography.Helper import *
+from neocore.Cryptography.Helper import bin_dbl_sha256
 from neo.Core.Helper import Helper
 from neo.Network.InventoryType import InventoryType
 

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -1,3 +1,4 @@
+import binascii
 from neo.Blockchain import GetBlockchain
 from neo.VM.ScriptBuilder import ScriptBuilder
 from neo.VM.InteropService import InteropInterface
@@ -32,7 +33,7 @@ from neo.Core.Blockchain import Blockchain
 from neo.EventHub import events
 from logzero import logger
 
-from neo.VM.OpCode import *
+from neo.VM.OpCode import PACK
 
 DEFAULT_MIN_FEE = Fixed8.FromDecimal(.0001)
 

--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -1,7 +1,9 @@
+import binascii
 from logzero import logger
 
 from neo.VM.ExecutionEngine import ExecutionEngine
-from neo.VM.OpCode import *
+from neo.VM.OpCode import CALL, APPCALL, CHECKSIG, HASH160, HASH256, NOP, SHA1, SHA256, DEPTH, DUP, PACK, TUCK, OVER, \
+    SYSCALL, TAILCALL, NEWARRAY, NEWSTRUCT, PUSH16, UNPACK, CAT, CHECKMULTISIG, PUSHDATA4
 from neo.VM import VMState
 from neocore.Cryptography.Crypto import Crypto
 from neocore.Fixed8 import Fixed8

--- a/neo/SmartContract/Contract.py
+++ b/neo/SmartContract/Contract.py
@@ -11,7 +11,6 @@ from neocore.Cryptography.Crypto import *
 from neocore.IO.Mixins import SerializableMixin
 from neo.Core.VerificationCode import VerificationCode
 from neo.Core.Helper import Helper
-from neocore.Cryptography.Helper import *
 from neocore.Cryptography.ECCurve import ECDSA
 
 

--- a/neo/SmartContract/Contract.py
+++ b/neo/SmartContract/Contract.py
@@ -5,7 +5,8 @@ Description:
 Usage:
     from neo.SmartContract.Contract import Contract
 """
-from neo.VM.OpCode import *
+import binascii
+from neo.VM.OpCode import CHECKMULTISIG, CHECKSIG
 from neo.VM.ScriptBuilder import ScriptBuilder
 from neocore.Cryptography.Crypto import bin_hash160, from_int_to_byte, Crypto
 from neocore.IO.Mixins import SerializableMixin

--- a/neo/SmartContract/Contract.py
+++ b/neo/SmartContract/Contract.py
@@ -7,7 +7,7 @@ Usage:
 """
 from neo.VM.OpCode import *
 from neo.VM.ScriptBuilder import ScriptBuilder
-from neocore.Cryptography.Crypto import *
+from neocore.Cryptography.Crypto import bin_hash160, from_int_to_byte, Crypto
 from neocore.IO.Mixins import SerializableMixin
 from neo.Core.VerificationCode import VerificationCode
 from neo.Core.Helper import Helper

--- a/neo/SmartContract/test_contract_parameters.py
+++ b/neo/SmartContract/test_contract_parameters.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from neo.VM.InteropService import *
+from neo.VM.InteropService import ByteArray, Integer, BigInteger, Boolean
 from neo.SmartContract.ContractParameter import ContractParameter
 from neo.SmartContract.ContractParameterType import ContractParameterType
 from neocore.UInt256 import UInt256

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -1,11 +1,11 @@
 import hashlib
 import datetime
 
+from neo.VM.OpCode import *
 from logzero import logger
 from neo.VM.RandomAccessStack import RandomAccessStack
 from neo.VM.ExecutionContext import ExecutionContext
 from neo.VM import VMState
-from neo.VM.OpCode import *
 from neo.VM.InteropService import Array, Struct, CollectionMixin, Map, Boolean
 from neocore.UInt160 import UInt160
 from neo.Settings import settings

--- a/neo/VM/ScriptBuilder.py
+++ b/neo/VM/ScriptBuilder.py
@@ -4,11 +4,12 @@ Description:
 Usage:
     from neo.Core.Scripts.ScriptBuilder import ScriptBuilder
 """
-
-from neo.VM.OpCode import *
+import struct
+import binascii
+from neo.VM.OpCode import PUSHDATA1, PUSHDATA2, PUSHDATA4, PUSHF, PUSHT, PACK, PUSH0, PUSH1, PUSHM1, PUSHBYTES75, \
+    APPCALL, TAILCALL, SYSCALL
 from neo.IO.MemoryStream import MemoryStream
 from neocore.BigInteger import BigInteger
-import struct
 
 
 class ScriptBuilder(object):

--- a/neo/VM/tests/test_execution_engine.py
+++ b/neo/VM/tests/test_execution_engine.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from neo.VM.InteropService import *
+from neo.VM.InteropService import StackItem
 from neo.VM.ExecutionEngine import ExecutionEngine
 from neo.VM.ExecutionEngine import ExecutionContext
 from neo.VM import OpCode

--- a/neo/VM/tests/test_interop_map.py
+++ b/neo/VM/tests/test_interop_map.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from neo.VM.InteropService import *
+from neo.VM.InteropService import Integer, BigInteger, ByteArray, StackItem, Map, Array
 from neo.VM.ExecutionEngine import ExecutionEngine
 from neo.VM.ExecutionContext import ExecutionContext
 from neo.VM import OpCode

--- a/neo/VM/tests/test_interop_serialize.py
+++ b/neo/VM/tests/test_interop_serialize.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from neo.VM.InteropService import *
+from neo.VM.InteropService import Struct, StackItem, Array, Boolean, Map
 from neo.VM.ExecutionEngine import ExecutionEngine
 from neo.VM.ExecutionEngine import ExecutionContext
 from neo.SmartContract.StateReader import StateReader

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -5,6 +5,7 @@ Usage:
     from neo.Wallets.Wallet import Wallet
 """
 import traceback
+import hashlib
 from itertools import groupby
 from base58 import b58decode
 from decimal import Decimal
@@ -18,7 +19,7 @@ from neo.Core.State.CoinState import CoinState
 from neo.Core.Blockchain import Blockchain
 from neo.Core.CoinReference import CoinReference
 from neo.Core.TX.ClaimTransaction import ClaimTransaction
-from neocore.Cryptography.Helper import *
+from neocore.Cryptography.Helper import scripthash_to_address
 from neocore.Cryptography.Crypto import Crypto
 from neo.Wallets.AddressState import AddressState
 from neo.Wallets.Coin import Coin


### PR DESCRIPTION
- in some places the star importing brought to the namespace a different package 
e.g, in neo.Core.BlockBase:
from neocore.Cryptography.Helper import *
->
import binascii
from neocore.Cryptography.Helper import bin_dbl_sha256

- in some places the star importing was redundant 
e.g, in neo.Core.Blockchain:
from neocore.Cryptography.Crypto import * 
-> 
∅

- in one place I think the star import is better than explicitly importing all the used objects:
neo.VM.ExecutionEngine