### PR TITLE
RPC JSON Property Tweaks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,15 +4,16 @@ Changelog
 All notable changes to this project are documented in this file.
 
 [0.7.0] in progress
------------------------
+-------------------
 - fix a bug with smart-contract parameter string parsing `#412 <https://github.com/CityOfZion/neo-python/issues/412>`_
 - fix ``StateMachine.Contract_Migrate`` and add tests
 - add ability to attach tx attrs to build command and testinvoke.  altered tx attr parsing
 - updated the install instructions present on ``docs``
+- fix issues with some JSON-RPC properties `#418 <https://github.com/CityOfZion/neo-python/issues/418>`_
 
 
 [0.6.9] 2018-04-30
------------------------
+------------------
 - alter logging
 - fix issue with dispatching transfer events when ``from_addr`` is ``False``
 - add TPS monitor to ``prompt`` ``state`` command
@@ -27,7 +28,7 @@ All notable changes to this project are documented in this file.
 
 
 [0.6.8] 2018-04-26
------------------------
+------------------
 - add ``ServiceEnabled`` boolean to settings to determine whether nodes should send other nodes blocks
 - updated new block retrieval mechanism
 - fix for token_delete command not removing tokens from wallet file
@@ -43,7 +44,7 @@ All notable changes to this project are documented in this file.
 
 
 [0.6.7] 2018-04-06
------------------------
+------------------
 - Update all the requirements
 - Networking changes
 - added ``--maxpeers`` option for ``np-prompt`` and ``np-api-server``.  This allows p2p discovery of new nodes up to the value specified

--- a/neo/Core/Block.py
+++ b/neo/Core/Block.py
@@ -259,7 +259,7 @@ class Block(BlockBase, InventoryMixin):
         else:
             json['tx'] = [tx.ToJson() for tx in self.Transactions]
 
-        json['sys_fee'] = GetBlockchain().GetSysFeeAmount(self.Hash)
+        # json['sys_fee'] = GetBlockchain().GetSysFeeAmount(self.Hash)
         return json
 
     def Trim(self):

--- a/neo/Core/Block.py
+++ b/neo/Core/Block.py
@@ -119,6 +119,8 @@ class Block(BlockBase, InventoryMixin):
             int: size.
         """
         s = super(Block, self).Size()
+        # todo: is getsizeof the right thing to use? the calculation isn't consistent with C# nodes.
+        # due to __sizeof__ not being implemented by Transaction? need to use Transaction.Size() instead?
         s = s + sys.getsizeof(self.Transactions)
 
         return s

--- a/neo/Core/BlockBase.py
+++ b/neo/Core/BlockBase.py
@@ -101,7 +101,7 @@ class BlockBase(VerifiableMixin):
         scriptsize = 0
         if self.Script is not None:
             scriptsize = self.Script.Size()
-        return uintsize + 32 + 32 + uintsize + uintsize + ulongsize + 160 + 1 + scriptsize
+        return uintsize + self.PrevHash.Size + self.MerkleRoot.Size + uintsize + uintsize + ulongsize + 160 + 1 + scriptsize
 
     def IndexBytes(self):
         """

--- a/neo/Core/BlockBase.py
+++ b/neo/Core/BlockBase.py
@@ -1,6 +1,7 @@
 import ctypes
 from .Mixins import VerifiableMixin
 from neocore.Cryptography.Helper import bin_dbl_sha256
+from neocore.Cryptography.Crypto import Crypto
 import binascii
 from neo.Core.Helper import Helper
 from neo.Blockchain import GetBlockchain, GetGenesis
@@ -212,14 +213,18 @@ class BlockBase(VerifiableMixin):
         json = {}
         json["hash"] = self.Hash.To0xString()
 
-        #        json["size"] = self.Size()
+        # todo: this size isn't calculating correctly currently, but it should be included in the JSON
+        # json["size"] = self.Size()
         json["version"] = self.Version
         json["previousblockhash"] = self.PrevHash.To0xString()
         json["merkleroot"] = self.MerkleRoot.To0xString()
         json["time"] = self.Timestamp
         json["index"] = self.Index
-        json['next_consensus'] = self.NextConsensus.To0xString()
-        json["consensus data"] = self.ConsensusData
+        nonce = bytearray(self.ConsensusData.to_bytes(8, 'little'))
+        nonce.reverse()
+        json["nonce"] = nonce.hex()
+        json['nextconsensus'] = Crypto.ToAddress(self.NextConsensus)
+        # json["consensus data"] = self.ConsensusData
         json["script"] = '' if not self.Script else self.Script.ToJson()
         return json
 

--- a/neo/Core/TX/ClaimTransaction.py
+++ b/neo/Core/TX/ClaimTransaction.py
@@ -17,6 +17,7 @@ class ClaimTransaction(Transaction):
         Returns:
             int: size.
         """
+        # todo: will sys.getsizeof work as expected? __sizeof__ not implemented by CoinReference. should use Size() instead?
         return super(ClaimTransaction, self).Size() + sys.getsizeof(self.Claims)
 
     def __init__(self, *args, **kwargs):

--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -590,6 +590,8 @@ class Transaction(InventoryMixin):
         """
         jsn = {}
         jsn["txid"] = self.Hash.To0xString()
+        # todo: this size isn't calculating correctly currently, but it should be included in the JSON
+        # jsn["size"] = self.Size()
         jsn["type"] = TransactionType.ToName(self.Type)
         jsn["version"] = self.Version
         jsn["attributes"] = [attr.ToJson() for attr in self.Attributes]

--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -358,6 +358,7 @@ class Transaction(InventoryMixin):
         Returns:
             int: size.
         """
+        # todo: will sys.getsizeof work as expected for each of these? is __sizeof__ implemented for each? should use Size() instead?
         len_attributes = sys.getsizeof(self.Attributes)
         len_inputs = sys.getsizeof(self.inputs)
         len_outputs = sys.getsizeof(self.outputs)

--- a/neo/Core/test_block.py
+++ b/neo/Core/test_block.py
@@ -189,6 +189,8 @@ class BlocksTestCase(NeoTestCase):
 
         self.assertEqual(json['index'], 1050514)
         self.assertEqual(json['hash'], '0x%s' % self.big_tx_hash.decode('utf-8'))
+        self.assertEqual(json['nonce'], 'a62f207d4f00af81')
+        self.assertEqual(json['nextconsensus'], 'APyEx5f4Zm4oCHwFWiSTaph1fPBxZacYVR')
         self.assertEqual(len(json['tx']), 65)
 
         for tx in json['tx']:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

As reported by @lucianoengel in Discord #neoscan-api, updated `next_consensus` JSON property to `nextconsensus`. Also completed an audit of the block and transaction JSON to make sure it complies with the C# implementation. This included adding the missing `nonce` property. The primary outstanding issue (which I've documented with todo comments) is to address incorrect size calculations.

**How did you solve this problem?**

Implemented the changes.

**How did you make sure your solution works?**

Tested it. Added tests to confirm `nonce` and `nextconsensus` are being generated properly.

**Are there any special changes in the code that we should be aware of?**

I need some direction/confirmation on how to address the block and transaction size issue to address the outstanding todo comments. Curious to get your thoughts: @localhuman @metachris 

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
