### PR TITLE
Update #view help for `np-api-server`

### DIFF
--- a/docs/source/basicusage.rst
+++ b/docs/source/basicusage.rst
@@ -74,24 +74,28 @@ Example notifications plus help with all available arguments:
                      [--port-rpc PORT_RPC] [--port-rest PORT_REST]
                      [--logfile LOGFILE] [--syslog] [--syslog-local [0-7]]
                      [--disable-stderr] [--datadir DATADIR]
+                     [--maxpeers MAXPEERS] [--wallet WALLET] [--host HOST]
 
-  optional arguments:
+    optional arguments:
     -h, --help            show this help message and exit
     --datadir DATADIR     Absolute path to use for database directories
+    --maxpeers MAXPEERS   Max peers to use for P2P Joining
+    --wallet WALLET       Open wallet. Will allow you to use methods that
+                          require an open wallet
+    --host HOST           Hostname ( for example 127.0.0.1)
 
-  Network options:
+    Network options:
     --mainnet             Use MainNet
     --testnet             Use TestNet
     --privnet             Use PrivNet
     --coznet              Use CozNet
     --config CONFIG       Use a specific config file
 
-  Mode(s):
-    --port-rpc PORT_RPC   port to use for the json-rpc api (eg. 10332)
-    --port-rest PORT_REST
-                          port to use for the rest api (eg. 80)
+    Mode(s):
+    --port-rpc PORT_RPC     port to use for the json-rpc api (eg. 10332)
+    --port-rest PORT_REST   port to use for the rest api (eg. 80)
 
-  Logging options:
+    Logging options:
     --logfile LOGFILE     Logfile
     --syslog              Log to syslog instead of to log file ('user' is the
                           default facility)


### PR DESCRIPTION
I noticed the example for `np-api-server -h` was out of date. I am using this in a tutorial I am writing.