### PR TITLE
add VarSize helper for Brian

### DIFF
--- a/neo/IO/Helper.py
+++ b/neo/IO/Helper.py
@@ -53,3 +53,23 @@ class Helper:
         tx = Transaction.DeserializeFrom(reader)
 
         return tx
+
+    @staticmethod
+    def GetVarSize(iterator):
+        """
+        Get length of a variable sized input.
+        Args:
+            iterator(iterator)
+        Returns:
+            int: length
+        """
+        value_len = len(iterator)
+
+        result = value_len
+        if (value_len < 0xFD):
+            result += 1  # byte
+        elif (value_len <= 0xFFF):
+            result += 3  # byte + ushort
+        else:
+            result += 5  # byte + int
+        return result


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Add a quick helper method from old consensus branch to avoid @brianlenz having to recreate or search for it when dealing with the `Size()` issue in #418

Note to @brianlenz , you'll likely need to inline it as shown below to avoid circular imports
https://github.com/CityOfZion/neo-python/blob/b33cf1488e8e33aa5618dc412732c2e4e717b065/neo/Core/Witness.py#L42-L50

**How did you solve this problem?**
add helper method from old consensus tree

**How did you make sure your solution works?**
not

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
