### PR TITLE
CheckWitness must FAULT if input is bad

### DIFF
--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -288,7 +288,7 @@ class StateReader(InteropService):
             point = ECDSA.decode_secp256r1(hashOrPubkey, unhex=False).G
             result = self.CheckWitnessPubkey(engine, point)
         else:
-            result = False
+            return False
 
         engine.EvaluationStack.PushT(result)
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

When a wrong input is passed to CheckWitness (empty byte array, for example) it must FAULT (not return false).

**How did you solve this problem?**

I detected two different executions from python and C#, then I located the source of the problem, a single line.

**How did you make sure your solution works?**

I tested on Eco platform (neocompiler.io), for both scenarios.

**Are there any special changes in the code that we should be aware of?**

Now it is consistent with the original C# design.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
This question is very good! I always forget to put to development branch... :)
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
