### PR TITLE
Fix ContextItem JSON decode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Adds support for ``IsPayable`` flag in prompt.
 - Fix Block header problems with ``block_import.py`` script
 - Update bootstrap files for mainnet and testnet
+- Fix ``ContextItem`` JSOn decoding
 
 [0.7.6] 2018-08-02
 ------------------

--- a/neo/SmartContract/ContractParameterContext.py
+++ b/neo/SmartContract/ContractParameterContext.py
@@ -15,7 +15,6 @@ from neo.Core.Witness import Witness
 
 
 class ContractParamater:
-
     Type = None
     Value = None
 
@@ -34,7 +33,6 @@ class ContractParamater:
 
 
 class ContextItem:
-
     Script = None
     ContractParameters = None
     Signatures = None
@@ -52,7 +50,10 @@ class ContextItem:
             if type(self.Script) is str:
                 jsn['script'] = self.Script
             else:
-                jsn['script'] = self.Script.decode()
+                try:
+                    jsn['script'] = self.Script.decode()
+                except UnicodeDecodeError:
+                    jsn['script'] = binascii.hexlify(self.Script).decode()
         jsn['parameters'] = [p.ToJson() for p in self.ContractParameters]
         if self.Signatures is not None:
             jsn['signatures'] = {}
@@ -68,7 +69,6 @@ class ContextItem:
 
 
 class ContractParametersContext:
-
     Verifiable = None
 
     ScriptHashes = None
@@ -240,7 +240,7 @@ class ContractParametersContext:
                 if type(item.Script) is str:
                     item.Script = item.Script.encode('utf-8')
                 vscript = item.Script
-#                logger.info("SCRIPT IS %s " % item.Script)
+            #                logger.info("SCRIPT IS %s " % item.Script)
 
             witness = Witness(
                 invocation_script=sb.ToArray(),


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
I've been seeing this error in travis-ci logs for a while now, figured i'd finally fix it.

```
Transaction initiated, but the signature is incomplete
could not send: 'utf-8' codec can't decode byte 0x8c in position 4: invalid start byte 
  File "/home/travis/virtualenv/python3.6.3/bin/coverage", line 11, in <module>
    sys.exit(main())
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/coverage/cmdline.py", line 753, in main
    status = CoverageScript().command_line(argv)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/coverage/cmdline.py", line 488, in command_line
    return self.do_run(options, args)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/coverage/cmdline.py", line 624, in do_run
    self.run_python_module(args[0], args)
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/coverage/execfile.py", line 114, in run_python_module
    run_python_file(pathname, args, package=packagename, modulename=modulename, path0="")
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/coverage/execfile.py", line 184, in run_python_file
    exec(code, main_mod.__dict__)
  File "/opt/python/3.6.3/lib/python3.6/unittest/__main__.py", line 18, in <module>
    main(module=None)
  File "/opt/python/3.6.3/lib/python3.6/unittest/main.py", line 95, in __init__
    self.runTests()
  File "/opt/python/3.6.3/lib/python3.6/unittest/main.py", line 256, in runTests
    self.result = testRunner.run(self.test)
  File "/opt/python/3.6.3/lib/python3.6/unittest/runner.py", line 176, in run
    test(result)
  File "/opt/python/3.6.3/lib/python3.6/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/opt/python/3.6.3/lib/python3.6/unittest/suite.py", line 122, in run
    test(result)
  File "/opt/python/3.6.3/lib/python3.6/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/opt/python/3.6.3/lib/python3.6/unittest/suite.py", line 122, in run
    test(result)
  File "/opt/python/3.6.3/lib/python3.6/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/opt/python/3.6.3/lib/python3.6/unittest/suite.py", line 122, in run
    test(result)
  File "/opt/python/3.6.3/lib/python3.6/unittest/case.py", line 653, in __call__
    return self.run(*args, **kwds)
  File "/opt/python/3.6.3/lib/python3.6/unittest/case.py", line 605, in run
    testMethod()
  File "/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/mock/mock.py", line 1305, in patched
    return func(*args, **keywargs)
  File "/home/travis/build/CityOfZion/neo-python/neo/Prompt/Commands/tests/test_send_command.py", line 191, in test_14_owners
    construct_and_send(None, wallet, args, prompt_password=False)
  File "/home/travis/build/CityOfZion/neo-python/neo/Prompt/Commands/Send.py", line 142, in construct_and_send
    traceback.print_stack()
Traceback (most recent call last):
  File "/home/travis/build/CityOfZion/neo-python/neo/Prompt/Commands/Send.py", line 137, in construct_and_send
    print(json.dumps(context.ToJson(), separators=(',', ':')))
  File "/home/travis/build/CityOfZion/neo-python/neo/SmartContract/ContractParameterContext.py", line 268, in ToJson
    jsn['items'][shkey] = value.ToJson()
  File "/home/travis/build/CityOfZion/neo-python/neo/SmartContract/ContractParameterContext.py", line 55, in ToJson
    jsn['script'] = self.Script.decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8c in position 4: invalid start byte
.sending with fee: 0.0 
```

**How did you solve this problem?**
use binascii to create the human readable bytes

**How did you make sure your solution works?**
`make test` and manually testing does no longer show the error

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
