### PR TITLE
Update Invoke.py

### DIFF
--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -10,6 +10,7 @@ from neo.Implementations.Blockchains.LevelDB.DBCollection import DBCollection
 from neo.Implementations.Blockchains.LevelDB.DBPrefix import DBPrefix
 from neo.Implementations.Blockchains.LevelDB.CachedScriptTable import CachedScriptTable
 from neo.Implementations.Blockchains.LevelDB.DebugStorage import DebugStorage
+from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
 
 from neo.Core.State.AccountState import AccountState
 from neo.Core.State.AssetState import AssetState
@@ -144,10 +145,9 @@ def InvokeWithTokenVerificationScript(wallet, tx, token, fee=Fixed8.Zero(), invo
 def TestInvokeContract(wallet, args, withdrawal_tx=None,
                        parse_params=True, from_addr=None,
                        min_fee=DEFAULT_MIN_FEE, invoke_attrs=None, owners=None):
-
-    BC = GetBlockchain()
-
-    contract = BC.GetContract(args[0])
+    
+    blockchain = LevelDBBlockchain(settings.chain_leveldb_path)
+    contract = blockchain.GetContract(args[0])
 
     if contract:
         #

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -147,6 +147,7 @@ def TestInvokeContract(wallet, args, withdrawal_tx=None,
                        min_fee=DEFAULT_MIN_FEE, invoke_attrs=None, owners=None):
     
     blockchain = LevelDBBlockchain(settings.chain_leveldb_path)
+    Blockchain.RegisterBlockchain(blockchain)
     contract = blockchain.GetContract(args[0])
 
     if contract:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
When calling TestInvokeContract, the LevelDB blockchain is not initialised therefore the function GetContract returns null.

**How did you solve this problem?**
I added the object LevelDBBlockchain. Note: there has to be no other instance of np-promt running in the meantime.

**How did you make sure your solution works?**
I have executed the function token_crowdsale_register and it works.

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [ ] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
