### PR TITLE
Add --wallet argument to the api server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ All notable changes to this project are documented in this file.
   history or logs because those files are just created from scratch in the custom datadir.
 - Updated the dependencies
 - Updated MainNet bootstrap files
+- Added ``--wallet`` flag to the ``np-api-server`` command. The server can now open a wallet. `#459 <https://github.com/CityOfZion/neo-python/pull/459>`_
+- Added a partial implementation of the ``listaddress`` RPC method. `#459 <https://github.com/CityOfZion/neo-python/pull/459>`_
 
 
 [0.7.1] 2018-06-02

--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -9,6 +9,7 @@ from neo.Wallets.Wallet import Wallet
 from neo.Wallets.Coin import Coin as WalletCoin
 from neo.SmartContract.Contract import Contract as WalletContract
 from neo.IO.Helper import Helper
+from neo.Core.Helper import Helper as CoreHelper
 from neo.Core.Blockchain import Blockchain
 from neo.Core.CoinReference import CoinReference
 from neo.Core.TX.Transaction import TransactionOutput
@@ -450,6 +451,14 @@ class UserWallet(Wallet):
             pass
 
         return result
+
+    def GetAddress(self, addrStr):
+        try:
+            script_hash = CoreHelper.AddrStrToScriptHash(addrStr).ToArray()
+            addr = Address.get(ScriptHash=bytes(script_hash))
+        except Exception as e:
+            raise Exception("Address not in wallet")
+        return addr
 
     def TokenBalancesForAddress(self, address):
         if len(self._tokens):

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -341,18 +341,13 @@ class JsonRpcApi:
         return result
 
     def list_address(self):
-        """Get information about all the addresses present on the open wallet
-
-        The current implementation still does not fully comply with the spec,
-        since it seems there isn't a straight forward way of getting "haskey"
-        information.
-        """
+        """Get information about all the addresses present on the open wallet"""
         result = []
         for addrStr in self.wallet.Addresses:
             addr = self.wallet.GetAddress(addrStr)
             result.append({
                 "address": addrStr,
-                # "haskey": True,
+                "haskey": not addr.IsWatchOnly,
                 "label": None,
                 "watchonly": addr.IsWatchOnly,
             })

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -245,6 +245,12 @@ class JsonRpcApi:
         elif method == "getpeers":
             return self.get_peers()
 
+        elif method == "listaddress":
+            if self.wallet:
+                return self.list_address()
+            else:
+                raise JsonRpcError(-400, "Access denied.")
+
         raise JsonRpcError.methodNotFound()
 
     def get_custom_error_payload(self, request_id, code, message):
@@ -332,4 +338,22 @@ class JsonRpcApi:
                 result['unconnected'].append({"address": addr,
                                               "port": int(port)})
 
+        return result
+
+    def list_address(self):
+        """Get information about all the addresses present on the open wallet
+
+        The current implementation still does not fully comply with the spec,
+        since it seems there isn't a straight forward way of getting "haskey"
+        information.
+        """
+        result = []
+        for addrStr in self.wallet.Addresses:
+            addr = self.wallet.GetAddress(addrStr)
+            result.append({
+                "address": addrStr,
+                # "haskey": True,
+                "label": None,
+                "watchonly": addr.IsWatchOnly,
+            })
         return result

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -73,8 +73,9 @@ class JsonRpcApi:
     app = Klein()
     port = None
 
-    def __init__(self, port):
+    def __init__(self, port, wallet=None):
         self.port = port
+        self.wallet = wallet
 
     #
     # JSON-RPC API Route

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -193,7 +193,11 @@ def main():
         if not os.path.exists(args.wallet):
             print("Wallet file not found")
             return
-        passwd = prompt("[password]> ", is_password=True)
+
+        passwd = os.environ.get('NEO_PYTHON_JSONRPC_WALLET_PASSWORD', None)
+        if not passwd:
+            passwd = prompt("[password]> ", is_password=True)
+
         password_key = to_aes_key(passwd)
         try:
             wallet = UserWallet.Open(args.wallet, password_key)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
According to issue https://github.com/CityOfZion/neo-python/issues/189 there are still a few methods missing in the RPC API of `neo-python`. Most of them require an open wallet, a functionality that was missing in the current implementation. 

#428 was later created asking for one of those methods.

**How did you solve this problem?**
Added ``--wallet`` flag to the ``np-api-server`` command. The server can now open a wallet and use it. As a demonstration I also implemented the `listaddress` method, which uses the wallet.

**How did you make sure your solution works?**
Using a manual testing process plus adding a couple of automated tests.

**Are there any special changes in the code that we should be aware of?**
Not really. Only that since a wallet can be opened, users should be aware that they should protect the RPC endpoint when used with the `--wallet` flag, in order to avoid unauthorized uses of the wallet.

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
