### PR TITLE
Readme Update 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -231,7 +231,7 @@ could lead to version conflicts.
 
   ::
 
-    # uninstall pycrypto & pycryptodome | reinstall pycrypto-2.61 & pycryptodome-3.6.1
+    # uninstall pycrypto & pycryptodome | reinstall pycrypto-2.6.1 & pycryptodome-3.6.1
 
     pip uninstall pycrypto pycryptodome
     pip install pycryptodome==3.6.1

--- a/README.rst
+++ b/README.rst
@@ -231,10 +231,11 @@ could lead to version conflicts.
 
   ::
 
-    # uninstall pycryto & pycryptodome | reinstall pycryptodome-3.6.1
+    # uninstall pycrypto & pycryptodome | reinstall pycrypto-2.61 & pycryptodome-3.6.1
 
-    pip uninstall pycryto pycryptodome
+    pip uninstall pycrypto pycryptodome
     pip install pycryptodome==3.6.1
+    pip install pycrypto==2.6.1
 
 Running
 -------

--- a/README.rst
+++ b/README.rst
@@ -234,8 +234,7 @@ could lead to version conflicts.
     # uninstall pycrypto & pycryptodome | reinstall pycrypto-2.6.1 & pycryptodome-3.6.1
 
     pip uninstall pycrypto pycryptodome
-    pip install pycryptodome==3.6.1
-    pip install pycrypto==2.6.1
+    pip install pycrypto==2.6.1 pycryptodome==3.6.1
 
 Running
 -------


### PR DESCRIPTION
Adds the instructions to install pycrypto-2.6.1 and fixes spelling errors.

It seems like my update to the readme included some spelling errors. Also, based on other people's comments and conversation in Discord, after uninstalling pycrypto, you should reinstall pycrypto-2.6.1.