### PR TITLE
Fix issue with UserWallet.SaveStoredData

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.7.7-dev] in progress
 ------------------------
+- Fix issue with ``UserWallet.SaveStoredData``
 - Update neo-core to v0.5.1
 - Add appropriate GAS cost for ``CHECKMULTISIG`` for an array
 - Add appropriate GAS cost for ``VERIFY``

--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -325,7 +325,6 @@ class UserWallet(Wallet):
         return tokens
 
     def LoadStoredData(self, key):
-        logger.debug("Looking for key %s " % key)
         try:
             return Key.get(Name=key).Value
         except Exception as e:
@@ -352,12 +351,12 @@ class UserWallet(Wallet):
 
     def SaveStoredData(self, key, value):
         k = None
-
         try:
             k = Key.get(Name=key)
-            k.Value.replace(value)
+            k.Value = value
+            k.save()
         except Exception as e:
-            pass
+            print("Could not save stored data %s " % e)
 
         if k is None:
             k = Key.create(Name=key, Value=value)

--- a/neo/Wallets/test_wallet.py
+++ b/neo/Wallets/test_wallet.py
@@ -124,3 +124,10 @@ class WalletTestCase(NeoTestCase):
     def test_privnet_wallet(self):
         """ Simple test if we can open the privnet wallet """
         wallet = UserWallet.Open(os.path.join(ROOT_INSTALL_PATH, "neo/data/neo-privnet.sample.wallet"), to_aes_key("coz"))
+
+    def test_wallet_height(self):
+        wallet = UserWallet("fakepath", to_aes_key("123"), True)
+        wallet.SaveStoredData('Height', 1234)
+        wallet._current_height = wallet.LoadStoredData('Height')
+        self.assertEqual(wallet._current_height, 1234)
+        self.assertEqual(wallet.WalletHeight, 1234)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- Currently if you open a wallet and let it sync for a while, then close it, it reverts back to the original height if you open it back up again.

**How did you solve this problem?**
- Fix the `SaveStoredData` method to save an existing Key/Value pair properly

**How did you make sure your solution works?**
- Added a test

**Are there any special changes in the code that we should be aware of?**
- No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
