### PR TITLE
disallow writing amounts in SmartContractEvent which are greater than…

### DIFF
--- a/neo/SmartContract/SmartContractEvent.py
+++ b/neo/SmartContract/SmartContractEvent.py
@@ -265,7 +265,12 @@ class NotifyEvent(SmartContractEvent):
         if self.is_standard_notify:
             writer.WriteUInt160(self.addr_from)
             writer.WriteUInt160(self.addr_to)
-            writer.WriteVarInt(self.amount)
+
+            if self.Amount < 0xffffffffffffffff:
+                writer.WriteVarInt(self.amount)
+            else:
+                logger.warn("Writing Payload value amount greater than ulong long is not allowed.  Setting to ulong long max")
+                writer.WriteVarInt(0xffffffffffffffff)
 
     def DeserializePayload(self, reader):
         try:


### PR DESCRIPTION
… ulong long max


**What current issue(s) does this address, or what feature is it adding?**
- Someone is dispatching events with very strange amounts.  This fix disallows trying to write an amount that is longer than ulong long max.

**How did you make sure your solution works?**
- manual testing.

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
