### PR TITLE
return type must be bigint

### DIFF
--- a/neo/Prompt/Commands/LoadSmartContract.py
+++ b/neo/Prompt/Commands/LoadSmartContract.py
@@ -119,7 +119,7 @@ def GatherLoadedContractParams(args, script):
     if type(params) is str:
         params = params.encode('utf-8')
 
-    return_type = bytearray(binascii.unhexlify(str(args[1]).encode('utf-8')))
+    return_type = BigInteger(int(str(args[1]).encode('utf-8')),16)
 
     needs_storage = bool(parse_param(args[2]))
     needs_dynamic_invoke = bool(parse_param(args[3]))
@@ -181,12 +181,12 @@ def GatherContractDetails(function_code, prompter):
     print(json.dumps(function_code.ToJson(), indent=4))
 
     return generate_deploy_script(function_code.Script, name, version, author, email, description,
-                                  function_code.ContractProperties, function_code.ReturnType,
+                                  function_code.ContractProperties, BigInteger(int(function_code.ReturnType,16)),
                                   function_code.ParameterList)
 
 
 def generate_deploy_script(script, name='test', version='test', author='test', email='test',
-                           description='test', contract_properties=0, return_type=bytearray(b'\xff'), parameter_list=[]):
+                           description='test', contract_properties=0, return_type=BigInteger(255), parameter_list=[]):
     sb = ScriptBuilder()
 
     plist = parameter_list

--- a/neo/Prompt/Commands/LoadSmartContract.py
+++ b/neo/Prompt/Commands/LoadSmartContract.py
@@ -9,6 +9,7 @@ from neo.Prompt.Utils import get_arg
 from neocore.Cryptography.Crypto import Crypto
 from neo.Core.Blockchain import Blockchain
 from neo.SmartContract.Contract import Contract
+from neocore import BigInteger
 
 
 def ImportContractAddr(wallet, args):
@@ -119,7 +120,7 @@ def GatherLoadedContractParams(args, script):
     if type(params) is str:
         params = params.encode('utf-8')
 
-    return_type = BigInteger(int(str(args[1]).encode('utf-8')),16)
+    return_type = BigInteger(int(str(args[1]).encode('utf-8'), 16))
 
     needs_storage = bool(parse_param(args[2]))
     needs_dynamic_invoke = bool(parse_param(args[3]))
@@ -181,7 +182,7 @@ def GatherContractDetails(function_code, prompter):
     print(json.dumps(function_code.ToJson(), indent=4))
 
     return generate_deploy_script(function_code.Script, name, version, author, email, description,
-                                  function_code.ContractProperties, BigInteger(int(function_code.ReturnType,16)),
+                                  function_code.ContractProperties, BigInteger(int(function_code.ReturnType, 16)),
                                   function_code.ParameterList)
 
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

According to a fruitful discussion in neo project ( https://github.com/neo-project/neo/pull/253 ), we concluded that the return type must be coded as a BigInteger, not a simple hex... For most types it doesn't matter (eg. boolean is 01, and BigInt(1).toHex is also 01), but for Void, the neo machine expects to receive \xff00 which is the real BigInt(255), not \xff, which is BigInt(-1)... This will also cause problems with InteropInterface type, that is passing now as \xf0, but it's supposed to be the BigInt representation of it.

**How did you solve this problem?**

Struggling for many months, and this last discussion in NEO: https://github.com/neo-project/neo/pull/253

**How did you make sure your solution works?**

This works already on Eco platform (neocompiler.io), when building transactions correctly.
On neo-python, I haven't tested well yet... this may have some impacts in FunctionCode, and I still haven't time to view all of it yet. But still, this needs to be fixed as soon as possible, in order to avoid other strange errors (such as https://github.com/CityOfZion/neo-python/pull/422 and https://github.com/CityOfZion/neo-python/issues/217)

**Are there any special changes in the code that we should be aware of?**

Not yet, we have to see the impacts.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
