### PR TITLE
High Volume GAS Claim Improvement

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 - fix ``StateMachine.Contract_Migrate`` and add tests
 - add ability to attach tx attrs to build command and testinvoke.  altered tx attr parsing
 - updated the install instructions present on ``docs``
+- added support for chunking through GAS claims 200 UTXOs at a time `#419 <https://github.com/CityOfZion/neo-python/issues/419>`_
 
 
 [0.6.9] 2018-04-30

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ All notable changes to this project are documented in this file.
 - fix ``StateMachine.Contract_Migrate`` and add tests
 - add ability to attach tx attrs to build command and testinvoke.  altered tx attr parsing
 - updated the install instructions present on ``docs``
-- added support for chunking through GAS claims 200 UTXOs at a time `#419 <https://github.com/CityOfZion/neo-python/issues/419>`_
+- added support for optionally chunking through GAS claims in prompt `#419 <https://github.com/CityOfZion/neo-python/issues/419>`_
 
 
 [0.6.9] 2018-04-30

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -11,6 +11,7 @@ from neocore.UInt160 import UInt160
 from prompt_toolkit import prompt
 import binascii
 import json
+import math
 
 
 def DeleteAddress(prompter, wallet, addr):
@@ -108,11 +109,17 @@ def AddAlias(wallet, addr, title):
 def ClaimGas(wallet, require_password=True, args=None):
 
     unclaimed_coins = wallet.GetUnclaimedCoins()
-    unclaimed_coin_refs = [coin.Reference for coin in unclaimed_coins]
 
-    if len(unclaimed_coin_refs) == 0:
+    unclaimed_count = len(unclaimed_coins)
+    if unclaimed_count == 0:
         print("no claims to process")
         return False
+
+    max_coins_per_claim = 200
+    if unclaimed_count > max_coins_per_claim:
+        unclaimed_coins = unclaimed_coins[:max_coins_per_claim]
+
+    unclaimed_coin_refs = [coin.Reference for coin in unclaimed_coins]
 
     available_bonus = Blockchain.Default().CalculateBonusIgnoreClaimed(unclaimed_coin_refs)
 
@@ -146,6 +153,8 @@ def ClaimGas(wallet, require_password=True, args=None):
 
     print("\n---------------------------------------------------------------")
     print("Will make claim for %s GAS" % available_bonus.ToString())
+    if unclaimed_count > max_coins_per_claim:
+        print("NOTE: There is a transaction limit on GAS claims. %s additional claim transactions will be required to claim all available GAS." % math.floor(unclaimed_count / max_coins_per_claim))
     print("------------------------------------------------------------------\n")
 
     if require_password:

--- a/neo/Prompt/Commands/tests/test_claim_command.py
+++ b/neo/Prompt/Commands/tests/test_claim_command.py
@@ -97,9 +97,18 @@ class UserWalletTestCase(WalletFixtureTestCase):
 
         wallet = self.GetWallet3()
 
+        claim = ClaimGas(wallet, require_password=False, args=['1'])
+
+        self.assertTrue(claim)
+
+    def test_5_wallet_claim_ok(self):
+
+        wallet = self.GetWallet3()
+
         claim = ClaimGas(wallet, require_password=False)
 
         self.assertTrue(claim)
+
 
     def test_block_150000_sysfee(self):
 

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -127,7 +127,7 @@ class PromptInterface:
                 'open wallet {path}',
                 'create wallet {path}',
                 'wallet {verbose}',
-                'wallet claim',
+                'wallet claim (max_coins_to_claim)',
                 'wallet migrate',
                 'wallet rebuild {start block}',
                 'wallet delete_addr {addr}',


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Addresses with thousands of UTXOs may have issues with transaction size preventing GAS claims from working in neo-python.

@localhuman: will be curious to hear your thoughts on this. Does the approach seem reasonable? Necessary? Anything that could be better about it?

**How did you solve this problem?**

Claim GAS for at most 200 UTXOs at a time.

**How did you make sure your solution works?**

Tested and used the process.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
