### PR TITLE
Contract payable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ All notable changes to this project are documented in this file.
 - Changes the structure of items dispatched in SmartContractEvents to use the ``ContractParameter`` interface for better type inference and variable usage.
 - Bugfix: np-api-server with open wallet now properly processes new blocks
 - Update neo-boa to v0.4.8 and neocore to v0.4.11
+- Add VM support for ``Neo.Contract.IsPayable``
 
 [0.7.2] 2018-06-21
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ All notable changes to this project are documented in this file.
 - Adds ability to *not* parse address strings such as AeV59NyZtgj5AMQ7vY6yhr2MRvcfFeLWSb when inputting to smart contract by passing the ``--no-parse`` flag
 - Changes the structure of items dispatched in SmartContractEvents to use the ``ContractParameter`` interface for better type inference and variable usage.
 - Bugfix: np-api-server with open wallet now properly processes new blocks
-
+- Update neo-boa to v0.4.8 and neocore to v0.4.11
 
 [0.7.2] 2018-06-21
 -------------------

--- a/neo/Core/State/ContractState.py
+++ b/neo/Core/State/ContractState.py
@@ -10,6 +10,7 @@ class ContractPropertyState(IntEnum):
     NoProperty = 0
     HasStorage = 1 << 0
     HasDynamicInvoke = 1 << 1
+    Payable = 1 << 2
 
 
 class ContractState(StateBase):
@@ -43,6 +44,16 @@ class ContractState(StateBase):
             bool: True if supported. False otherwise.
         """
         return self.ContractProperties & ContractPropertyState.HasDynamicInvoke > 0
+
+    @property
+    def Payable(self):
+        """
+        Flag indicating if the contract should accept system assets or tokens
+
+        Returns:
+            bool: True if supported. False otherwise.
+        """
+        return self.ContractProperties & ContractPropertyState.Payable > 0
 
     @property
     def IsNEP5Contract(self):

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -143,7 +143,7 @@ class StateReader(InteropService):
         self.Register("Neo.Asset.GetAdmin", self.Asset_GetAdmin)
         self.Register("Neo.Asset.GetIssuer", self.Asset_GetIssuer)
         self.Register("Neo.Contract.GetScript", self.Contract_GetScript)
-#        self.Register("Neo.Contract.IsPayable", self.Contract_IsPayable)
+        self.Register("Neo.Contract.IsPayable", self.Contract_IsPayable)
         self.Register("Neo.Storage.Find", self.Storage_Find)
         self.Register("Neo.Enumerator.Create", self.Enumerator_Create)
         self.Register("Neo.Enumerator.Next", self.Enumerator_Next)
@@ -912,6 +912,14 @@ class StateReader(InteropService):
         if contract is None:
             return False
         engine.EvaluationStack.PushT(contract.Code.Script)
+        return True
+
+    def Contract_IsPayable(self, engine):
+
+        contract = engine.EvaluationStack.Pop().GetInterface()
+        if contract is None:
+            return False
+        engine.EvaluationStack.PushT(contract.Payable)
         return True
 
     def Storage_GetContext(self, engine):

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,9 +34,9 @@ memory-profiler==0.52.0
 mmh3==2.5.1
 mock==2.0.0
 mpmath==1.0.0
-neo-boa==0.4.7
+neo-boa==0.4.8
 neo-python-rpc==0.2.1
-neocore==0.4.10
+neocore==0.4.11
 numpy==1.14.5
 pbr==4.0.4
 peewee==2.10.2


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- Even though NEP7 is not implemented/approved yet, many contracts on testnet call the `Neo.Contract.IsPayable` method.  This PR adds that method to the Interop layer, though it will always return False for the moment.

**How did you solve this problem?**

**How did you make sure your solution works?**

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
