### PR TITLE
Fix datadir setup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ All notable changes to this project are documented in this file.
 - support RPC and REST endpoints in parallel `#420 <https://github.com/CityOfZion/neo-python/issues/420>`_
 - Added new command ``tkn_history`` to the prompt. It shows the recorded history of transfers of a given NEP5 token, that are related to the open wallet.
 - fix current block lookup during smart contract event processing `#426 <https://github.com/CityOfZion/neo-python/issues/426>`_
-
+- fixed custom datadir setup for prompt and api-server
 
 [0.6.9] 2018-04-30
 ------------------

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -241,6 +241,10 @@ class SettingsHolder:
         else:
             self.DATA_DIR_PATH = path
 
+        if not os.path.exists(self.DATA_DIR_PATH):
+            logzero.logger.info("Data directory %s does not yet exist. Creating...", self.DATA_DIR_PATH)
+            os.makedirs(self.DATA_DIR_PATH)
+
     def set_max_peers(self, num_peers):
         try:
             self.CONNECTED_PEER_MAX = int(num_peers)

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -138,7 +138,11 @@ def main():
         parser.print_help()
         return
 
-    # Setup depending on command line arguments. By default, the testnet settings are already loaded.
+    # Setting the datadir must come before setting the network, else the wrong path is checked at net setup.
+    if args.datadir:
+        settings.set_data_dir(args.datadir)
+
+    # Network configuration depending on command line arguments. By default, the testnet settings are already loaded.
     if args.config:
         settings.setup(args.config)
     elif args.mainnet:
@@ -150,8 +154,6 @@ def main():
     elif args.coznet:
         settings.setup_coznet()
 
-    if args.datadir:
-        settings.set_data_dir(args.datadir)
     if args.maxpeers:
         settings.set_max_peers(args.maxpeers)
 

--- a/neo/bin/bootstrap.py
+++ b/neo/bin/bootstrap.py
@@ -30,16 +30,17 @@ def main():
     if args.skipconfirm:
         require_confirm = False
     else:
-        require_confirm = True      
+        require_confirm = True
+
+    # Setting the datadir must come before setting the network, else the wrong path is checked at net setup.
+    if args.datadir:
+        settings.set_data_dir(args.datadir)
 
     # Setup depending on command line arguments. By default, the testnet settings are already loaded.
     if args.config:
         settings.setup(args.config)
     elif args.mainnet:
         settings.setup_mainnet()
-
-    if args.datadir:
-        settings.set_data_dir(args.datadir)
 
     if args.notifications:
         BootstrapBlockchainFile(settings.notification_leveldb_path, settings.NOTIF_BOOTSTRAP_FILE, require_confirm)

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -1059,6 +1059,10 @@ def main():
 
     args = parser.parse_args()
 
+    # Setting the datadir must come before setting the network, else the wrong path is checked at net setup.
+    if args.datadir:
+        settings.set_data_dir(args.datadir)
+
     # Setup depending on command line arguments. By default, the testnet settings are already loaded.
     if args.config:
         settings.setup(args.config)
@@ -1078,9 +1082,6 @@ def main():
 
     if args.verbose:
         settings.set_log_smart_contract_events(True)
-
-    if args.datadir:
-        settings.set_data_dir(args.datadir)
 
     if args.maxpeers:
         settings.set_max_peers(args.maxpeers)


### PR DESCRIPTION
See also #434

**What current issue(s) does this address, or what feature is it adding?**

In api-server and prompt.py a custom datadir was set after configuring the network. But the network config step checked the datadir. So the datadir needed to be configured before the network.

**How did you solve this problem?**

Updating np-prompt and np-api-server and np-bootstrap

**How did you make sure your solution works?**

Manual test

**Are there any special changes in the code that we should be aware of?**

No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
