### PR TITLE
Fixed REST API height always behind by 1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ All notable changes to this project are documented in this file.
 - Updating Enumerator API for parity with `Neo PR #244 <https://github.com/neo-project/neo/pull/244>`_
 - Unifying interop namespace `Neo PR #254 <https://github.com/neo-project/neo/pull/254>`_
 - Update ``neo-boa`` version for new Enumerator/Iterator interop methods
+- Fixed REST API ``/status`` ``current_height`` off-by-one `#475 <https://github.com/CityOfZion/neo-python/pull/475>`_
 
 [0.7.1] 2018-06-02
 ------------------

--- a/neo/api/REST/RestApi.py
+++ b/neo/api/REST/RestApi.py
@@ -205,7 +205,7 @@ class RestApi:
     def get_status(self, request):
         request.setHeader('Content-Type', 'application/json')
         return json.dumps({
-            'current_height': Blockchain.Default().Height,
+            'current_height': Blockchain.Default().Height + 1,
             'version': settings.VERSION_NAME,
             'num_peers': len(NodeLeader.Instance().Peers)
         }, indent=4, sort_keys=True)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

The REST API height is always behind by 1 as returned by `/status`.

**How did you solve this problem?**

Added 1 to the return value for consistency with the height checks everywhere else (including in JSON-RPC and other REST API endpoints)

**How did you make sure your solution works?**

Tested that it always returns the same value as JSON-RPC now.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
