### PR TITLE
update pycryptodome to match neocore version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ psutil==5.4.6
 py==1.5.4
 pycodestyle==2.4.0
 pycparser==2.18
-pycryptodome==3.6.3
+pycryptodome==3.6.6
 Pygments==2.2.0
 pymitter==0.2.3
 Pympler==0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,6 @@ psutil==5.4.6
 py==1.5.4
 pycodestyle==2.4.0
 pycparser==2.18
-pycryptodome==3.6.6
 Pygments==2.2.0
 pymitter==0.2.3
 Pympler==0.5


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- Fix build issue when running integration tests with neo-core

**How did you solve this problem?**
- remove pycryptodome from `requirements.txt` since it is already in `neocore`


- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
