### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,7 +194,7 @@ could lead to version conflicts.
     git clone https://github.com/CityOfZion/neo-python.git
     cd neo-python
     
-    #setup alias for python and pip
+    # setup alias for python and pip
     
     alias python=python3
     alias pip=pip3
@@ -215,12 +215,12 @@ could lead to version conflicts.
     mkdir myproject
     cd myproject
     
-    #setup alias for python and pip
+    # setup alias for python and pip
     
     alias python=python3
     alias pip=pip3
 
-   # create virtual environment and activate
+    # create virtual environment and activate
 
     python -m venv venv
     source venv/bin/activate
@@ -231,7 +231,7 @@ could lead to version conflicts.
 
   ::
 
-    #uninstall pycryto & pycryptodome | reinstall pycryptodome-3.6.1
+    # uninstall pycryto & pycryptodome | reinstall pycryptodome-3.6.1
 
     pip uninstall pycryto pycryptodome
     pip install pycryptodome==3.6.1

--- a/README.rst
+++ b/README.rst
@@ -167,6 +167,8 @@ Virtual Machine with Linux. You can find more information and a guide
 for setting up the Linux subsystem
 `here <https://medium.com/@gubanotorious/installing-and-running-neo-python-on-windows-10-284fb518b213>`__.
 
+Installing "Ubuntu" from Microsoft Store installs Ubuntu 16.04. You should install Ubuntu 18.04 from Microsoft Store found here: https://www.microsoft.com/en-us/p/ubuntu-1804/9n9tngvndl3q?activetab=pivot%3aoverviewtab
+
 Python 3.6
 ~~~~~~~~~~
 
@@ -191,10 +193,15 @@ could lead to version conflicts.
 
     git clone https://github.com/CityOfZion/neo-python.git
     cd neo-python
+    
+    #setup alias for python and pip
+    
+    alias python=python3
+    alias pip=pip3
 
     # create virtual environment and activate
 
-    python3.6 -m venv venv # this can also be python3 -m venv venv depending on your environment
+    python -m venv venv
     source venv/bin/activate
 
     # install the package in an editable form
@@ -215,8 +222,14 @@ could lead to version conflicts.
 
     (venv) pip install neo-python
 
+3. Prior to First Run
 
+  ::
 
+    #uninstall pycryto & pycryptodome | reinstall pycryptodome-3.6.1
+
+    pip uninstall pycryto pycryptodome
+    pip install pycryptodome==3.6.1
 
 Running
 -------

--- a/README.rst
+++ b/README.rst
@@ -214,10 +214,15 @@ could lead to version conflicts.
     # create project dir
     mkdir myproject
     cd myproject
+    
+    #setup alias for python and pip
+    
+    alias python=python3
+    alias pip=pip3
 
-    # create virtual environment and activate
+   # create virtual environment and activate
 
-    python3.6 -m venv venv # this can also be python3 -m venv venv depending on your environment
+    python -m venv venv
     source venv/bin/activate
 
     (venv) pip install neo-python


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Updates which Ubuntu Windows users are directed to install.
Simplifies the instructions for creating and activating a venv.
Gives instructions for first time users of neo-python.

**How did you solve this problem?**

Gives the address for Ubuntu 18.04.
Directs users to create an alias for python and pip.
Directs users to uninstall pycryto and pycryptodome and install pycryptodome 3.6.1 specifically because simply using pip install pycryptodome will install pycryptodome 3.6.3 which is incompatible with neo-python.

**How did you make sure your solution works?**

I ran it. I was finally able to run neo-python for the first time.

**Are there any special changes in the code that we should be aware of?**

no
