### PR TITLE
Bugfix neopython prompt return value

### DIFF
--- a/neo/Core/FunctionCode.py
+++ b/neo/Core/FunctionCode.py
@@ -1,6 +1,7 @@
 from neocore.IO.Mixins import SerializableMixin
 from neocore.Cryptography.Crypto import Crypto
 from neocore.BigInteger import BigInteger
+from binascii import hexlify
 
 
 class FunctionCode(SerializableMixin):
@@ -16,7 +17,7 @@ class FunctionCode(SerializableMixin):
 
     @property
     def ReturnTypeBigInteger(self):
-        return BigInteger(self.ReturnType)
+        return BigInteger(int(hexlify(self.ReturnType), 16))
 
     @property
     def HasStorage(self):


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

This commit fixes a small issue, regading invocation errors using prompt.py (parse error on return value type), and should contribute to PR https://github.com/CityOfZion/neo-python/pull/448. 

`import contract test.avm "" 02 True False`

Conversion error at: `File "/neo-python/neo/Core/FunctionCode.py", line 19, in ReturnTypeBigInteger    return BigInteger(self.ReturnType)`

**How did you solve this problem?**

I tested locally and realized prompt.py was failing (with conversion errors b'\xff' to BigInteger), so I converted data to string b'ff', then to int, then to BigInteger (if convert b'ff' to BigInteger it will become -1, not 255 as intended). The same applies to other types (int 0x02 was also failing with conversion error).

**How did you make sure your solution works?**

I tested locally and now all invocations work (for Void ff, and other types, boolean, int...). This version is running online at Eco platform neocompiler.io.

**Are there any special changes in the code that we should be aware of?**

It contributes to the PR https://github.com/CityOfZion/neo-python/pull/448

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)

Thanks for the attention!