### PR TITLE
Add test for np-prompt using pexpect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.7.7-dev] in progress
 ------------------------
+- Adds test for np-prompt using pexpect
 - Add getwalletheight RPC call
 - Add support for Peewee 3.6.4
 - Adds support for ``IsPayable`` flag in prompt.

--- a/neo/bin/test_prompt.py
+++ b/neo/bin/test_prompt.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+import pexpect
+
+
+class PromptTest(TestCase):
+
+    def test_prompt_run(self):
+
+        child = pexpect.spawn('np-prompt')
+        child.expect([pexpect.EOF, pexpect.TIMEOUT], timeout=10)  # if test is failing consider increasing timeout time
+        before = child.before
+        text = before.decode('utf-8', 'ignore')
+        checktext = "neo>"
+        self.assertIn(checktext, text)
+        child.terminate()
+
+    def test_prompt_open_wallet(self):
+
+        child = pexpect.spawn('np-prompt')
+        child.send('open wallet fixtures/testwallet.db3\n')
+        child.send('testpassword\n')
+        child.expect([pexpect.EOF, pexpect.TIMEOUT], timeout=15)  # if test is failing consider increasing timeout time
+        before = child.before
+        text = before.decode('utf-8', 'ignore')
+        checktext = "Opened"
+        self.assertIn(checktext, text)
+        child.terminate()

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ neo-python-rpc==0.2.1
 neocore==0.4.11
 pbr==4.1.1
 peewee==3.6.4
+pexpect==4.2.1
 pluggy==0.6.0
 plyvel==1.0.5
 prompt-toolkit==2.0.3


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Addresses issue #490
Adds test_prompt.py for testing np-prompt with pexpect
Re-created from https://github.com/CityOfZion/neo-python/pull/536 for to solve compatibility problems

**How did you solve this problem?**
Learned about pexpect, trial and error

**How did you make sure your solution works?**
Using unittest

**Are there any special changes in the code that we should be aware of?**
Yes, requires installation of pexpect

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
