### PR TITLE
Trivial error change for REST API when transaction is not found

### DIFF
--- a/neo/Prompt/Commands/tests/test_claim_command.py
+++ b/neo/Prompt/Commands/tests/test_claim_command.py
@@ -109,7 +109,6 @@ class UserWalletTestCase(WalletFixtureTestCase):
 
         self.assertTrue(claim)
 
-
     def test_block_150000_sysfee(self):
 
         fee = Blockchain.Default().GetSysFeeAmountByHeight(150000)

--- a/neo/api/REST/RestApi.py
+++ b/neo/api/REST/RestApi.py
@@ -153,6 +153,8 @@ class RestApi:
         try:
             hash = UInt256.ParseString(tx_hash)
             tx, height = bc.GetTransaction(hash)
+            if not tx:
+                return self.format_message("Could not find transaction for hash %s" % (tx_hash))
             block_notifications = self.notif.get_by_block(height - 1)
             for n in block_notifications:
                 if n.tx_hash == tx.Hash:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

The error message is inaccurate/confusing in REST API when transaction is not found.

**How did you solve this problem?**

Fixed the handling to deal with tx not found.

**How did you make sure your solution works?**

Tested.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
