### PR TITLE
Support RPC and REST in parallel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 - fix ``StateMachine.Contract_Migrate`` and add tests
 - add ability to attach tx attrs to build command and testinvoke.  altered tx attr parsing
 - updated the install instructions present on ``docs``
+- support RPC and REST endpoints in parallel `#420 <https://github.com/CityOfZion/neo-python/issues/420>`_
 
 
 [0.6.9] 2018-04-30

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -45,7 +45,8 @@ from logzero import logger
 from twisted.logger import STDLibLogObserver, globalLogPublisher
 
 # Twisted and Klein methods and modules
-from twisted.internet import reactor, task
+from twisted.internet import reactor, task, endpoints
+from twisted.web.server import Site
 
 # neo methods and modules
 from neo.Core.Blockchain import Blockchain
@@ -207,17 +208,17 @@ def main():
     if args.port_rpc:
         logger.info("Starting json-rpc api server on http://%s:%s" % (args.host, args.port_rpc))
         api_server_rpc = JsonRpcApi(args.port_rpc)
-#        endpoint_rpc = "tcp:port={0}:interface={1}".format(args.port_rpc, args.host)
-#        endpoints.serverFromString(reactor, endpoint_rpc).listen(Site(api_server_rpc.app.resource()))
+        endpoint_rpc = "tcp:port={0}:interface={1}".format(args.port_rpc, args.host)
+        endpoints.serverFromString(reactor, endpoint_rpc).listen(Site(api_server_rpc.app.resource()))
 #        reactor.listenTCP(int(args.port_rpc), server.Site(api_server_rpc))
-        api_server_rpc.app.run(args.host, args.port_rpc)
+#        api_server_rpc.app.run(args.host, args.port_rpc)
 
     if args.port_rest:
         logger.info("Starting REST api server on http://%s:%s" % (args.host, args.port_rest))
         api_server_rest = RestApi()
-#        endpoint_rest = "tcp:port={0}:interface={1}".format(args.port_rest, args.host)
-#        endpoints.serverFromString(reactor, endpoint_rest).listen(Site(api_server_rest.app.resource()))
-        api_server_rest.app.run(args.host, args.port_rest)
+        endpoint_rest = "tcp:port={0}:interface={1}".format(args.port_rest, args.host)
+        endpoints.serverFromString(reactor, endpoint_rest).listen(Site(api_server_rest.app.resource()))
+#        api_server_rest.app.run(args.host, args.port_rest)
 
     reactor.run()
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

RPC and REST endpoints weren't supported in parallel.

**How did you solve this problem?**

Changed it back to the previous implementation so they can both run in parallel.

**How did you make sure your solution works?**

Tested it.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
