### PR TITLE
Add votes and registered members to ValidatorState class

### DIFF
--- a/neo/Core/State/ValidatorState.py
+++ b/neo/Core/State/ValidatorState.py
@@ -1,11 +1,15 @@
 from .StateBase import StateBase
 from neocore.IO.BinaryReader import BinaryReader
+from neocore.IO.BinaryWriter import BinaryWriter
 from neo.IO.MemoryStream import StreamManager
 from neocore.Cryptography.ECCurve import EllipticCurve, ECDSA
+from neocore.Fixed8 import Fixed8
 
 
 class ValidatorState(StateBase):
-    PublicKey = None
+    PublicKey = None  # ECPoint
+    Registered = False  # bool
+    Votes = Fixed8.Zero()
 
     def __init__(self, pub_key=None):
         """
@@ -31,7 +35,7 @@ class ValidatorState(StateBase):
         """
         return super(ValidatorState, self).Size()
 
-    def Deserialize(self, reader):
+    def Deserialize(self, reader: BinaryReader):
         """
         Deserialize full object.
 
@@ -40,6 +44,8 @@ class ValidatorState(StateBase):
         """
         super(ValidatorState, self).Deserialize(reader)
         self.PublicKey = ECDSA.Deserialize_Secp256r1(reader)
+        self.Registered = reader.ReadBool()
+        self.Votes = reader.ReadFixed8()
 
     @staticmethod
     def DeserializeFromDB(buffer):
@@ -61,7 +67,7 @@ class ValidatorState(StateBase):
 
         return v
 
-    def Serialize(self, writer):
+    def Serialize(self, writer: BinaryWriter):
         """
         Serialize full object.
 
@@ -70,6 +76,8 @@ class ValidatorState(StateBase):
         """
         super(ValidatorState, self).Serialize(writer)
         self.PublicKey.Serialize(writer)
+        writer.WriteBool(self.Registered)
+        writer.WriteFixed8(self.Votes)
 
     def ToJson(self):
         """


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Fixes #494 and is a prerequisite to be able to address #427 

**How did you solve this problem?**
Update the class to match the [C# version](https://github.com/neo-project/neo/blob/master/neo/Core/ValidatorState.cs)

Note that I did not add the equivalent of the `ICloneable` interface, as does not seem to be used anywhere in neo-python.

**How did you make sure your solution works?**
🤞 
For a while I looked into getting some raw data from the C# client that triggers the creation of this class, but I'm not willing to figure out how to create an undocumented `StateTransaction` or how to do an `EnrollmentTransaction` with neo-cli. The edits are so basic that I found it not worth putting that much time in.

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
