### PR TITLE
return value of address in ImportMultiSigContractAddr()

### DIFF
--- a/neo/Prompt/Commands/LoadSmartContract.py
+++ b/neo/Prompt/Commands/LoadSmartContract.py
@@ -235,7 +235,6 @@ def ImportMultiSigContractAddr(wallet, args):
         wallet.AddContract(verification_contract)
 
         print("Added multi-sig contract address %s to wallet" % address)
-        
         return address
 
     return 'Hello'

--- a/neo/Prompt/Commands/LoadSmartContract.py
+++ b/neo/Prompt/Commands/LoadSmartContract.py
@@ -235,5 +235,7 @@ def ImportMultiSigContractAddr(wallet, args):
         wallet.AddContract(verification_contract)
 
         print("Added multi-sig contract address %s to wallet" % address)
+        
+        return address
 
     return 'Hello'


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Currently we are unable to directly get the address of a multisig contract. This is for ease-of-use for creating custom python programs. 

**How did you solve this problem?**
I added `return address`.

**How did you make sure your solution works?**
It's a simple, quality of life improvement

**Are there any special changes in the code that we should be aware of?**
Just two words

**Please check the following, if applicable:**

- [x ] Did you add any tests?
- [x ] Did you run `make lint`?
- [x ] Did you run `make test`?
- [x ] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
