### PR TITLE
Update NodeLeader peer monitoring system and configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,12 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
-[0.7.3] 2018-07-
+[0.7.4-dev] in progress
+-----------------------
+- Update NodeLeader peer monitoring system
+- Add ability to configure size of requests for blocks as well as block processing queue size
+
+[0.7.3] 2018-07-12
 -----------------------
 - Updated package requirements, removed ``pycrypto`` from all dependencies to fix install error(s) `#485 <https://github.com/CityOfZion/neo-python/issues/485>`_
 - Adds option to enter arguments for smart contract in an 'interactive' mode, which allows for much better parsing of input, activated by passing the ``--i`` flag when invoking.

--- a/neo/Network/test_node_leader.py
+++ b/neo/Network/test_node_leader.py
@@ -107,9 +107,6 @@ class LeaderTestCase(WalletFixtureTestCase):
                         for peer in peers:
                             leader.RemoveConnectedPeer(peer)
 
-                        # and peers should be equal to the seed list
-                        self.assertEqual(len(leader.Peers), len(settings.SEED_LIST))
-
                         # test reset
                         leader.ResetBlockRequestsAndCache()
                         self.assertEqual(Blockchain.Default()._block_cache, {})

--- a/neo/SmartContract/tests/test_migrate_destroy.py
+++ b/neo/SmartContract/tests/test_migrate_destroy.py
@@ -54,7 +54,7 @@ class ContractMigrateTestCase(WalletFixtureTestCase):
 
         output = Compiler.instance().load('%s/MigrateTest1.py' % os.path.dirname(__file__)).default
         script = output.write()
-        print("script : %s " % script)
+
         tx, results, total_ops, engine = TestBuild(script, ['store_data', bytearray(b'\x10')], self.GetWallet1(), '0705', '05')
 
         self.assertEqual(len(results), 1)
@@ -69,76 +69,76 @@ class ContractMigrateTestCase(WalletFixtureTestCase):
         tx, results, total_ops, engine = TestBuild(script, ['get_data', bytearray(b'\x10')], self.GetWallet1(), '0705', '05')
 
         self.assertEqual(len(results), 1)
-        # mylist = results[0].GetArray()
-        #
-        # self.assertEqual([item.GetByteArray() for item in mylist], [bytearray(b'\x01'), bytearray(b'abc'), bytearray(b'\x01\x02\x03')])
-        #
-        # tx, results, total_ops, engine = TestBuild(script, ['do_destroy', bytearray(b'\x10')], self.GetWallet1(), '0705', '05')
-        #
-        # self.assertEqual(len(results), 1)
-        # self.assertEqual(results[0].GetBoolean(), True)
-        # self.assertEqual(len(destroyed_items), 1)
-        #
-        # destroyed_hash = destroyed_items[0].contract_hash.ToBytes()
-        # script_table = engine._Table
-        # self.assertIsNone(script_table.GetScript(destroyed_hash))
+        mylist = results[0].GetArray()
 
