### PR TITLE
Update test_prompt.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.7.7-dev] in progress
 ------------------------
+- Update test_prompt.py to acheive passing neo-python-core build
 - Add Seedlist.rst and update Basicusage.rst for API Servers
 - Adds test for np-prompt using pexpect
 - Add getwalletheight RPC call

--- a/neo/bin/test_prompt.py
+++ b/neo/bin/test_prompt.py
@@ -6,7 +6,7 @@ class PromptTest(TestCase):
 
     def test_prompt_run(self):
 
-        child = pexpect.spawn('np-prompt')
+        child = pexpect.spawn('python neo/bin/prompt.py')
         child.expect([pexpect.EOF, pexpect.TIMEOUT], timeout=10)  # if test is failing consider increasing timeout time
         before = child.before
         text = before.decode('utf-8', 'ignore')
@@ -16,7 +16,7 @@ class PromptTest(TestCase):
 
     def test_prompt_open_wallet(self):
 
-        child = pexpect.spawn('np-prompt')
+        child = pexpect.spawn('python neo/bin/prompt.py')
         child.send('open wallet fixtures/testwallet.db3\n')
         child.send('testpassword\n')
         child.expect([pexpect.EOF, pexpect.TIMEOUT], timeout=15)  # if test is failing consider increasing timeout time


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Updates test_prompt to spawn prompt.py directly instead of using the shortcut `np-prompt`. Does not change the functionality of the test.

This PR was created to achieve a passing neo-python-core build to merge PR [#60](https://github.com/CityOfZion/neo-python-core/pull/60).
cc @localhuman 

**How did you solve this problem?**
Discussion with @localhuman and tested it personally.

**How did you make sure your solution works?**
Tested personally with unittest.

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
