### PR TITLE
fix invoke to allow signatures to be added

### DIFF
--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -51,6 +51,11 @@ def InvokeContract(wallet, tx, fee=Fixed8.Zero(), from_addr=None, owners=None):
 
     if wallet_tx:
 
+        if owners:
+            for owner in list(owners):
+                wallet_tx.Attributes.append(TransactionAttribute(usage=TransactionAttributeUsage.Script, data=owner))
+            wallet_tx.Attributes = make_unique_script_attr(tx.Attributes)
+
         context = ContractParametersContext(wallet_tx)
         wallet.Sign(context)
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- After some recent changes, the ability to invoke tx by specifying additional owners was broken.  This fixes that.


**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