-    # def test_build_contract_and_migrate(self):
-    #
-    #     items = []
-    #     migrated_items = []
-    #
-    #     def on_created(sc_event):
-    #         items.append(sc_event)
-    #
-    #     def on_migrated(sc_event):
-    #         migrated_items.append(sc_event)
-    #
-    #     events.on(SmartContractEvent.CONTRACT_CREATED, on_created)
-    #     events.on(SmartContractEvent.CONTRACT_MIGRATED, on_migrated)
-    #
-    #     output = Compiler.instance().load('%s/MigrateTest1.py' % os.path.dirname(__file__)).default
-    #     script = output.write()
-    #     tx, results, total_ops, engine = TestBuild(script, ['store_data', bytearray(b'\x10')], self.GetWallet1(), '0705', '05')
-    #
-    #     self.assertEqual(len(results), 1)
-    #     self.assertEqual(results[0].GetBoolean(), True)
-    #
-    #     self.assertEqual(len(items), 1)
-    #
-    #     created_hash = items[0].contract_hash.ToBytes()
-    #     script_table = engine._Table
-    #     self.assertIsNotNone(script_table.GetScript(created_hash))
-    #
-    #     migrateScript = Compiler.instance().load('%s/MigrateTest2.py' % os.path.dirname(__file__)).default.write()
-    #     tx, results, total_ops, engine = TestBuild(script, ['do_migrate', migrateScript], self.GetWallet1(), '0705', '05')
-    #
-    #     self.assertEqual(len(results), 1)
-    #     new_contract = results[0].GetInterface()
-    #     self.assertIsInstance(new_contract, ContractState)
-    #
-    #     self.assertEqual(len(migrated_items), 1)
-    #     self.assertEqual(new_contract, migrated_items[0].event_payload[0])
-    #
-    #     # now make sure the original contract isnt there
-    #     script_table = engine._Table
-    #     self.assertIsNone(script_table.GetScript(created_hash))
-    #
-    #     # and make sure the new one is there
-    #     migrated_hash = migrated_items[0].contract_hash
-    #
-    #     self.assertIsNotNone(script_table.GetScript(migrated_hash.ToBytes()))
-    #
-    #     # now make sure the new contract has the same storage
-    #
-    #     tx, results, total_ops, engine = TestBuild(migrateScript, ['i1'], self.GetWallet1(), '07', '05')
-    #     self.assertEqual(len(results), 1)
-    #     self.assertEqual(results[0].GetByteArray(), bytearray(b'\x01'))
-    #
-    #     tx, results, total_ops, engine = TestBuild(migrateScript, ['s2'], self.GetWallet1(), '07', '05')
-    #     self.assertEqual(len(results), 1)
-    #     self.assertEqual(results[0].GetByteArray(), bytearray(b'hello world'))
-    #
-    #     tx, results, total_ops, engine = TestBuild(migrateScript, ['i4'], self.GetWallet1(), '07', '05')
-    #     self.assertEqual(len(results), 1)
-    #     self.assertEqual(results[0].GetBigInteger(), 400000000000)
+        self.assertEqual([item.GetByteArray() for item in mylist], [bytearray(b'\x01'), bytearray(b'abc'), bytearray(b'\x01\x02\x03')])
+
+        tx, results, total_ops, engine = TestBuild(script, ['do_destroy', bytearray(b'\x10')], self.GetWallet1(), '0705', '05')
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetBoolean(), True)
+        self.assertEqual(len(destroyed_items), 1)
+
+        destroyed_hash = destroyed_items[0].contract_hash.ToBytes()
+        script_table = engine._Table
+        self.assertIsNone(script_table.GetScript(destroyed_hash))
+
+    def test_build_contract_and_migrate(self):
+
+        items = []
+        migrated_items = []
+
+        def on_created(sc_event):
+            items.append(sc_event)
+
+        def on_migrated(sc_event):
+            migrated_items.append(sc_event)
+
+        events.on(SmartContractEvent.CONTRACT_CREATED, on_created)
+        events.on(SmartContractEvent.CONTRACT_MIGRATED, on_migrated)
+
+        output = Compiler.instance().load('%s/MigrateTest1.py' % os.path.dirname(__file__)).default
+        script = output.write()
+        tx, results, total_ops, engine = TestBuild(script, ['store_data', bytearray(b'\x10')], self.GetWallet1(), '0705', '05')
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetBoolean(), True)
+
+        self.assertEqual(len(items), 1)
+
+        created_hash = items[0].contract_hash.ToBytes()
+        script_table = engine._Table
+        self.assertIsNotNone(script_table.GetScript(created_hash))
+
+        migrateScript = Compiler.instance().load('%s/MigrateTest2.py' % os.path.dirname(__file__)).default.write()
+        tx, results, total_ops, engine = TestBuild(script, ['do_migrate', migrateScript], self.GetWallet1(), '0705', '05')
+
+        self.assertEqual(len(results), 1)
+        new_contract = results[0].GetInterface()
+        self.assertIsInstance(new_contract, ContractState)
+
+        self.assertEqual(len(migrated_items), 1)
+        self.assertEqual(new_contract, migrated_items[0].event_payload.Value)
+
+        # now make sure the original contract isnt there
+        script_table = engine._Table
+        self.assertIsNone(script_table.GetScript(created_hash))
+
+        # and make sure the new one is there
+        migrated_hash = migrated_items[0].contract_hash
+
+        self.assertIsNotNone(script_table.GetScript(migrated_hash.ToBytes()))
+
+        # now make sure the new contract has the same storage
+
+        tx, results, total_ops, engine = TestBuild(migrateScript, ['i1'], self.GetWallet1(), '07', '05')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetByteArray(), bytearray(b'\x01'))
+
+        tx, results, total_ops, engine = TestBuild(migrateScript, ['s2'], self.GetWallet1(), '07', '05')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetByteArray(), bytearray(b'hello world'))
+
+        tx, results, total_ops, engine = TestBuild(migrateScript, ['i4'], self.GetWallet1(), '07', '05')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].GetBigInteger(), 400000000000)

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -112,6 +112,8 @@ class PromptInterface:
                 'config debug {on/off}',
                 'config sc-events {on/off}',
                 'config maxpeers {num_peers}',
