### PR TITLE
Notification server updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ All notable changes to this project are documented in this file.
 - Fix size calculations for all serializable classes
 - Add ``size`` key to JSON output of Block and Transaction
 - add prompt command to split VIN to multiple VOUT
+- update notification endpoint to include ``total_pages`` in output, and allow ``pagesize`` paramater to be passed in
+- update seeds for mainnet
 
 [0.7.3] 2018-07-12
 ------------------

--- a/neo/api/REST/RestApi.py
+++ b/neo/api/REST/RestApi.py
@@ -15,7 +15,7 @@ from neocore.UInt160 import UInt160
 from neocore.UInt256 import UInt256
 from neo.Settings import settings
 from neo.api.utils import cors_header
-
+import math
 
 API_URL_PREFIX = "/v1"
 
@@ -67,8 +67,9 @@ class RestApi:
                             <pre>
 {
     "page_len": 1000,
+    "total_pages": 1,
     "total": 4,
-    "page": 0,
+    "page": 1,
     "current_height": 982506,
     "results": [
         {
@@ -211,23 +212,36 @@ class RestApi:
         }, indent=4, sort_keys=True)
 
     def format_notifications(self, request, notifications, show_none=False):
+
         notif_len = len(notifications)
         page_len = 500
-        page = 0
+        page = 1
         message = ''
         if b'page' in request.args:
             try:
                 page = int(request.args[b'page'][0])
             except Exception as e:
                 print("could not get page: %s" % e)
+        if b'pagesize' in request.args:
+            try:
+                page_len = int(request.args[b'pagesize'][0])
+            except Exception as e:
+                print("could not get page length: %s" % e)
 
-        start = page_len * page
+        # note, we want pages to start from 1, not 0, to be
+        # in sync with C# version
+        # we'll also convert page 0 to page1
+        if page == 0:
+            page = 1
+
+        start = page_len * (page - 1)
         end = start + page_len
 
         if start > notif_len:
             message = 'page greater than result length'
 
         notifications = notifications[start:end]
+        total_pages = math.ceil(notif_len / page_len)
 
         return json.dumps({
             'current_height': Blockchain.Default().Height + 1,
@@ -235,7 +249,8 @@ class RestApi:
             'total': notif_len,
             'results': None if show_none else [n.ToJson() for n in notifications],
             'page': page,
-            'page_len': page_len
+            'page_len': page_len,
+            'total_pages': total_pages
         }, indent=4, sort_keys=True)
 
     def format_message(self, message):
@@ -245,5 +260,6 @@ class RestApi:
             'total': 0,
             'results': None,
             'page': 0,
-            'page_len': 0
+            'page_len': 0,
+            'total_pages': 0
         }, indent=4, sort_keys=True)

--- a/neo/api/REST/test_rest_api.py
+++ b/neo/api/REST/test_rest_api.py
@@ -184,6 +184,7 @@ class NotificationDBTestCase(BlockchainFixtureTestCase):
         self.assertEqual(jsn['total'], 1027)
         results = jsn['results']
         self.assertEqual(len(results), 500)
+        self.assertEqual(jsn['total_pages'], 3)
 
         mock_req = requestMock(path=b'/addr/AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM?page=1')
         res = self.app.get_by_addr(mock_req, 'AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM')
@@ -196,6 +197,28 @@ class NotificationDBTestCase(BlockchainFixtureTestCase):
         res = self.app.get_by_addr(mock_req, 'AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM')
         jsn = json.loads(res)
         self.assertEqual(jsn['total'], 1027)
+        results = jsn['results']
+        self.assertEqual(len(results), 500)
+
+        mock_req = requestMock(path=b'/addr/AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM?page=3')
+        res = self.app.get_by_addr(mock_req, 'AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM')
+        jsn = json.loads(res)
+        self.assertEqual(jsn['total'], 1027)
+        results = jsn['results']
+        self.assertEqual(len(results), 27)
+
+    def test_pagination_page_size_for_addr_results(self):
+        mock_req = requestMock(path=b'/addr/AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM?pagesize=100')
+        res = self.app.get_by_addr(mock_req, 'AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM')
+        jsn = json.loads(res)
+        self.assertEqual(jsn['total'], 1027)
+        results = jsn['results']
+        self.assertEqual(len(results), 100)
+        self.assertEqual(jsn['total_pages'], 11)
+
+        mock_req = requestMock(path=b'/addr/AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM?pagesize=100&page=11')
+        res = self.app.get_by_addr(mock_req, 'AFmseVrdL9f9oyCzZefL9tG6UbvhPbdYzM')
+        jsn = json.loads(res)
         results = jsn['results']
         self.assertEqual(len(results), 27)
 


### PR DESCRIPTION
update notification endpoint to include total_pages in output, and allow pagesize paramater to be passed in.  This brings the server in parallel with the C# notification implementation.

Also now page index starts at 1 rather than 0.  Passing in `page=0` will convert to page 1.

**How did you solve this problem?**
- added `total_pages` value to output.

**How did you make sure your solution works?**
- tests

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
