### PR TITLE
Feature Invoke TX Attrs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 [0.7.0] in progress
 -----------------------
 - fix ``StateMachine.Contract_Migrate`` and add tests
+- add ability to attach tx attrs to build command and testinvoke.  altered tx attr parsing
 
 
 [0.6.9] 2018-04-30

--- a/neo/Core/FunctionCode.py
+++ b/neo/Core/FunctionCode.py
@@ -42,6 +42,9 @@ class FunctionCode(SerializableMixin):
         else:
             self.ParameterList = param_list
 
+        if len(return_type) > 1:
+            return_type = return_type[0:1]
+
         self.ReturnType = return_type
 
         self.ContractProperties = contract_properties

--- a/neo/Core/FunctionCode.py
+++ b/neo/Core/FunctionCode.py
@@ -42,7 +42,7 @@ class FunctionCode(SerializableMixin):
         else:
             self.ParameterList = param_list
 
-        if len(return_type) > 1:
+        if return_type and not isinstance(return_type, int) and len(return_type) > 1:
             return_type = return_type[0:1]
 
         self.ReturnType = return_type

--- a/neo/Prompt/Commands/BuildNRun.py
+++ b/neo/Prompt/Commands/BuildNRun.py
@@ -1,4 +1,4 @@
-from neo.Prompt.Utils import get_arg, get_from_addr
+from neo.Prompt.Utils import get_arg, get_from_addr, get_tx_attr_from_args
 from neo.Prompt.Commands.LoadSmartContract import GatherLoadedContractParams, generate_deploy_script
 from neo.SmartContract.ContractParameterType import ContractParameterType
 from neo.SmartContract.ContractParameter import ContractParameter
@@ -39,9 +39,11 @@ def LoadAndRun(arguments, wallet):
 
 
 def BuildAndRun(arguments, wallet, verbose=True, min_fee=DEFAULT_MIN_FEE, invocation_test_mode=True):
-    arguments, from_addr = get_from_addr(arguments)
-    path = get_arg(arguments)
+    print("arguments %s " % arguments)
 
+    arguments, from_addr = get_from_addr(arguments)
+    arguments, invoke_attrs = get_tx_attr_from_args(arguments)
+    path = get_arg(arguments)
     contract_script = Compiler.instance().load_and_save(path)
 
     newpath = path.replace('.py', '.avm')
@@ -53,10 +55,10 @@ def BuildAndRun(arguments, wallet, verbose=True, min_fee=DEFAULT_MIN_FEE, invoca
         with open(debug_map_path, 'r') as dbg:
             debug_map = json.load(dbg)
 
-    return DoRun(contract_script, arguments, wallet, path, verbose, from_addr, min_fee, invocation_test_mode, debug_map=debug_map)
+    return DoRun(contract_script, arguments, wallet, path, verbose, from_addr, min_fee, invocation_test_mode, debug_map=debug_map, invoke_attrs=invoke_attrs)
 
 
-def DoRun(contract_script, arguments, wallet, path, verbose=True, from_addr=None, min_fee=DEFAULT_MIN_FEE, invocation_test_mode=True, debug_map=None):
+def DoRun(contract_script, arguments, wallet, path, verbose=True, from_addr=None, min_fee=DEFAULT_MIN_FEE, invocation_test_mode=True, debug_map=None, invoke_attrs=None):
 
     test = get_arg(arguments, 1)
 
@@ -69,7 +71,7 @@ def DoRun(contract_script, arguments, wallet, path, verbose=True, from_addr=None
 
             script = GatherLoadedContractParams(f_args, contract_script)
 
-            tx, result, total_ops, engine = test_deploy_and_invoke(script, i_args, wallet, from_addr, min_fee, invocation_test_mode, debug_map=debug_map)
+            tx, result, total_ops, engine = test_deploy_and_invoke(script, i_args, wallet, from_addr, min_fee, invocation_test_mode, debug_map=debug_map, invoke_attrs=invoke_attrs)
             i_args.reverse()
 
             return_type_results = []

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -114,7 +114,10 @@ def get_tx_attr_from_args(params):
             to_remove.append(item)
             try:
                 attr_str = item.replace('--tx-attr=', '')
-                tx_attr_obj = json.loads(attr_str)
+
+# this doesn't work for loading in bytearrays
+#                tx_attr_obj = json.loads(attr_str)
+                tx_attr_obj = eval(attr_str)
                 if type(tx_attr_obj) is dict:
                     if attr_obj_to_tx_attr(tx_attr_obj) is not None:
                         tx_attr_dict.append(attr_obj_to_tx_attr(tx_attr_obj))

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -39,7 +39,7 @@ from neo.Prompt.Commands.Tokens import token_approve_allowance, token_get_allowa
     token_mint, token_crowdsale_register
 from neo.Prompt.Commands.Wallet import DeleteAddress, ImportWatchAddr, ImportToken, ClaimGas, DeleteToken, AddAlias, \
     ShowUnspentCoins
-from neo.Prompt.Utils import get_arg, get_from_addr
+from neo.Prompt.Utils import get_arg, get_from_addr, get_tx_attr_from_args
 from neo.Prompt.InputParser import InputParser
 from neo.Settings import settings, PrivnetConnectionError, PATH_USER_DATA
 from neo.UserPreferences import preferences
@@ -753,9 +753,9 @@ class PromptInterface:
             return
 
         args, from_addr = get_from_addr(args)
-
+        args, invoke_attrs = get_tx_attr_from_args(args)
         if args and len(args) > 0:
-            tx, fee, results, num_ops = TestInvokeContract(self.Wallet, args, from_addr=from_addr)
+            tx, fee, results, num_ops = TestInvokeContract(self.Wallet, args, from_addr=from_addr, invoke_attrs=invoke_attrs)
 
             if tx is not None and results is not None:
                 print(
@@ -772,7 +772,7 @@ class PromptInterface:
                 passwd = prompt("[password]> ", is_password=True)
                 if not self.Wallet.ValidatePassword(passwd):
                     return print("Incorrect password")
-
+                tx.Attributes = invoke_attrs
                 result = InvokeContract(self.Wallet, tx, fee, from_addr=from_addr)
 
                 return


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- add ability to attach tx attrs to build command and testinvoke.  altered tx attr parsing

**How did you solve this problem?**
- added `invoke_attrs` to various method calls

**How did you make sure your solution works?**
- ran tests

**Are there any special changes in the code that we should be aware of?**
- you can now do something like `build path/to/avm test 07 01 True False mymethod --tx-attrs=[{'usage':241,'data':bytearray(b'\x01\x02')}]`

- or `testinvoke {hash} mymethod --tx-attrs=[{'usage':241,'data':bytearray(b'\x01\x02')}]`

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
