### PR TITLE
fix error with string parameter parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.7.0] in progress
 -----------------------
+- fix a bug with smart-contract parameter string parsing `#412 <https://github.com/CityOfZion/neo-python/issues/412>`_
 - fix ``StateMachine.Contract_Migrate`` and add tests
 - add ability to attach tx attrs to build command and testinvoke.  altered tx attr parsing
 

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -174,9 +174,7 @@ def parse_param(p, wallet=None, ignore_int=False, prefer_hex=True):
 
     try:
         val = eval(p, {"__builtins__": {'bytearray': bytearray, 'bytes': bytes}}, {})
-        if type(val) is bytearray:
-            return val
-        elif type(val) is bytes:
+        if type(val) is bytes:
             # try to unhex
             try:
                 val = binascii.unhexlify(val)
@@ -184,8 +182,9 @@ def parse_param(p, wallet=None, ignore_int=False, prefer_hex=True):
                 pass
             # now it should be unhexxed no matter what, and we can hex it
             return val.hex().encode('utf-8')
+        elif type(val) is not float:
+            return val
 
-        return val
     except Exception as e:
         pass
 

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -610,7 +610,7 @@ class PromptInterface:
 
     def show_nodes(self):
         if len(NodeLeader.Instance().Peers) > 0:
-            out = "Total Connected: %s " % len(NodeLeader.Instance().Peers)
+            out = "Total Connected: %s\n" % len(NodeLeader.Instance().Peers)
             for peer in NodeLeader.Instance().Peers:
                 out += "Peer %s - IO: %s\n" % (peer.Name(), peer.IOStats())
             print_tokens([(Token.Number, out)], self.token_style)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Some string parameters, which can be parsed as float in hex, e.g. `binascii.hexlify(b'anf') == b'616e66'`, are parsed incorrectly.
This PR fixes https://github.com/CityOfZion/neo-python/issues/412

**How did you solve this problem?**
removed unwanted return
I have also added proper (?) formatting to `nodes` command.

**How did you make sure your solution works?**
I have tried to invoke my contract with 'problem' strings (as well as with normal).

**Are there any special changes in the code that we should be aware of?**
No.

**Please check the following, if applicable:**

- [-] Did you add any tests?
- [+] Did you run `make lint`?
- [+] Did you run `make test`? (executing right now)
- [+] Are you making a PR to a feature branch or development rather than master?
- [+] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
