### PR TITLE
NEP5 token transfer history

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 - add ability to attach tx attrs to build command and testinvoke.  altered tx attr parsing
 - updated the install instructions present on ``docs``
 - support RPC and REST endpoints in parallel `#420 <https://github.com/CityOfZion/neo-python/issues/420>`_
+- Added new command ``tkn_history` to the prompt. It shows the recorded history of transfers of a given NEP5 token, that are related to the open wallet.
 
 
 [0.6.9] 2018-04-30

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ All notable changes to this project are documented in this file.
 - add ability to attach tx attrs to build command and testinvoke.  altered tx attr parsing
 - updated the install instructions present on ``docs``
 - support RPC and REST endpoints in parallel `#420 <https://github.com/CityOfZion/neo-python/issues/420>`_
-- Added new command ``tkn_history` to the prompt. It shows the recorded history of transfers of a given NEP5 token, that are related to the open wallet.
+- Added new command ``tkn_history`` to the prompt. It shows the recorded history of transfers of a given NEP5 token, that are related to the open wallet.
 
 
 [0.6.9] 2018-04-30

--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -1,5 +1,6 @@
 from neo.Prompt.Commands.Invoke import InvokeContract, InvokeWithTokenVerificationScript
 from neo.Prompt.Utils import get_asset_id, get_from_addr
+from neo.Wallets.NEP5Token import NEP5Token
 from neocore.Fixed8 import Fixed8
 from prompt_toolkit import prompt
 from decimal import Decimal
@@ -206,6 +207,39 @@ def do_token_transfer(token, wallet, from_address, to_address, amount, prompt_pa
 
     print("could not transfer tokens")
     return False
+
+
+def token_history(wallet, db, args):
+    if len(args) < 1:
+        print("Please provide the token symbol of the token you wish consult")
+        return False
+
+    if not db:
+        print("Unable to fetch history, notification database not enabled")
+        return False
+
+    token = get_asset_id(wallet, args[0])
+
+    if not isinstance(token, NEP5Token):
+        print("The given symbol does not represent a loaded NEP5 token")
+        return False
+
+    events = db.get_by_contract(token.ScriptHash)
+
+    addresses = wallet.Addresses
+    print("-----------------------------------------------------------")
+    print("Recent transaction history (last = more recent):")
+    for event in events:
+        if event.Type != 'transfer':
+            continue
+        if event.AddressFrom in addresses:
+            print(f"[{event.AddressFrom}]: Sent {string_from_amount(token, event.Amount)}"
+                  f" {args[0]} to {event.AddressTo}")
+        if event.AddressTo in addresses:
+            print(f"[{event.AddressTo}]: Received {string_from_amount(token, event.Amount)}"
+                  f" {args[0]} from {event.AddressFrom}")
+    print("-----------------------------------------------------------")
+    return True
 
 
 def amount_from_string(token, amount_str):

--- a/neo/Prompt/Commands/tests/test_token_commands.py
+++ b/neo/Prompt/Commands/tests/test_token_commands.py
@@ -1,10 +1,12 @@
 from neo.Utils.WalletFixtureTestCase import WalletFixtureTestCase
 from neo.Wallets.utils import to_aes_key
 from neo.Implementations.Wallets.peewee.UserWallet import UserWallet
+from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
 from neo.Core.Blockchain import Blockchain
 from neocore.UInt160 import UInt160
 from neo.Prompt.Commands.Wallet import ImportToken
-from neo.Prompt.Commands.Tokens import token_get_allowance, token_approve_allowance, token_send, token_send_from
+from neo.Prompt.Commands.Tokens import token_get_allowance, \
+    token_approve_allowance, token_send, token_send_from, token_history
 import shutil
 
 
@@ -141,3 +143,29 @@ class UserWalletTestCase(WalletFixtureTestCase):
         send = token_send_from(wallet, args, prompt_passwd=False)
 
         self.assertFalse(send)
+
+    def test_7_token_history_correct(self):
+
+        wallet = self.GetWallet1(recreate=True)
+
+        ImportToken(wallet, self.token_hash_str)
+
+        db = NotificationDB.instance()
+
+        token = self.get_token(wallet)
+
+        result = token_history(wallet, db, [token.symbol])
+
+        self.assertTrue(result)
+
+    def test_7_token_history_no_token(self):
+
+        wallet = self.GetWallet1(recreate=True)
+
+        ImportToken(wallet, self.token_hash_str)
+
+        db = NotificationDB.instance()
+
+        result = token_history(wallet, db, ["BAD"])
+
+        self.assertFalse(result)

--- a/neo/Prompt/Commands/tests/test_token_commands.py
+++ b/neo/Prompt/Commands/tests/test_token_commands.py
@@ -158,6 +158,8 @@ class UserWalletTestCase(WalletFixtureTestCase):
 
         self.assertTrue(result)
 
+        db.close()
+
     def test_7_token_history_no_token(self):
 
         wallet = self.GetWallet1(recreate=True)
@@ -169,3 +171,5 @@ class UserWalletTestCase(WalletFixtureTestCase):
         result = token_history(wallet, db, ["BAD"])
 
         self.assertFalse(result)
+
+        db.close()

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -36,7 +36,7 @@ from neo.Prompt.Commands.Send import construct_and_send, parse_and_sign
 from neo.contrib.nex.withdraw import RequestWithdrawFrom, PrintHolds, DeleteHolds, WithdrawOne, WithdrawAll, \
     CancelWithdrawalHolds, ShowCompletedHolds, CleanupCompletedHolds
 from neo.Prompt.Commands.Tokens import token_approve_allowance, token_get_allowance, token_send, token_send_from, \
-    token_mint, token_crowdsale_register
+    token_mint, token_crowdsale_register, token_history
 from neo.Prompt.Commands.Wallet import DeleteAddress, ImportWatchAddr, ImportToken, ClaimGas, DeleteToken, AddAlias, \
     ShowUnspentCoins
 from neo.Prompt.Utils import get_arg, get_from_addr, get_tx_attr_from_args
@@ -139,6 +139,7 @@ class PromptInterface:
                 'wallet tkn_allowance {token symbol} {address_from} {address to}',
                 'wallet tkn_mint {token symbol} {mint_to_addr} (--attach-neo={amount}, --attach-gas={amount})',
                 'wallet tkn_register {addr} ({addr}...) (--from-addr={addr})',
+                'wallet tkn_history {token symbol}',
                 'wallet unspent',
                 'wallet close',
                 'withdraw_request {asset_name} {contract_hash} {to_addr} {amount}',
@@ -192,7 +193,7 @@ class PromptInterface:
                                 'wallet', 'contract', 'asset', 'wif',
                                 'watch_addr', 'contract_addr', 'testinvoke', 'tkn_send',
                                 'tkn_mint', 'tkn_send_from', 'tkn_approve', 'tkn_allowance',
-                                'tkn_register', 'build', 'notifications', ]
+                                'tkn_register', 'build', 'notifications', 'tkn_history']
 
         if self.Wallet:
             for addr in self.Wallet.Addresses:
@@ -565,6 +566,9 @@ class PromptInterface:
             token_mint(self.Wallet, arguments[1:])
         elif item == 'tkn_register':
             token_crowdsale_register(self.Wallet, arguments[1:])
+        elif item == 'tkn_history':
+            notification_db = NotificationDB.instance()
+            token_history(self.Wallet, notification_db, arguments[1:])
         elif item == 'unspent':
             ShowUnspentCoins(self.Wallet, arguments[1:])
         elif item == 'alias':


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Added a simple version of the transfer history related to a given NEP5 token #162
**How did you solve this problem?**
Added a command to the prompt, that queries the `NotificationDB` for the events related to a given contract. Then extracted the events related to the user's wallet. 
**How did you make sure your solution works?**
Manually and with simple automated tests. At the moment I still need to solve an issue in my private network (it is unusable -> blocked on a given block) to be able to do more extensive testing. Just submitted so other people can review it, while I try to solve the issue. 
**Are there any special changes in the code that we should be aware of?**
No
**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
