### PR TITLE
Update to neo-python-core v0.4.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 All notable changes to this project are documented in this file.
 
 [0.7.0-dev] in progress
--------------------
+-----------------------
 - fix a bug with smart-contract parameter string parsing `#412 <https://github.com/CityOfZion/neo-python/issues/412>`_
 - fix ``StateMachine.Contract_Migrate`` and add tests
 - add ability to attach tx attrs to build command and testinvoke.  altered tx attr parsing
@@ -17,6 +17,11 @@ All notable changes to this project are documented in this file.
 - fixed custom datadir setup for prompt and api-server
 - added ``mint`` smart-contract event to NotificationDB `#433 <https://github.com/CityOfZion/neo-python/pull/433>`_
 - update to neo-boa v0.4.4
+- Update to `neo-python-core <https://github.com/CityOfZion/neo-python-core/blob/master/HISTORY.rst>`_ v0.4.8:
+
+  - Create wallets with ``np-utils --create-wallet``
+  - ``BigInteger(0)`` now is ``b'\x00'``
+
 
 [0.6.9] 2018-04-30
 ------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ mock==2.0.0
 mpmath==1.0.0
 neo-boa==0.4.4
 neo-python-rpc==0.2.0
-neocore==0.4.6
+neocore==0.4.8
 numpy==1.14.2
 pbr==4.0.1
 peewee==2.10.2


### PR DESCRIPTION
Includes:

* Create wallets with `np-utils --create-wallet`
* `BigInteger(0)` now is `b'\x00'` (PR #50)

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
