### PR TITLE
Allow SmartContract to use a hash with or without 0x prefix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 - fix current block lookup during smart contract event processing `#426 <https://github.com/CityOfZion/neo-python/issues/426>`_
 - fixed custom datadir setup for prompt and api-server
 - added ``mint`` smart-contract event to NotificationDB `#433 <https://github.com/CityOfZion/neo-python/pull/433>`_
+- Allow ``SmartContract`` to use a hash with or without 0x prefix
 
 
 [0.6.9] 2018-04-30

--- a/neo/contrib/smartcontract.py
+++ b/neo/contrib/smartcontract.py
@@ -55,6 +55,7 @@ class SmartContract:
 
         # Handle EventHub events for SmartContract decorators
         self.event_handlers = defaultdict(list)
+
         @events.on(SmartContractEvent.RUNTIME_NOTIFY)
         @events.on(SmartContractEvent.RUNTIME_LOG)
         @events.on(SmartContractEvent.EXECUTION_SUCCESS)

--- a/neo/contrib/smartcontract.py
+++ b/neo/contrib/smartcontract.py
@@ -43,11 +43,18 @@ class SmartContract:
     event_handlers = None
 
     def __init__(self, contract_hash):
+        """
+        Instantiate a new SmartContract for a specific contract_hash
+        contract_hash can optionally be prefixed with '0x'
+        """
         assert contract_hash
         self.contract_hash = str(contract_hash)
-        self.event_handlers = defaultdict(list)
+
+        if self.contract_hash[:2] == "0x":
+            self.contract_hash = self.contract_hash[2:]
 
         # Handle EventHub events for SmartContract decorators
+        self.event_handlers = defaultdict(list)
         @events.on(SmartContractEvent.RUNTIME_NOTIFY)
         @events.on(SmartContractEvent.RUNTIME_LOG)
         @events.on(SmartContractEvent.EXECUTION_SUCCESS)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Allow SmartContract to use a hash with or without 0x prefix as output by neo-python contract operations.

**How did you solve this problem?**

Check for `0x` prefix and remove it

**How did you make sure your solution works?**

Manual test

**Are there any special changes in the code that we should be aware of?**

No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
