### PR TITLE
fix issue with resetting storages between failed invocations

### DIFF
--- a/neo/Implementations/Blockchains/LevelDB/DBCollection.py
+++ b/neo/Implementations/Blockchains/LevelDB/DBCollection.py
@@ -72,6 +72,12 @@ class DBCollection:
             self.Changed = []
             self.Deleted = []
 
+    def Reset(self):
+        for keyval in self.Changed:
+            self.Collection[keyval] = None
+        self.Changed = []
+        self.Deleted = []
+
     def GetAndChange(self, keyval, new_instance=None, debug_item=False):
 
         item = self.TryGet(keyval)

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -36,8 +36,8 @@ class NodeLeader:
 
     _MissedBlocks = []
 
-    BREQPART = 50
-    NREQMAX = 250
+    BREQPART = 100
+    NREQMAX = 500
     BREQMAX = 10000
 
     KnownHashes = []

--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -65,6 +65,8 @@ class StateMachine(StateReader):
         # commit storages right away
         if success:
             self.Commit()
+        else:
+            self.ResetState()
 
         super(StateMachine, self).ExecutionCompleted(engine, success, error)
 
@@ -75,6 +77,13 @@ class StateMachine(StateReader):
             self._assets.Commit(self._wb, False)
             self._contracts.Commit(self._wb, False)
             self._storages.Commit(self._wb, False)
+
+    def ResetState(self):
+        self._accounts.Reset()
+        self._validators.Reset()
+        self._assets.Reset()
+        self._contracts.Reset()
+        self._storages.Reset()
 
     def TestCommit(self):
         if self._storages.DebugStorage:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
reset storage state between invocations when an invocation fails.

**How did you solve this problem?**
debugging.

**How did you make sure your solution works?**
manual review

**Are there any special changes in the code that we should be aware of?**
no
**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
