### PR TITLE
Fix privnet check in settings

### DIFF
--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -14,7 +14,7 @@ import sys
 import logzero
 import pip
 from neocore.Cryptography import Helper
-from neorpc.Client import RPCClient
+from neorpc.Client import RPCClient, NEORPCException
 from neorpc.Settings import settings as rpc_settings
 
 from neo import __version__
@@ -311,8 +311,10 @@ class SettingsHolder:
         """
         rpc_settings.setup(self.RPC_LIST)
         client = RPCClient()
-        version = client.get_version()
-        if not version:
+
+        try:
+            version = client.get_version()
+        except NEORPCException:
             raise PrivnetConnectionError("Error: private network container doesn't seem to be running, or RPC is not enabled.")
 
         print("Privatenet useragent '%s', nonce: %s" % (version["useragent"], version["nonce"]))


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Fixed the privnet check in settings -- if no privnet is running, now gives proper error message.

**How did you solve this problem?**

n/a

**How did you make sure your solution works?**

manual test

**Are there any special changes in the code that we should be aware of?**

no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
