### PR TITLE
Fix duplicate transaction attributes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - Update bootstrap files for mainnet and testnet
 - Fix ``ContextItem`` JSOn decoding
 - Fix ``sys_fee`` calculation for certain transaction types
+- Fix ``TransactionAttribute`` duplication in Transactions
 
 
 [0.7.6] 2018-08-02

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -240,17 +240,16 @@ def make_unique_script_attr(attributes):
         if attr.Usage != TransactionAttributeUsage.Script:
             filtered_attr.append(attr)
         else:
-            if isinstance(attr.Data, UInt160):
+            data = attr.Data
+            if isinstance(data, UInt160):
                 # convert it to equal type
                 data = attr.Data.ToArray()
 
-                # only add if it's not already in the list
-                if data not in script_list:
-                    script_list.append(data)
-                    filtered_attr.append(attr)
-            else:
-                script_list.append(attr.Data)
+            # only add if it's not already in the list
+            if data not in script_list:
+                script_list.append(data)
                 filtered_attr.append(attr)
+
     return filtered_attr
 
 

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -34,16 +34,16 @@ from neo.Core.Blockchain import Blockchain
 from neo.EventHub import events
 from logzero import logger
 from prompt_toolkit import prompt
+from copy import deepcopy
 
 from neocore.Cryptography.ECCurve import ECDSA
-
+from neocore.UInt160 import UInt160
 from neo.VM.OpCode import PACK
 
 DEFAULT_MIN_FEE = Fixed8.FromDecimal(.0001)
 
 
 def InvokeContract(wallet, tx, fee=Fixed8.Zero(), from_addr=None, owners=None):
-
     if from_addr is not None:
         from_addr = lookup_addr_str(wallet, from_addr)
 
