### PR TITLE
Add "getwalletheight" RPC method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.7.7-dev] in progress
 ------------------------
+- Add getwalletheight RPC call
 - Add support for Peewee 3.6.4
 - Adds support for ``IsPayable`` flag in prompt.
 - Fix Block header problems with ``block_import.py`` script

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -259,7 +259,7 @@ class JsonRpcApi:
                 return self.wallet.WalletHeight
             else:
                 raise JsonRpcError(-400, "Access denied.")
-                
+
         elif method == "listaddress":
             if self.wallet:
                 return self.list_address()

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -31,6 +31,7 @@ from neo.VM.ScriptBuilder import ScriptBuilder
 from neo.VM.VMState import VMStateStr
 from neo.Implementations.Wallets.peewee.Models import Account
 from neo.Prompt.Utils import get_asset_id
+from neo.Wallets.Wallet import Wallet
 
 
 class JsonRpcError(Exception):
@@ -253,6 +254,12 @@ class JsonRpcApi:
             else:
                 raise JsonRpcError(-400, "Access denied.")
 
+        elif method == "getwalletheight":
+            if self.wallet:
+                return self.wallet.WalletHeight
+            else:
+                raise JsonRpcError(-400, "Access denied.")
+                
         elif method == "listaddress":
             if self.wallet:
                 return self.list_address()

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -488,6 +488,25 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         node.Peers = []
         node.ADDRS = []
 
+    def test_getwalletheight_no_wallet(self):
+        req = self._gen_rpc_req("getwalletheight", params=["some id here"])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+
+        error = res.get('error', {})
+
+        self.assertEqual(error.get('code', None), -400)
+        self.assertEqual(error.get('message', None), "Access denied.")
+
+    def test_getwalletheight(self):
+        self.app.wallet = UserWallet.Open(os.path.join(ROOT_INSTALL_PATH, "neo/data/neo-privnet.sample.wallet"), to_aes_key("coz"))
+        
+        req = self._gen_rpc_req("getwalletheight", params=[])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+        
+        self.assertEqual(1, res.get('result'))
+
     def test_getbalance_no_wallet(self):
         req = self._gen_rpc_req("getbalance", params=["some id here"])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -21,6 +21,7 @@ from neo.Blockchain import GetBlockchain
 from neo.Settings import settings
 from neo.Network.NodeLeader import NodeLeader
 from neo.Network.NeoNode import NeoNode
+from neo.Settings import ROOT_INSTALL_PATH
 
 
 def mock_request(body):

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -501,11 +501,11 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
 
     def test_getwalletheight(self):
         self.app.wallet = UserWallet.Open(os.path.join(ROOT_INSTALL_PATH, "neo/data/neo-privnet.sample.wallet"), to_aes_key("coz"))
-        
+
         req = self._gen_rpc_req("getwalletheight", params=[])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
-        
+
         self.assertEqual(1, res.get('result'))
 
     def test_getbalance_no_wallet(self):


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
This PR addresses issue #189 and adds new `getwalletheight` RPC method
Adds similar functionality to https://github.com/neo-project/neo-cli/pull/203

**How did you solve this problem?**
Trial and Error

**How did you make sure your solution works?**
Added two tests

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
