### PR TITLE
WIP: Put prompt log and history files into custom datadir, if specified

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 - fix current block lookup during smart contract event processing `#426 <https://github.com/CityOfZion/neo-python/issues/426>`_
 - fixed custom datadir setup for prompt and api-server
 - added ``mint`` smart-contract event to NotificationDB `#433 <https://github.com/CityOfZion/neo-python/pull/433>`_
+- Store prompt log and history files in custom ``datadir``, if specified with ``--datadir``
 
 
 [0.6.9] 2018-04-30

--- a/examples/node.py
+++ b/examples/node.py
@@ -34,6 +34,9 @@ def custom_background_code():
 
 
 def main():
+    # Use TestNet
+    settings.setup_testnet()
+
     # Setup the blockchain
     blockchain = LevelDBBlockchain(settings.chain_leveldb_path)
     Blockchain.RegisterBlockchain(blockchain)

--- a/examples/smart-contract-rest-api.py
+++ b/examples/smart-contract-rest-api.py
@@ -140,6 +140,9 @@ def echo_post(request):
 
 
 def main():
+    # Use TestNet
+    settings.setup_testnet()
+
     # Setup the blockchain
     blockchain = LevelDBBlockchain(settings.chain_leveldb_path)
     Blockchain.RegisterBlockchain(blockchain)

--- a/examples/smart-contract.py
+++ b/examples/smart-contract.py
@@ -56,6 +56,9 @@ def custom_background_code():
 
 
 def main():
+    # Use TestNet
+    settings.setup_testnet()
+
     # Setup the blockchain
     blockchain = LevelDBBlockchain(settings.chain_leveldb_path)
     Blockchain.RegisterBlockchain(blockchain)

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -24,14 +24,6 @@ dir_current = os.path.dirname(os.path.abspath(__file__))
 # ROOT_INSTALL_PATH is the root path of neo-python, whether installed as package or from git.
 ROOT_INSTALL_PATH = os.path.abspath(os.path.join(dir_current, ".."))
 
-USER_HOME_DIR = os.path.expanduser('~')
-# PATH_USER_DATA is the root path where to store data (Chain databases, history, etc.)
-PATH_USER_DATA = os.path.join(USER_HOME_DIR, ".neopython")  # Works for both Windows and *nix
-
-# Make sure the data path exists (only if the home directory also exists)
-if os.path.isdir(USER_HOME_DIR) and not os.path.isdir(PATH_USER_DATA):
-    os.mkdir(PATH_USER_DATA)
-
 # This detects if we are running from an 'editable' version (like ``python neo/bin/prompt.py``)
 # or from a packaged install version from pip
 IS_PACKAGE_INSTALL = 'site-packages/neo' in dir_current
@@ -88,7 +80,7 @@ class SettingsHolder:
     PUBLISH_TX_FEE = None
     REGISTER_TX_FEE = None
 
-    DATA_DIR_PATH = PATH_USER_DATA
+    DATA_DIR_PATH = None
     LEVELDB_PATH = None
     NOTIFICATION_DB_PATH = None
 
@@ -162,7 +154,12 @@ class SettingsHolder:
 
     # Setup methods
     def setup(self, config_file):
-        """ Load settings from a JSON config file """
+        """ Setup settings from a JSON config file """
+        if not self.DATA_DIR_PATH:
+            path_user_home = os.path.expanduser('~')
+            path_user_data = os.path.join(path_user_home, ".neopython")  # Works for both Windows and *nix
+            self.set_data_dir(path_user_data)
+
         with open(config_file) as data_file:
             data = json.load(data_file)
 
@@ -242,7 +239,6 @@ class SettingsHolder:
             self.DATA_DIR_PATH = path
 
         if not os.path.exists(self.DATA_DIR_PATH):
-            logzero.logger.info("Data directory %s does not yet exist. Creating...", self.DATA_DIR_PATH)
             os.makedirs(self.DATA_DIR_PATH)
 
     def set_max_peers(self, num_peers):
@@ -342,7 +338,7 @@ class SettingsHolder:
 settings = SettingsHolder()
 
 # Load testnet settings as default
-settings.setup_testnet()
+# settings.setup_testnet()
 
 # By default, set loglevel to INFO. DEBUG just print a lot of internal debug statements
 settings.set_loglevel(logging.INFO)

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -156,9 +156,8 @@ class SettingsHolder:
     def setup(self, config_file):
         """ Setup settings from a JSON config file """
         if not self.DATA_DIR_PATH:
-            path_user_home = os.path.expanduser('~')
-            path_user_data = os.path.join(path_user_home, ".neopython")  # Works for both Windows and *nix
-            self.set_data_dir(path_user_data)
+            # Setup default data dir
+            self.set_data_dir(None)
 
         with open(config_file) as data_file:
             data = json.load(data_file)
@@ -233,7 +232,10 @@ class SettingsHolder:
         self.setup(FILENAME_SETTINGS_COZNET)
 
     def set_data_dir(self, path):
-        if path == '.':
+        if not path:
+            path_user_home = os.path.expanduser('~')
+            self.DATA_DIR_PATH = os.path.join(path_user_home, ".neopython")  # Works for both Windows and *nix
+        elif path == '.':
             self.DATA_DIR_PATH = os.getcwd()
         else:
             self.DATA_DIR_PATH = path

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -153,6 +153,8 @@ def main():
         settings.setup_privnet()
     elif args.coznet:
         settings.setup_coznet()
+    else:
+        raise Exception("Need to specify a network to use")
 
     if args.maxpeers:
         settings.set_max_peers(args.maxpeers)

--- a/neo/bin/bootstrap.py
+++ b/neo/bin/bootstrap.py
@@ -41,6 +41,8 @@ def main():
         settings.setup(args.config)
     elif args.mainnet:
         settings.setup_mainnet()
+    else:
+        settings.setup_testnet()
 
     if args.notifications:
         BootstrapBlockchainFile(settings.notification_leveldb_path, settings.NOTIF_BOOTSTRAP_FILE, require_confirm)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

If user specifies a custom datadir, also use it to store prompt log and history files.

**How did you solve this problem?**

Minor refactoring of prompt.py main function and settings.

**How did you make sure your solution works?**

Manual tests.

**Are there any special changes in the code that we should be aware of?**

Removed automatic setup of testnet in Settings.py, to avoid creating unnecessary directories at instantiation of settings, before any custom datadir is set.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
