### PR TITLE
Added mint event type to NotificationDB

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
-[0.7.0] in progress
+[0.7.0-dev] in progress
 -------------------
 - fix a bug with smart-contract parameter string parsing `#412 <https://github.com/CityOfZion/neo-python/issues/412>`_
 - fix ``StateMachine.Contract_Migrate`` and add tests
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 - support RPC and REST endpoints in parallel `#420 <https://github.com/CityOfZion/neo-python/issues/420>`_
 - Added new command ``tkn_history`` to the prompt. It shows the recorded history of transfers of a given NEP5 token, that are related to the open wallet.
 - fix current block lookup during smart contract event processing `#426 <https://github.com/CityOfZion/neo-python/issues/426>`_
+- added ``mint`` smart-contract event to NotificationDB `#433 <https://github.com/CityOfZion/neo-python/pull/433>`_
 
 
 [0.6.9] 2018-04-30

--- a/neo/Implementations/Notifications/LevelDB/NotificationDB.py
+++ b/neo/Implementations/Notifications/LevelDB/NotificationDB.py
@@ -115,7 +115,7 @@ class NotificationDB:
             logger.info("Not Notify Event instance")
             return
         if sc_event.ShouldPersist:
-            if sc_event.notify_type == NotifyType.TRANSFER or sc_event.notify_type == NotifyType.REFUND:
+            if sc_event.notify_type in [NotifyType.TRANSFER, NotifyType.REFUND, NotifyType.MINT]:
                 self._events_to_write.append(sc_event)
 
     def on_persist_completed(self, block):

--- a/neo/Implementations/Notifications/LevelDB/test_notification_db.py
+++ b/neo/Implementations/Notifications/LevelDB/test_notification_db.py
@@ -6,7 +6,6 @@ from neocore.UInt256 import UInt256
 from uuid import uuid1
 import shutil
 import os
-import sys
 
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
 from neocore.BigInteger import BigInteger

--- a/neo/Implementations/Notifications/LevelDB/test_notification_db.py
+++ b/neo/Implementations/Notifications/LevelDB/test_notification_db.py
@@ -6,6 +6,7 @@ from neocore.UInt256 import UInt256
 from uuid import uuid1
 import shutil
 import os
+import sys
 
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
 from neocore.BigInteger import BigInteger
@@ -126,3 +127,12 @@ class NotificationDBTestCase(TestCase):
         events = ndb.get_by_addr(sh)
 
         self.assertEqual(len(events), 0)
+
+    def test_should_persist_mint_event(self):
+        sc = NotifyEvent(SmartContractEvent.RUNTIME_NOTIFY, [b'mint', self.addr_to, BigInteger(123000)], self.contract_hash, 91349, self.event_tx, True, False)
+
+        ndb = NotificationDB.instance()
+        ndb.on_smart_contract_event(sc)
+
+        self.assertEqual(len(ndb.current_events), 1)
+        ndb.on_persist_completed(None)

--- a/neo/SmartContract/SmartContractEvent.py
+++ b/neo/SmartContract/SmartContractEvent.py
@@ -162,12 +162,10 @@ class SmartContractEvent(SerializableMixin):
 
 
 class NotifyType:
-
     TRANSFER = b'transfer'  # OnTransfer = RegisterAction('transfer', 'to', 'from', 'amount')
-
     APPROVE = b'approve'  # OnApprove = RegisterAction('approve', 'addr_from', 'addr_to', 'amount')
-
     REFUND = b'refund'  # OnRefund = RegisterAction('refund', 'to', 'amount')
+    MINT = b'mint'  # OnMint = RegisterAction('mint', 'addr_to', 'amount')
 
 
 class NotifyEvent(SmartContractEvent):
@@ -231,11 +229,18 @@ class NotifyEvent(SmartContractEvent):
                     self.amount = int(BigInteger.FromBytes(event_payload[3])) if isinstance(event_payload[3], bytes) else int(event_payload[3])
                     self.is_standard_notify = True
 
-                elif plen == 3 and self.notify_type == NotifyType.REFUND:
+                elif self.notify_type == NotifyType.REFUND and plen >= 3:  # Might have more arguments
                     self.addr_to = UInt160(data=self.event_payload[1]) if len(self.event_payload[1]) == 20 else empty
                     self.amount = int(BigInteger.FromBytes(event_payload[2])) if isinstance(event_payload[2], bytes) else int(event_payload[2])
                     self.addr_from = self.contract_hash
                     self.is_standard_notify = True
+
+                elif self.notify_type == NotifyType.MINT and plen == 3:
+                    self.addr_to = UInt160(data=self.event_payload[1]) if len(self.event_payload[1]) == 20 else empty
+                    self.amount = int(BigInteger.FromBytes(event_payload[2])) if isinstance(event_payload[2], bytes) else int(event_payload[2])
+                    self.addr_from = self.contract_hash
+                    self.is_standard_notify = True
+
             except Exception as e:
                 logger.info("Could not determine notify event: %s %s" % (e, self.event_payload))
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Added mint events to the NotificationDB.

**How did you solve this problem?**

Updated `NotificationDB.py` and `SmartContractEvent.py`

**How did you make sure your solution works?**

Added a test, but not live tested.

Couldn't get any current mint events on my bootstrapped chains. Is there an easy way to test it, besides on a private net and deploying a NEP-5 SC? (Reminds me, we should a NEP-5 SC to the privatenet default)

**Are there any special changes in the code that we should be aware of?**

No

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
