### PR TITLE
Fixed Docs & Examples for SmartContractEvent.event_payload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ All notable changes to this project are documented in this file.
 - Add ``size`` key to JSON output of Block and Transaction
 
 [0.7.3] 2018-07-12
------------------------
+------------------
 - Updated package requirements, removed ``pycrypto`` from all dependencies to fix install error(s) `#485 <https://github.com/CityOfZion/neo-python/issues/485>`_
 - Adds option to enter arguments for smart contract in an 'interactive' mode, which allows for much better parsing of input, activated by passing the ``--i`` flag when invoking.
 - Adds ability to *not* parse address strings such as AeV59NyZtgj5AMQ7vY6yhr2MRvcfFeLWSb when inputting to smart contract by passing the ``--no-parse`` flag
@@ -24,7 +24,7 @@ All notable changes to this project are documented in this file.
 
 
 [0.7.2] 2018-06-21
--------------------
+------------------
 - When using a custom datadir (with ``--datadir``), ``np-prompt`` will store log and history files there instead of
   the default directory. Note: if you use a custom datadir that does not yet exist, ``np-prompt`` starts without
   history or logs because those files are just created from scratch in the custom datadir.
@@ -124,7 +124,7 @@ All notable changes to this project are documented in this file.
 
 
 [0.6.5] 2018-03-31
------------------------
+------------------
 - Changed the ``eval()`` call when parsing the `--tx-attr` param to parse only json. Reduced the surface and options available on the other 2 eval calls to improve security.
 - fix wallet rebuild database lock errors (`PR #365 <https://github.com/CityOfZion/neo-python/pull/365>`_)
 - Fixed `synced_watch_only_balances` being always zero issue (`#209  <https://github.com/CityOfZion/neo-python/issues/209>`_)

--- a/docs/source/neo/SmartContract/smartcontracts.rst
+++ b/docs/source/neo/SmartContract/smartcontracts.rst
@@ -6,7 +6,7 @@ A common use case for implementing neo-python is to interact with smart contract
 include ``Runtime.Notify``, ``Runtime.Log``, execution success or failure and ``Storage.GET/PUT/DELETE``.
 
 Event Types
-"""""""""""""""""""""
+"""""""""""
 
 This is a list of smart contract event types which can currently be handled with neo-python:
 
@@ -58,7 +58,7 @@ Property              Data type Info
 
 
 neo.contrib.smartcontract.SmartContract
-"""""""""""""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""""""""
 
 Developers can easily subscribe to these events by using ``neo.contrib.smartcontract.SmartContract``.
 This is an example of listening for ``Runtime.Notify`` events of a smart contract with the hash ``6537b4bd100e514119e3a7ab49d520d20ef2c2a4``:
@@ -74,13 +74,13 @@ This is an example of listening for ``Runtime.Notify`` events of a smart contrac
         print("SmartContract Runtime.Notify event:", event)
 
         # Make sure that the event payload list has at least one element.
-        if not len(event.event_payload):
+        if not isinstance(event.event_payload, ContractParameter) or event.event_payload.Type != ContractParameterType.Array or not len(event.event_payload.Value):
             return
 
         # The event payload list has at least one element. As developer of the smart contract
         # you should know what data-type is in the bytes, and how to decode it. In this example,
         # it's just a string, so we decode it with utf-8:
-        print("- payload part 1:", event.event_payload[0].decode("utf-8"))
+        print("- payload part 1:", event.event_payload.Value[0].decode("utf-8"))
 
 
 The following decorators are currently available:
@@ -101,6 +101,7 @@ Here is another example, showing how to listen for all events and distinguishing
 ::
 
     from neo.contrib.smartcontract import SmartContract
+    from neo.SmartContract.ContractParameter import ContractParameter, ContractParameterType
     from neo.EventHub import SmartContractEvent
 
     smart_contract = SmartContract("6537b4bd100e514119e3a7ab49d520d20ef2c2a4")
@@ -112,18 +113,18 @@ Here is another example, showing how to listen for all events and distinguishing
         # Check if it is a Runtime.Notify event
         if event.event_type == SmartContractEvent.RUNTIME_NOTIFY:
             # Exit if an empty payload list
-            if not len(event.event_payload):
+            if not isinstance(event.event_payload, ContractParameter) or event.event_payload.Type != ContractParameterType.Array or not len(event.event_payload.Value):
                 return
 
             # Decode the first payload item and print it
