### PR TITLE
Improve peer connection maintenance in NodeLeader

### DIFF
--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -110,7 +110,6 @@ class NeoNode(Protocol):
 
     def connectionLost(self, reason=None):
         """Callback handler from twisted when a connection was lost."""
-        self.endpoint = self.transport.getPeer()
         if self.block_loop:
             self.block_loop.stop()
             self.block_loop = None

--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -110,6 +110,7 @@ class NeoNode(Protocol):
 
     def connectionLost(self, reason=None):
         """Callback handler from twisted when a connection was lost."""
+        self.endpoint = self.transport.getPeer()
         if self.block_loop:
             self.block_loop.stop()
             self.block_loop = None
@@ -233,6 +234,7 @@ class NeoNode(Protocol):
             self.Log("Command %s not implemented " % m.Command)
 
     def ProtocolReady(self):
+        self.RequestPeerInfo()
         self.AskForMoreHeaders()
 
         self.block_loop = task.LoopingCall(self.AskForMoreBlocks)

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -23,7 +23,6 @@ class NeoClientFactory(ReconnectingClientFactory):
                 NodeLeader.Instance().ADDRS.remove(address)
                 if address not in NodeLeader.Instance().DEAD_ADDRS:
                     NodeLeader.Instance().DEAD_ADDRS.append(address)
-            
 
     def clientConnectionLost(self, connector, reason):
         address = "%s:%s" % (connector.host, connector.port)
@@ -195,7 +194,7 @@ class NodeLeader:
         # that were previously active but lost their connection
 
         start_delay = 0
-        connected  = []
+        connected = []
         for peer in self.Peers:
             connected.append(peer.Address)
         for addr in self.ADDRS:
@@ -203,7 +202,6 @@ class NodeLeader:
                 host, port = addr.split(":")
                 reactor.callLater(start_delay, self.SetupConnection, host, port)
                 start_delay += 1
-
 
     def ResetBlockRequestsAndCache(self):
         """Reset the block request counter and its cache."""

--- a/neo/Network/test_node_leader.py
+++ b/neo/Network/test_node_leader.py
@@ -54,7 +54,7 @@ class LeaderTestCase(WalletFixtureTestCase):
         def mock_call_later(delay, method, *args):
             method(*args)
 
-        def mock_connect_tcp(host, port, factory):
+        def mock_connect_tcp(host, port, factory, timeout=120):
             node = NeoNode()
             node.endpoint = Endpoint(host, port)
             leader.AddConnectedPeer(node)
@@ -95,7 +95,7 @@ class LeaderTestCase(WalletFixtureTestCase):
                         leader.RemoveConnectedPeer(peer)
 
                         self.assertEqual(len(leader.Peers), len(settings.SEED_LIST) - 1)
-                        self.assertEqual(len(leader.ADDRS), len(settings.SEED_LIST) - 1)
+                        self.assertEqual(len(leader.ADDRS), len(settings.SEED_LIST))
 
                         # now test adding another
                         leader.RemoteNodePeerReceived('hello.com', 1234, 6)
@@ -129,7 +129,7 @@ class LeaderTestCase(WalletFixtureTestCase):
         def mock_call_later(delay, method, *args):
             method(*args)
 
-        def mock_connect_tcp(host, port, factory):
+        def mock_connect_tcp(host, port, factory, timeout=120):
             node = NeoNode()
             node.endpoint = Endpoint(host, port)
             leader.AddConnectedPeer(node)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Even after the recent fixes in the development branch to fix the issues in #492, maintaining connection to the peer pool on a long-term basis is still an issue for neo-python in some cases. Often neo-python gets into a state where the peer count will drop to just a few nodes, and no new peers are added after that. Some of the blame may lie on remote nodes incorrectly reporting dead peers as active, a situation neo-python doesn't seem to currently deal well with.

**How did you solve this problem?**

A multi-pronged approach seems to work to improve overall stability of the peer count
:
1. After the initial protocol handshake with a new peer, immediately request its peer list instead of waiting for the timer

2. Track connection failures in a Twisted callback and maintain a session blacklist of peers that have either refused connections or have timed out during the initial connection attempt, to avoid wasting resources attempting to connect to known-dead peers

3. Only add a new remote address to the ADDRS list after a successful connection has been made

4. When new peers are received from a connected node, check the blacklist before attempting a connection to them

5. Instead of reverting back to the seed nodes in PeerCheckLoop if the amount has fallen below 2 peers, instead attempt to reconnect to all unconnected-but-known-good peers up to CONNECTED_PEER_MAX

6. Increased timeout to 120 in Twisted connectTCP, as it seems to be a collective timeout from the beginning of the connection queue start instead of an individual per-connection timeout, resulting in connections timing out very early when a larger CONNECTED_PEER_MAX causes Twisted to open many connections in sequence

**How did you make sure your solution works?**

Manual testing/observation of seed list on MainNet/TestNet over 24 hours

**Are there any special changes in the code that we should be aware of?**

No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (seems redundant due to other NodeLeader changes recorded in this cycle)