+                'config node-requests {reqsize} {queuesize}',
+                'config node-requests {slow/normal/fast}',
                 'build {path/to/file.py} (test {params} {returntype} {needs_storage} {needs_dynamic_invoke} [{test_params} or --i]) --no-parse-addr (parse address strings to script hash bytearray)',
                 'load_run {path/to/file.avm} (test {params} {returntype} {needs_storage} {needs_dynamic_invoke} [{test_params} or --i]) --no-parse-addr (parse address strings to script hash bytearray)',
                 'import wif {wif}',
@@ -914,6 +916,11 @@ class PromptInterface:
             else:
                 print("Cannot configure VM instruction logging. Please specify on|off")
 
+        elif what == 'node-requests':
+            if len(args) == 3:
+                NodeLeader.Instance().setBlockReqSizeAndMax(int(args[1]), int(args[2]))
+            elif len(args) == 2:
+                NodeLeader.Instance().setBlockReqSizeByName(args[1])
         else:
             print(
                 "Cannot configure %s try 'config sc-events on|off', 'config debug on|off', 'config sc-debug-notify on|off' or 'config vm-log on|off'" % what)

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,6 @@ mpmath==1.0.0
 neo-boa==0.4.8
 neo-python-rpc==0.2.1
 neocore==0.4.11
-numpy==1.14.5
 pbr==4.0.4
 peewee==2.10.2
 pluggy==0.6.0


### PR DESCRIPTION
Update `NodeLeader` peer monitoring system, Add ability to configure size of requests for blocks as well as block processing queue size

You can now set the number of blocks each node request for blocks sends, as well as the total number of blocks to hold in the block processing queue.  To configure manually you can do:
`config node-requests 30 10000` to have each node request 30 blocks at a time and have at most 10k blocks in the processing queue.

You can also use presets `slow/normal/fast` to use values that have been found to be useful: `config node-requests slow`.

Slower node requests are better when block sizes are high ( like during an airdrop) where as fast would be better when syncing the beginning of the chain with mostly empty blocks.

Also adds in `migrate` tests that had been commented out, and removes `numpy` as a dependency.

**What current issue(s) does this address, or what feature is it adding?**
This should address #492, and allow node to sync more efficiently through different parts of the chain.

**How did you solve this problem?**
- Update `neo/Network/NodeLeader.py`

**How did you make sure your solution works?**
- Automated and manual tests

**Are there any special changes in the code that we should be aware of?**
- No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