-            print("- payload part 1:", event.event_payload[0].decode("utf-8"))
+            print("- payload part 1:", event.event_payload.Value[0].decode("utf-8"))
 
 
 
 
 
 Smart Contracts within the Prompt
-"""""""""""""""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""""""
 
 One of the most enjoyable features of ``neo-python`` is the ability to quickly build, test, import, and invoke smart contracts on the NEO platform.
 

--- a/examples/smart-contract-rest-api.py
+++ b/examples/smart-contract-rest-api.py
@@ -40,6 +40,7 @@ from neo.Settings import settings
 
 from neo.Network.api.decorators import json_response, gen_authenticated_decorator, catch_exceptions
 from neo.contrib.smartcontract import SmartContract
+from neo.SmartContract.ContractParameter import ContractParameter, ContractParameterType
 
 # Set the hash of your contract here:
 SMART_CONTRACT_HASH = "6537b4bd100e514119e3a7ab49d520d20ef2c2a4"
@@ -79,13 +80,13 @@ def sc_notify(event):
     logger.info("SmartContract Runtime.Notify event: %s", event)
 
     # Make sure that the event payload list has at least one element.
-    if not len(event.event_payload):
+    if not isinstance(event.event_payload, ContractParameter) or event.event_payload.Type != ContractParameterType.Array or not len(event.event_payload.Value):
         return
 
     # The event payload list has at least one element. As developer of the smart contract
     # you should know what data-type is in the bytes, and how to decode it. In this example,
     # it's just a string, so we decode it with utf-8:
-    logger.info("- payload part 1: %s", event.event_payload[0].decode("utf-8"))
+    logger.info("- payload part 1: %s", event.event_payload.Value[0].decode("utf-8"))
 
 
 #

--- a/examples/smart-contract.py
+++ b/examples/smart-contract.py
@@ -14,6 +14,7 @@ from logzero import logger
 from twisted.internet import reactor, task
 
 from neo.contrib.smartcontract import SmartContract
+from neo.SmartContract.ContractParameter import ContractParameter, ContractParameterType
 from neo.Network.NodeLeader import NodeLeader
 from neo.Core.Blockchain import Blockchain
 from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
@@ -34,13 +35,13 @@ def sc_notify(event):
     logger.info("SmartContract Runtime.Notify event: %s", event)
 
     # Make sure that the event payload list has at least one element.
-    if not len(event.event_payload):
+    if not isinstance(event.event_payload, ContractParameter) or event.event_payload.Type != ContractParameterType.Array or not len(event.event_payload.Value):
         return
 
     # The event payload list has at least one element. As developer of the smart contract
     # you should know what data-type is in the bytes, and how to decode it. In this example,
     # it's just a string, so we decode it with utf-8:
-    logger.info("- payload part 1: %s", event.event_payload[0].decode("utf-8"))
+    logger.info("- payload part 1: %s", event.event_payload.Value[0].decode("utf-8"))
 
 
 def custom_background_code():

--- a/neo/contrib/smartcontract.py
+++ b/neo/contrib/smartcontract.py
@@ -16,14 +16,15 @@ class SmartContract:
     on smart contract calls to `Runtime.Notify` or `Runtime.Log`:
 
         from neo.contrib.smartcontract import SmartContract
+        from neo.SmartContract.ContractParameter import ContractParameter, ContractParameterType
 
         smart_contract = SmartContract("6537b4bd100e514119e3a7ab49d520d20ef2c2a4")
 
         @smart_contract.on_notify
         def sc_notify(event):
             print("SmartContract Runtime.Notify event:", event)
-            if len(event.event_payload):
-                print(event.event_payload[0].decode("utf-8"))
+            if isinstance(event.event_payload, ContractParameter) and event.event_payload.Type == ContractParameterType.Array and len(event.event_payload.Value):
+                print(event.event_payload.Value[0].decode("utf-8"))
 
     Handlers receive as `event` argument an instance of the `neo.EventHub.SmartContractEvent`
     object. It has the following properties:


### PR DESCRIPTION
* The `SmartContractEvent.event_payload` implementation changed from an array to a `ContractParameter`, which is a breaking change for any event handlers that are introspecting the event data. I've updated all of the docs and examples to work with the updated data type. There already was a note in the CHANGELOG about this change for 0.7.3, so I left that as-is.

* Tweaked some markup issues in the rst docs that I noticed when applying the updates.


**What current issue(s) does this address, or what feature is it adding?**

Fixes documentation and examples to align with version 0.7.3.

**How did you solve this problem?**

Updates.

**How did you make sure your solution works?**

Tested the new process in our event handler.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
