### PR TITLE
update neo-boa version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changelog
 All notable changes to this project are documented in this file.
 
 [0.7.8-dev] 2018-xx-xx
+----------------------
 - Prefix ``vin`` JSON output format to match C#
+- Update ``neo-boa`` to v0.5.0 for Python 3.7 compatibility
 
 
 [0.7.7] 2018-08-23

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ memory-profiler==0.52.0
 mmh3==2.5.1
 mock==2.0.0
 mpmath==1.0.0
-neo-boa==0.4.9
+neo-boa==0.5.0
 neo-python-rpc==0.2.1
 neocore==0.5.1
 pbr==4.1.1


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- Makes neo-boa compatible with Python 3.7, so in theory this whole project should now be compatible with Python 3.7
- Should resolve #518 

**How did you solve this problem?**
- Update neo-boa version

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