@@ -225,10 +225,38 @@ def TestInvokeContract(wallet, args, withdrawal_tx=None,
     return None, None, None, None
 
 
+def make_unique_script_attr(attributes):
+    """
+    Filter out duplicate `Script` TransactionAttributeUsage types.
+    Args:
+        attributes: a list of TransactionAttribute's
+
+    Returns:
+        list:
+    """
+    filtered_attr = []
+    script_list = []
+    for attr in attributes:
+        if attr.Usage != TransactionAttributeUsage.Script:
+            filtered_attr.append(attr)
+        else:
+            if isinstance(attr.Data, UInt160):
+                # convert it to equal type
+                data = attr.Data.ToArray()
+
+                # only add if it's not already in the list
+                if not data in script_list:
+                    script_list.append(data)
+                    filtered_attr.append(attr)
+            else:
+                script_list.append(attr.Data)
+                filtered_attr.append(attr)
+    return filtered_attr
+
+
 def test_invoke(script, wallet, outputs, withdrawal_tx=None,
                 from_addr=None, min_fee=DEFAULT_MIN_FEE,
                 invoke_attrs=None, owners=None):
-
     # print("invoke script %s " % script)
 
     if from_addr is not None:
@@ -258,7 +286,7 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None,
     tx.Version = 1
     tx.scripts = []
     tx.Script = binascii.unhexlify(script)
-    tx.Attributes = [] if invoke_attrs is None else invoke_attrs
+    tx.Attributes = [] if invoke_attrs is None else deepcopy(invoke_attrs)
 
     script_table = CachedScriptTable(contracts)
     service = StateMachine(accounts, validators, assets, contracts, storages, None)
@@ -266,6 +294,7 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None,
     if len(outputs) < 1:
         contract = wallet.GetDefaultContract()
         tx.Attributes.append(TransactionAttribute(usage=TransactionAttributeUsage.Script, data=contract.ScriptHash))
+        tx.Attributes = make_unique_script_attr(tx.Attributes)
 
     # same as above. we don't want to re-make the transaction if it is a withdrawal tx
     if withdrawal_tx is not None:
@@ -282,14 +311,15 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None,
             #            print("contract %s %s" % (wallet.GetDefaultContract().ScriptHash, owner))
             if wallet.GetDefaultContract().ScriptHash != owner:
                 wallet_tx.Attributes.append(TransactionAttribute(usage=TransactionAttributeUsage.Script, data=owner))
+                wallet_tx.Attributes = make_unique_script_attr(tx.Attributes)
         context = ContractParametersContext(wallet_tx, isMultiSig=True)
 
     if context.Completed:
         wallet_tx.scripts = context.GetScripts()
     else:
         logger.warn("Not gathering signatures for test build.  For a non-test invoke that would occur here.")
-#        if not gather_signatures(context, wallet_tx, owners):
-#            return None, [], 0, None
+    #        if not gather_signatures(context, wallet_tx, owners):
+    #            return None, [], 0, None
 
     engine = ApplicationEngine(
         trigger_type=TriggerType.Application,
@@ -336,14 +366,14 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None,
             wallet_tx.Gas = tx_gas
             # reset the wallet outputs
             wallet_tx.outputs = outputs
-            wallet_tx.Attributes = [] if invoke_attrs is None else invoke_attrs
+            wallet_tx.Attributes = [] if invoke_attrs is None else deepcopy(invoke_attrs)
 
             return wallet_tx, net_fee, engine.EvaluationStack.Items, engine.ops_processed
 
         # this allows you to to test invocations that fail
         else:
             wallet_tx.outputs = outputs
-            wallet_tx.Attributes = [] if invoke_attrs is None else invoke_attrs
+            wallet_tx.Attributes = [] if invoke_attrs is None else deepcopy(invoke_attrs)
             return wallet_tx, min_fee, [], engine.ops_processed
 
     except Exception as e:
@@ -355,7 +385,6 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None,
 def test_deploy_and_invoke(deploy_script, invoke_args, wallet,
                            from_addr=None, min_fee=DEFAULT_MIN_FEE, invocation_test_mode=True,
                            debug_map=None, invoke_attrs=None, owners=None):
-
     bc = GetBlockchain()
 
     sn = bc._db.snapshot()
@@ -392,6 +421,7 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet,
 
     contract = wallet.GetDefaultContract()
     dtx.Attributes = [TransactionAttribute(usage=TransactionAttributeUsage.Script, data=Crypto.ToScriptHash(contract.Script, unhex=False))]
+    dtx.Attributes = make_unique_script_attr(dtx.Attributes)
 
     to_dispatch = []
 
@@ -491,13 +521,14 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet,
         itx.outputs = outputs
         itx.inputs = []
         itx.scripts = []
-        itx.Attributes = invoke_attrs if invoke_attrs else []
+        itx.Attributes = deepcopy(invoke_attrs) if invoke_attrs else []
         itx.Script = binascii.unhexlify(out)
 
         if len(outputs) < 1 and not owners:
             contract = wallet.GetDefaultContract()
             itx.Attributes.append(TransactionAttribute(usage=TransactionAttributeUsage.Script,
                                                        data=contract.ScriptHash))
+            itx.Attributes = make_unique_script_attr(itx.Attributes)
 
         itx = wallet.MakeTransaction(tx=itx, from_addr=from_addr)
 
@@ -508,16 +539,17 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet,
             owners = list(owners)
             for owner in owners:
                 itx.Attributes.append(TransactionAttribute(usage=TransactionAttributeUsage.Script, data=owner))
+                itx.Attributes = make_unique_script_attr(itx.Attributes)
             context = ContractParametersContext(itx, isMultiSig=True)
 
         if context.Completed:
             itx.scripts = context.GetScripts()
         else:
             logger.warn("Not gathering signatures for test build.  For a non-test invoke that would occur here.")
-#            if not gather_signatures(context, itx, owners):
-#                return None, [], 0, None
+        #            if not gather_signatures(context, itx, owners):
+        #                return None, [], 0, None
 
-#        print("gathered signatures %s " % itx.scripts)
+        #        print("gathered signatures %s " % itx.scripts)
 
         engine = ApplicationEngine(
             trigger_type=TriggerType.Application,

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -245,7 +245,7 @@ def make_unique_script_attr(attributes):
                 data = attr.Data.ToArray()
 
                 # only add if it's not already in the list
-                if not data in script_list:
+                if data not in script_list:
                     script_list.append(data)
                     filtered_attr.append(attr)
             else:

--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -183,7 +183,10 @@ def token_crowdsale_register(wallet, args, prompt_passwd=True):
     return False
 
 
-def do_token_transfer(token, wallet, from_address, to_address, amount, prompt_passwd=True, tx_attributes=[]):
+def do_token_transfer(token, wallet, from_address, to_address, amount, prompt_passwd=True, tx_attributes=None):
+    if not tx_attributes:
+        tx_attributes = []
+
     if from_address is None:
         print("Please specify --from-addr={addr} to send NEP5 tokens")
         return False

--- a/neo/Wallets/NEP5Token.py
+++ b/neo/Wallets/NEP5Token.py
@@ -150,7 +150,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
 
         return 0
 
-    def Transfer(self, wallet, from_addr, to_addr, amount, tx_attributes=[]):
+    def Transfer(self, wallet, from_addr, to_addr, amount, tx_attributes=None):
         """
         Transfer a specified amount of the NEP5Token to another address.
 
@@ -167,6 +167,9 @@ class NEP5Token(VerificationCode, SerializableMixin):
                 int: the transaction fee.
                 list: the neo VM evaluationstack results.
         """
+        if not tx_attributes:
+            tx_attributes = []
+
         sb = ScriptBuilder()
         sb.EmitAppCallWithOperationAndArgs(self.ScriptHash, 'transfer',
                                            [parse_param(from_addr, wallet), parse_param(to_addr, wallet),


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Fix https://github.com/CityOfZion/neo-python/issues/558

**How did you solve this problem?**
One issue was caused by default argument mutation ([read more here](https://docs.python-guide.org/writing/gotchas/))

The other caused by not checking for duplicate scripts before adding them as transaction attributes. Ideally we'd build a transaction via `setters` and have the setter filter for duplicates. Right now I added a separate script. 

I also had to `deepcopy` the `invokeattrs` because they were assigned by reference which caused reusing issues later on. [example location](https://github.com/ixje/neo-python/blob/025d18a7919226685aa9d2c82d3a825eaa11a78a/neo/Prompt/Commands/Invoke.py#L289)

**How did you make sure your solution works?**
Manual. Followed the same steps as described in the issue.

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
