### PR TITLE
Development

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 ------------------------
 - Adds support for ``IsPayable`` flag in prompt.
 - Fix Block header problems with ``block_import.py`` script
+- Sync GAS price calculations with current Neo core
 
 
 [0.7.6] 2018-08-02

--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -319,6 +319,7 @@ class ApplicationEngine(ExecutionEngine):
         api_name = strbytes.decode('utf-8')
 
         api = api_name.replace('Antshares.', 'Neo.')
+        api = api.replace('System.', 'Neo.')
 
         if api == "Neo.Runtime.CheckWitness":
             return 200
@@ -329,10 +330,10 @@ class ApplicationEngine(ExecutionEngine):
         elif api == "Neo.Blockchain.GetBlock":
             return 200
 
-        elif api == "Neo.Runtime.GetTime":
+        elif api == "Neo.Blockchain.GetTransaction":
             return 100
 
-        elif api == "Neo.Blockchain.GetTransaction":
+        elif api == "Neo.Blockchain.GetTransactionHeight":
             return 100
 
         elif api == "Neo.Blockchain.GetAccount":


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
GAS price calculation for syscalls in neo-python is out-of-sync with the core code in neo-project. neo-python was calculating a GAS price of 0.1 GAS for `GetTime` which is not present in the Neo core GAS price calculation. 

Additionally, a GAS fee of 0.1 for the API call `GetTransactionHeight` was added to core but was not present in neo-python. 

Finally, a new prefix `System` was added to the core code in addition to `Neo.` and `Antshares.` which was not handled in neo-python.

**How did you solve this problem?*
I brought the GAS price calculation code in ApplicationEngine.py back into sync with the ApplicationEngine.cs in the Neo core code.

**How did you make sure your solution works?**
I ran an audit comparing the unchanged neo-python code with neo-cli transaction GAS usage/state results, identifying specific transactions that were inconsistent, the first one of which was 94ac4c0e5d8d9f16246ca5eba63ab5b6b5fa6f38952a8707b9c0de8d772d9a20.

After applying the changes, I ran the audit again, and the GAS calculations for previously inconsistent transactions including the one above are now correct in the modified neo-python instance.

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
