### PR TITLE
Update pexpect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 ----------------------
 - Prefix ``vin`` JSON output format to match C#
 - Update ``neo-boa`` to v0.5.0 for Python 3.7 compatibility
+- Update pexpect to 4.6.0 to be compatible with Python 3.7
 
 
 [0.7.7] 2018-08-23

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ neo-python-rpc==0.2.1
 neocore==0.5.1
 pbr==4.1.1
 peewee==3.6.4
-pexpect==4.2.1
+pexpect==4.6.0
 pluggy==0.6.0
 plyvel==1.0.5
 prompt-toolkit==2.0.3


### PR DESCRIPTION
Make pexpect compatible with Python 3.7

will solve build failure seen here: https://travis-ci.org/CityOfZion/neo-python/builds/420864567#L1656

and help solve this issue #518 

A similar issue can be seen here which was solved with pexpect 4.6.0: https://github.com/pexpect/pexpect/issues/453