### PR TITLE
Fix block_import script

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.7.7-dev] in progress
 ------------------------
-- ...
+- Fix Block header problems with ``block_import.py`` script
 
 
 [0.7.6] 2018-08-02

--- a/neo/Core/Block.py
+++ b/neo/Core/Block.py
@@ -25,7 +25,7 @@ class Block(BlockBase, InventoryMixin):
     #  该区块的区块头
     #  < / summary >
 
-    __header = None
+    _header = None
 
     __is_trimmed = False
     #  < summary >
@@ -106,11 +106,11 @@ class Block(BlockBase, InventoryMixin):
         Returns:
             neo.Core.Header:
         """
-        if not self.__header:
-            self.__header = Header(self.PrevHash, self.MerkleRoot, self.Timestamp,
-                                   self.Index, self.ConsensusData, self.NextConsensus, self.Script)
+        if not self._header:
+            self._header = Header(self.PrevHash, self.MerkleRoot, self.Timestamp,
+                                  self.Index, self.ConsensusData, self.NextConsensus, self.Script)
 
-        return self.__header
+        return self._header
 
     def Size(self):
         """

--- a/neo/bin/import_blocks.py
+++ b/neo/bin/import_blocks.py
@@ -99,6 +99,9 @@ def main():
             if block.Index > 0:
                 chain.AddBlockDirectly(block)
 
+            # reset blockheader
+            block._header = None
+
             # reset stream
             reader.stream.Cleanup()
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Fix #534 

**How did you solve this problem?**
Make block._header accessible and reset header to None after each block commit as a suggested solution by @hal0x2328 

**How did you make sure your solution works?**

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
