### PR TITLE
Add ability to attach fee to send tx

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,13 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
-[0.7.4-dev] in progress
+[0.7.6] in progress
+-----------------------
+- adds ability to attach a fee to a ``send`` transaction:
+- update Node selection mechanism
+
+
+[0.7.5] 2018-07-19
 -----------------------
 - Update NodeLeader peer monitoring system
 - Add ability to configure size of requests for blocks as well as block processing queue size

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -3,7 +3,7 @@ from neo.Core.TX.Transaction import TransactionOutput, ContractTransaction
 from neo.Core.TX.TransactionAttribute import TransactionAttribute, TransactionAttributeUsage
 from neo.SmartContract.ContractParameterContext import ContractParametersContext
 from neo.Network.NodeLeader import NodeLeader
-from neo.Prompt.Utils import get_arg, get_from_addr, get_asset_id, lookup_addr_str, get_tx_attr_from_args, get_owners_from_params
+from neo.Prompt.Utils import get_arg, get_from_addr, get_asset_id, lookup_addr_str, get_tx_attr_from_args, get_owners_from_params, get_fee
 from neo.Prompt.Commands.Tokens import do_token_transfer, amount_from_string
 from neo.Prompt.Commands.Invoke import gather_signatures
 from neo.Wallets.NEP5Token import NEP5Token
@@ -26,7 +26,7 @@ def construct_and_send(prompter, wallet, arguments, prompt_password=True):
         arguments, from_address = get_from_addr(arguments)
         arguments, user_tx_attributes = get_tx_attr_from_args(arguments)
         arguments, owners = get_owners_from_params(arguments)
-
+        arguments, priority_fee = get_fee(arguments)
         to_send = get_arg(arguments)
         address_to = get_arg(arguments, 1)
         amount = get_arg(arguments, 2)
@@ -62,6 +62,10 @@ def construct_and_send(prompter, wallet, arguments, prompt_password=True):
             return False
 
         fee = Fixed8.Zero()
+        if priority_fee is not None:
+            fee = priority_fee
+
+        print("sending with fee: %s " % fee.ToString())
 
         output = TransactionOutput(AssetId=assetId, Value=f8amount, script_hash=scripthash_to)
         tx = ContractTransaction(outputs=[output])

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -131,6 +131,22 @@ def get_from_addr(params):
     return params, from_addr
 
 
+def get_fee(params):
+    to_remove = []
+    fee = None
+    for item in params:
+        if '--fee=' in item:
+            to_remove.append(item)
+            try:
+                fee = get_asset_amount(item.replace('--fee=', ''), Blockchain.SystemCoin().Hash)
+            except Exception as e:
+                pass
+    for item in to_remove:
+        params.remove(item)
+
+    return params, fee
+
+
 def get_parse_addresses(params):
     if '--no-parse-addr' in params:
         params.remove('--no-parse-addr')

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -646,7 +646,7 @@ class Wallet:
         # abstract
         pass
 
-    def ProcessBlocks(self, block_limit=10000):
+    def ProcessBlocks(self, block_limit=1000):
         """
         Method called on a loop to check the current height of the blockchain.  If the height of the blockchain
         is more than the current stored height in the wallet, we get the next block in line and

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -150,7 +150,7 @@ class PromptInterface:
                 'withdraw cleanup # cleans up completed holds',
                 'withdraw # withdraws the first hold availabe',
                 'withdraw all # withdraw all holds available',
-                'send {assetId or name} {address} {amount} (--from-addr={addr})',
+                'send {assetId or name} {address} {amount} (--from-addr={addr}) (--fee={priority_fee})',
                 'sign {transaction in JSON format}',
                 'testinvoke {contract hash} [{params} or --i] (--attach-neo={amount}, --attach-gas={amount}) (--from-addr={addr}) --no-parse-addr (parse address strings to script hash bytearray)',
                 'debugstorage {on/off/reset}'


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

- adds ability to attach a fee to a `send` transaction:
`send neo {Addr} {amount} --fee=.0000001`

**How did you make sure your solution works?**
-manual testing

**Are there any special changes in the code that we should be aware of?**
-no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
