### PR TITLE
Process SC events after write_batch() commit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ All notable changes to this project are documented in this file.
 - updated the install instructions present on ``docs``
 - support RPC and REST endpoints in parallel `#420 <https://github.com/CityOfZion/neo-python/issues/420>`_
 - Added new command ``tkn_history`` to the prompt. It shows the recorded history of transfers of a given NEP5 token, that are related to the open wallet.
+- fix current block lookup during smart contract event processing `#426 <https://github.com/CityOfZion/neo-python/issues/426>`_
 
 
 [0.6.9] 2018-04-30

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -812,8 +812,8 @@ class LevelDBBlockchain(Blockchain):
 
             self.TXProcessed += len(block.Transactions)
 
-            for event in to_dispatch:
-                events.emit(event.event_type, event)
+        for event in to_dispatch:
+            events.emit(event.event_type, event)
 
     def PersistBlocks(self):
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Fixes #424.

**How did you solve this problem?**

Emit SC events after the block batch has been committed.

**How did you make sure your solution works?**

Tested it.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
