### PR TITLE
Add Neo.Blockchain.GetTransactionHeight API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 - Added ``getnewaddress`` method to the JSON RPC API `#464 <https://github.com/CityOfZion/neo-python/pull/464>`_
 - Added an implementation of the ``getbalance`` RPC method. `#465 <https://github.com/CityOfZion/neo-python/pull/465>`_
 - updated seed list, change behavior of restarting NodeLeader when connected nodes falls below 2
+- Add Neo.Blockchain.GetTransactionHeight API
 
 [0.7.1] 2018-06-02
 ------------------

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -63,6 +63,7 @@ class StateReader(InteropService):
         self.Register("Neo.Blockchain.GetHeader", self.Blockchain_GetHeader)
         self.Register("Neo.Blockchain.GetBlock", self.Blockchain_GetBlock)
         self.Register("Neo.Blockchain.GetTransaction", self.Blockchain_GetTransaction)
+        self.Register("Neo.Blockchain.GetTransactionHeight", self.Blockchain_GetTransactionHeight)
         self.Register("Neo.Blockchain.GetAccount", self.Blockchain_GetAccount)
         self.Register("Neo.Blockchain.GetValidators", self.Blockchain_GetValidators)
         self.Register("Neo.Blockchain.GetAsset", self.Blockchain_GetAsset)
@@ -471,6 +472,17 @@ class StateReader(InteropService):
             tx, height = Blockchain.Default().GetTransaction(UInt256(data=data))
 
         engine.EvaluationStack.PushT(StackItem.FromInterface(tx))
+        return True
+
+    def Blockchain_GetTransactionHeight(self, engine):
+
+        data = engine.EvaluationStack.Pop().GetByteArray()
+        height = -1
+
+        if Blockchain.Default() is not None:
+            tx, height = Blockchain.Default().GetTransaction(UInt256(data=data))
+
+        engine.EvaluationStack.PushT(height)
         return True
 
     def Blockchain_GetAccount(self, engine):

--- a/neo/VM/tests/test_interop_blockchain.py
+++ b/neo/VM/tests/test_interop_blockchain.py
@@ -1,0 +1,99 @@
+from neo.Utils.BlockchainFixtureTestCase import BlockchainFixtureTestCase
+from neo.VM.InteropService import Integer, BigInteger, ByteArray, StackItem, Map, Array
+from neo.VM.ExecutionEngine import ExecutionEngine
+from neo.VM.ExecutionContext import ExecutionContext
+from neo.SmartContract.StateReader import StateReader
+from neo.Core.Block import Block
+from neo.Core.TX.Transaction import Transaction
+from neo.Settings import settings
+from logging import DEBUG
+from neocore.UInt256 import UInt256
+import os
+
+
+class StringIn(str):
+    def __eq__(self, other):
+        return self in other
+
+
+class BlockchainInteropTest(BlockchainFixtureTestCase):
+    engine = None
+    econtext = None
+    state_reader = None
+
+    @classmethod
+    def leveldb_testpath(self):
+        return os.path.join(settings.DATA_DIR_PATH, 'fixtures/test_chain')
+
+    @classmethod
+    def setUpClass(cls):
+        super(BlockchainInteropTest, cls).setUpClass()
+        settings.set_loglevel(DEBUG)
+
+    def setUp(self):
+        self.engine = ExecutionEngine()
+        self.econtext = ExecutionContext()
+        self.state_reader = StateReader()
+
+    def test_interop_getblock(self):
+
+        height = StackItem.New(1234)
+
+        self.engine.EvaluationStack.PushT(height)
+        self.state_reader.Blockchain_GetBlock(self.engine)
+
+        block = self.engine.EvaluationStack.Pop().GetInterface()
+
+        self.assertIsInstance(block, Block)
+
+    def test_interop_get_transaction(self):
+
+        u256 = UInt256.ParseString('e4d2ea5df2adf77df91049beccbb16f98863b93a16439c60381eac1f23bff178')
+
+        hash = StackItem.New(u256.Data)
+
+        self.engine.EvaluationStack.PushT(hash)
+        self.state_reader.Blockchain_GetTransaction(self.engine)
+
+        tx = self.engine.EvaluationStack.Pop().GetInterface()
+
+        self.assertIsInstance(tx, Transaction)
+
+    def test_interop_get_bad_transaction(self):
+
+        u256 = UInt256.ParseString('e4d2ea5df2adf77df91049beccbb16f98863b93a16439c60381eac1f23bff176')
+
+        hash = StackItem.New(u256.Data)
+
+        self.engine.EvaluationStack.PushT(hash)
+        self.state_reader.Blockchain_GetTransaction(self.engine)
+
+        tx = self.engine.EvaluationStack.Pop().GetInterface()
+
+        self.assertIsNone(tx)
+
+    def test_interop_get_transaction_height(self):
+
+        u256 = UInt256.ParseString('e4d2ea5df2adf77df91049beccbb16f98863b93a16439c60381eac1f23bff178')
+
+        hash = StackItem.New(u256.Data)
+
+        self.engine.EvaluationStack.PushT(hash)
+        self.state_reader.Blockchain_GetTransactionHeight(self.engine)
+
+        height = self.engine.EvaluationStack.Pop().GetBigInteger()
+
+        self.assertEqual(height, 4999)
+
+    def test_interop_get_bad_transaction_height(self):
+
+        u256 = UInt256.ParseString('e4d2ea5df2adf77df91049beccbb16f98863b93a16439c60381eac1f23bff176')
+
+        hash = StackItem.New(u256.Data)
+
+        self.engine.EvaluationStack.PushT(hash)
+        self.state_reader.Blockchain_GetTransactionHeight(self.engine)
+
+        height = self.engine.EvaluationStack.Pop().GetBigInteger()
+
+        self.assertEqual(height, -1)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- Closes #469 

**How did you solve this problem?**
- add additional interop method

**How did you make sure your solution works?**
- added tests

**Are there any special changes in the code that we should be aware of?**
- New test in `neo/VM/tests/test_interop_blockchain` could be used as a template to add tests to all interop methods.

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
