### PR TITLE
Add Support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
-python:
-  - "3.7"
-
-sudo: required
+python: 3.7
+dist: xenial
+sudo: true
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.6"
+  - "3.7"
 
 sudo: required
 services:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.7.4-dev] in progress
 -----------------------
+- Add support for Python 3.7
 - Update NodeLeader peer monitoring system
 - Add ability to configure size of requests for blocks as well as block processing queue size
 - Update mainnet bootstrap files

--- a/README.rst
+++ b/README.rst
@@ -113,13 +113,20 @@ OSX
 Ubuntu/Debian 16.10+
 ^^^^^^^^^^^^^^^^^^^^
 
-Ubuntu starting at 16.10 supports Python 3.6 in the official
-repositories, and you can just install Python 3.6 and all the system
-dependencies like this:
+Ubuntu starting at 16.10 supports Python 3.6+ in the official repositories. We recommend
+using Python 3.7. 
+
+First, ensure Ubuntu is fully up-to-date with this:
 
 ::
 
-    apt-get install python3.6 python3.6-dev python3.6-venv python3-pip libleveldb-dev libssl-dev g++
+   sudo apt-get update && sudo apt-get upgrade
+
+You can install Python 3.7 and all the system dependencies like this:
+
+::
+
+   sudo apt-get install python3.7 python3.7-dev python3.7-venv python3-pip libleveldb-dev libssl-dev g++
 
 Older Ubuntu versions (eg. 16.04)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -158,25 +165,25 @@ Centos/Redhat/Fedora
 Windows
 ^^^^^^^
 
-Help needed. Installing the Python package plyvel seems to require C++
+Help needed for running natively. Installing the Python package plyvel seems to require C++
 compiler support tied to Visual Studio and libraries. Refer to
 `documentation <https://neo-python.readthedocs.io/en/latest/installwindows.html>`__.
 
-Currently you probably should use the Linux subsystem with Ubuntu, or a
+Currently, you should use the Linux subsystem with Ubuntu, or a
 Virtual Machine with Linux. You can find more information and a guide
 for setting up the Linux subsystem
 `here <https://medium.com/@gubanotorious/installing-and-running-neo-python-on-windows-10-284fb518b213>`__.
 
 Installing "Ubuntu" from Microsoft Store installs Ubuntu 16.04. You should install Ubuntu 18.04 from Microsoft Store found here: https://www.microsoft.com/en-us/p/ubuntu-1804/9n9tngvndl3q?activetab=pivot%3aoverviewtab
 
-Python 3.6
+Python 3.7
 ~~~~~~~~~~
 
 neo-python is compatible with **Python 3.6 and later**.
 
-On \*nix systems, install Python 3.6 via your package manager, or
+On \*nix systems, install Python 3.7 via your package manager, or
 download an installation package from the `official
-homepage <https://www.python.org/downloads/release/python-364/>`__.
+homepage <https://www.python.org/downloads/>`__.
 
 
 Install
@@ -196,7 +203,7 @@ could lead to version conflicts.
     
     # setup alias for python and pip
     
-    alias python=python3
+    alias python=python3.7
     alias pip=pip3
 
     # create virtual environment and activate
@@ -217,7 +224,7 @@ could lead to version conflicts.
     
     # setup alias for python and pip
     
-    alias python=python3
+    alias python=python3.7
     alias pip=pip3
 
     # create virtual environment and activate

--- a/README.rst
+++ b/README.rst
@@ -113,8 +113,7 @@ OSX
 Ubuntu/Debian 16.10+
 ^^^^^^^^^^^^^^^^^^^^
 
-Ubuntu starting at 16.10 supports Python 3.6+ in the official repositories. We recommend
-using Python 3.7. 
+Ubuntu starting at 16.10 supports Python 3.6+ in the official repositories.
 
 First, ensure Ubuntu is fully up-to-date with this:
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -2,7 +2,7 @@
 Installation
 ------------
 
-You will need to install the libleveldb library. Install `Python 3.6 <https://www.python.org/downloads/release/python-364/>`_ to make sure you don't run into any issues with your version of Python being different than the current maintainer's version. Note that Python 3.5 and below are not supported.
+You will need to install the libleveldb library. Install `Python 3.7 <https://www.python.org/downloads/release/python-370/>`_ to make sure you don't run into any issues with your version of Python being different than the current maintainer's version. Note that Python 3.5 and below are not supported.
 
 You should install platform specific items before installing ``neo-python``.
 
@@ -13,11 +13,19 @@ Platform Specific Instructions
 Ubuntu/Debian 16.10+
 """"""""""""""""""""
 
-Ubuntu starting at 16.10 supports Python 3.6 in the official repositories, and you can just install Python 3.6 and all the system dependencies like this:
+Ubuntu starting at 16.10 supports Python 3.6+ in the official repositories.
+
+First, ensure Ubuntu is fully up-to-date with this:
 
 ::
 
-    apt-get install python3.6 python3.6-dev python3-pip python3-venv libleveldb-dev libssl-dev g++
+   sudo apt-get update && sudo apt-get upgrade
+
+You can install Python 3.7 and all the system dependencies like this:
+
+::
+
+   sudo apt-get install python3.7 python3.7-dev python3.7-venv python3-pip libleveldb-dev libssl-dev g++
 
 
 Older Ubuntu versions (eg. 16.04)
@@ -130,15 +138,20 @@ Install from PyPi
 
 The easiest way to install ``neo-python`` on your machine is to download it and install from PyPi using ``pip``. First, we recommend you to create a virtual environment in order to isolate this installation from your system directories and then install it as you normally would do:
 
-  ::
+::
 
     # create project dir
     mkdir myproject
     cd myproject
+    
+    # setup alias for python and pip
+    
+    alias python=python3.7
+    alias pip=pip3
 
     # create virtual environment and activate
 
-    python3.6 -m venv venv # this can also be python3 -m venv venv depending on your environment
+    python -m venv venv
     source venv/bin/activate
 
     (venv) pip install neo-python
@@ -152,15 +165,21 @@ Make a Python 3 virtual environment and activate it via
 
 ::
 
-    python3.6 -m venv venv
+    git clone https://github.com/CityOfZion/neo-python.git
+    cd neo-python
+    
+    # setup alias for python and pip
+    
+    alias python=python3.7
+    alias pip=pip3
+
+    # create virtual environment and activate
+
+    python -m venv venv
     source venv/bin/activate
 
-Then install the requirements via
-
-::
-
-    pip install -U setuptools pip wheel
-    pip install -e .
+    # install the package in an editable form
+    (venv) pip install -e .
 
 
 Updating neo-python from Git

--- a/docs/source/installwindows.rst
+++ b/docs/source/installwindows.rst
@@ -4,6 +4,8 @@ Installation (Windows)
 The instructions are written for Windows 7 x64 with MSYS2 environment and Visual Studio 2017. It should probably work for other Windows distributions.
 Another option is to setup a Linux Subsystem with Ubuntu (see also `here <https://medium.com/@gubanotorious/installing-and-running-neo-python-on-windows-10-284fb518b213>`_ for more infos and a guide).
 
+ - Note: Installing "Ubuntu" from Microsoft Store installs Ubuntu 16.04. You should install Ubuntu 18.04 from Microsoft Store found here: https://www.microsoft.com/en-us/p/ubuntu-1804/9n9tngvndl3q?activetab=pivot%3aoverviewtab
+
 Building LevelDB
 ================
 


### PR DESCRIPTION
This update gives specific instructions for installing and running with Python3.7 with no prior dependencies installed.

Note: I uninstalled Ubuntu and re-installed running Windows 10. Everything runs smoothly.