### PR TITLE
ReturnType is now written by ScriptBuilder as a BigInteger

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ All notable changes to this project are documented in this file.
 - Create wallets with ``np-utils --create-wallet``
 - ``BigInteger(0)`` now is ``b'\x00'``
 - CheckWitness now only accepts 20 or 33 byte addresses
-
+- When creating contracts, ReturnType is now written by ScriptBuilder as a BigInteger
 
 
 [0.6.9] 2018-04-30

--- a/neo/Core/FunctionCode.py
+++ b/neo/Core/FunctionCode.py
@@ -1,5 +1,6 @@
 from neocore.IO.Mixins import SerializableMixin
 from neocore.Cryptography.Crypto import Crypto
+from neocore.BigInteger import BigInteger
 
 
 class FunctionCode(SerializableMixin):
@@ -12,6 +13,10 @@ class FunctionCode(SerializableMixin):
     _scriptHash = None
 
     ContractProperties = None
+
+    @property
+    def ReturnTypeBigInteger(self):
+        return BigInteger(self.ReturnType)
 
     @property
     def HasStorage(self):

--- a/neo/Prompt/Commands/BuildNRun.py
+++ b/neo/Prompt/Commands/BuildNRun.py
@@ -10,6 +10,7 @@ import binascii
 from neo.Core.State.ContractState import ContractPropertyState
 import os
 import json
+from neocore.BigInteger import BigInteger
 
 
 def LoadAndRun(arguments, wallet):
@@ -117,6 +118,6 @@ def TestBuild(script, invoke_args, wallet, plist='05', ret='05', dynamic=False):
     if not isinstance(ret, bytearray):
         ret = bytearray(binascii.unhexlify(str(ret).encode('utf-8')))
 
-    script = generate_deploy_script(script, contract_properties=int(properties), parameter_list=plist, return_type=ret)
+    script = generate_deploy_script(script, contract_properties=int(properties), parameter_list=plist, return_type=BigInteger.FromBytes(ret))
 
     return test_deploy_and_invoke(script, invoke_args, wallet)

--- a/neo/Prompt/Commands/LoadSmartContract.py
+++ b/neo/Prompt/Commands/LoadSmartContract.py
@@ -9,6 +9,7 @@ from neo.Prompt.Utils import get_arg
 from neocore.Cryptography.Crypto import Crypto
 from neo.Core.Blockchain import Blockchain
 from neo.SmartContract.Contract import Contract
+from neocore.BigInteger import BigInteger
 
 
 def ImportContractAddr(wallet, args):
@@ -119,7 +120,7 @@ def GatherLoadedContractParams(args, script):
     if type(params) is str:
         params = params.encode('utf-8')
 
-    return_type = bytearray(binascii.unhexlify(str(args[1]).encode('utf-8')))
+    return_type = BigInteger.FromBytes(bytearray(binascii.unhexlify(str(args[1]).encode('utf-8'))))
 
     needs_storage = bool(parse_param(args[2]))
     needs_dynamic_invoke = bool(parse_param(args[3]))
@@ -181,12 +182,12 @@ def GatherContractDetails(function_code, prompter):
     print(json.dumps(function_code.ToJson(), indent=4))
 
     return generate_deploy_script(function_code.Script, name, version, author, email, description,
-                                  function_code.ContractProperties, function_code.ReturnType,
+                                  function_code.ContractProperties, function_code.ReturnTypeBigInteger,
                                   function_code.ParameterList)
 
 
 def generate_deploy_script(script, name='test', version='test', author='test', email='test',
-                           description='test', contract_properties=0, return_type=bytearray(b'\xff'), parameter_list=[]):
+                           description='test', contract_properties=0, return_type=BigInteger(255), parameter_list=[]):
     sb = ScriptBuilder()
 
     plist = parameter_list


### PR DESCRIPTION

**What current issue(s) does this address, or what feature is it adding?**
- using this in favor of https://github.com/CityOfZion/neo-python/pull/444

**How did you solve this problem?**
- `generate_deploy_script` now expects `BigInteger` for the `ReturnType` paramater

**How did you make sure your solution works?**
- tests

**Are there any special changes in the code that we should be aware of?**
- no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
