### PR TITLE
Add RPC method: "getnewaddress"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - Updated MainNet bootstrap files
 - Added ``--wallet`` flag to the ``np-api-server`` command. The server can now open a wallet. `#459 <https://github.com/CityOfZion/neo-python/pull/459>`_
 - Added a partial implementation of the ``listaddress`` RPC method. `#459 <https://github.com/CityOfZion/neo-python/pull/459>`_
+- Added ``getnewaddress`` method to the JSON RPC API `#464 <https://github.com/CityOfZion/neo-python/pull/464>`_
 
 
 [0.7.1] 2018-06-02

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -8,12 +8,10 @@ See also:
 """
 import json
 import base58
-import random
 import binascii
 from json.decoder import JSONDecodeError
 
 from klein import Klein
-from logzero import logger
 
 from neo.Settings import settings
 from neo.Core.Blockchain import Blockchain
@@ -29,6 +27,7 @@ from neo.SmartContract.ApplicationEngine import ApplicationEngine
 from neo.SmartContract.ContractParameter import ContractParameter
 from neo.VM.ScriptBuilder import ScriptBuilder
 from neo.VM.VMState import VMStateStr
+from neo.Implementations.Wallets.peewee.Models import Account
 
 
 class JsonRpcError(Exception):
@@ -248,6 +247,16 @@ class JsonRpcApi:
         elif method == "listaddress":
             if self.wallet:
                 return self.list_address()
+            else:
+                raise JsonRpcError(-400, "Access denied.")
+
+        elif method == "getnewaddress":
+            if self.wallet:
+                keys = self.wallet.CreateKey()
+                account = Account.get(
+                    PublicKeyHash=keys.PublicKeyHash.ToBytes()
+                )
+                return account.contract_set[0].Address.ToString()
             else:
                 raise JsonRpcError(-400, "Access denied.")
 

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -6,6 +6,7 @@ Run only thse tests:
 import json
 import binascii
 import os
+from tempfile import mkdtemp
 from klein.test.test_resource import requestMock
 
 from neo import __version__
@@ -498,7 +499,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         self.assertEqual(error.get('message', None), "Access denied.")
 
     def test_listaddress_with_wallet(self):
-        test_wallet_path = "./listaddress.db3"
+        test_wallet_path = os.path.join(mkdtemp(), "listaddress.db3")
         self.app.wallet = UserWallet.Create(
             test_wallet_path,
             to_aes_key('awesomepassword')
@@ -526,7 +527,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         self.assertEqual(error.get('message', None), "Access denied.")
 
     def test_getnewaddress_with_wallet(self):
-        test_wallet_path = "./listaddress.db3"
+        test_wallet_path = os.path.join(mkdtemp(), "getnewaddress.db3")
         self.app.wallet = UserWallet.Create(
             test_wallet_path,
             to_aes_key('awesomepassword')


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
According to the issue https://github.com/CityOfZion/neo-python/issues/189 there are still a few methods missing in the API. This pull request implements `getnewaddress`.

**How did you solve this problem?**
When calling the method on a node with a open wallet, a new address is created.

**How did you make sure your solution works?**
Manually and with automated tests.
**Are there any special changes in the code that we should be aware of?**
No
**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
