### PR TITLE
np-api-server: wallet processblocks loop

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ All notable changes to this project are documented in this file.
 - Adds option to enter arguments for smart contract in an 'interactive' mode, which allows for much better parsing of input, activated by passing the ``--i`` flag when invoking.
 - Adds ability to *not* parse address strings such as AeV59NyZtgj5AMQ7vY6yhr2MRvcfFeLWSb when inputting to smart contract by passing the ``--no-parse`` flag
 - Changes the structure of items dispatched in SmartContractEvents to use the ``ContractParameter`` interface for better type inference and variable usage.
+- Bugfix: np-api-server with open wallet now properly processes new blockss
+
 
 [0.7.2] 2018-06-21
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ All notable changes to this project are documented in this file.
 - Adds option to enter arguments for smart contract in an 'interactive' mode, which allows for much better parsing of input, activated by passing the ``--i`` flag when invoking.
 - Adds ability to *not* parse address strings such as AeV59NyZtgj5AMQ7vY6yhr2MRvcfFeLWSb when inputting to smart contract by passing the ``--no-parse`` flag
 - Changes the structure of items dispatched in SmartContractEvents to use the ``ContractParameter`` interface for better type inference and variable usage.
-- Bugfix: np-api-server with open wallet now properly processes new blockss
+- Bugfix: np-api-server with open wallet now properly processes new blocks
 
 
 [0.7.2] 2018-06-21

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -201,6 +201,9 @@ def main():
         password_key = to_aes_key(passwd)
         try:
             wallet = UserWallet.Open(args.wallet, password_key)
+            walletdb_loop = task.LoopingCall(wallet.ProcessBlocks)
+            walletdb_loop.start(1)
+
         except Exception as e:
             print(f"Could not open wallet {e}")
             return

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -201,8 +201,6 @@ def main():
         password_key = to_aes_key(passwd)
         try:
             wallet = UserWallet.Open(args.wallet, password_key)
-            walletdb_loop = task.LoopingCall(wallet.ProcessBlocks)
-            walletdb_loop.start(1)
 
         except Exception as e:
             print(f"Could not open wallet {e}")
@@ -225,6 +223,11 @@ def main():
     Blockchain.RegisterBlockchain(blockchain)
     dbloop = task.LoopingCall(Blockchain.Default().PersistBlocks)
     dbloop.start(.1)
+
+    # If a wallet is open, make sure it processes blocks
+    if wallet:
+        walletdb_loop = task.LoopingCall(wallet.ProcessBlocks)
+        walletdb_loop.start(1)
 
     # Setup twisted reactor, NodeLeader and start the NotificationDB
     reactor.suggestThreadPoolSize(15)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Added process blocks loop for open wallets to np-api-server (see #479)

**How did you solve this problem?**

Adding a task.loopingCall

**How did you make sure your solution works?**

Manual test

**Are there any special changes in the code that we should be aware of?**

No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
