### PR TITLE
Add ISSUE question and direction to first update to latest version

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 ### Current behavior
-
+- Are you using the latest available version? If not, first update and verify the problem still exists.
 - What is the problem?
 - Include a screenshot if it makes sense.
 


### PR DESCRIPTION
There are quite some issues that are being reported where people use an old `neo-python` version. I've added a line asking to first update before reporting. 

I kept the question for writing down in which version the issue happens because reporting might happen while on the latest version (at that point in time) but investigation might happen later on. This way we know ourselves to first test on a later version if we were busy with other higher priority items. 
