### PR TITLE
Feature max testops

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ All notable changes to this project are documented in this file.
 - Update ``neo-boa`` to v0.5.0 for Python 3.7 compatibility
 - Update pexpect to 4.6.0 to be compatible with Python 3.7
 - Accept incoming node connections, configurable via protocol config file setting
-
+- Fixes vulnerability to RPC invoke functionality that can send node into unclosed loop during 'test' invokes
 
 [0.7.7] 2018-08-23
 ------------------

--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -38,6 +38,8 @@ class ApplicationEngine(ExecutionEngine):
 
     invocation_args = None
 
+    max_free_ops = 500000
+
     def GasConsumed(self):
         return Fixed8(self.gas_consumed)
 
@@ -231,6 +233,11 @@ class ApplicationEngine(ExecutionEngine):
 
                 if not self.testMode and self.gas_consumed > self.gas_amount:
                     logger.debug("NOT ENOUGH GAS")
+                    self._VMState |= VMState.FAULT
+                    return False
+
+                if self.testMode and self.ops_processed > self.max_free_ops:
+                    logger.error("Too many free operations processed")
                     self._VMState |= VMState.FAULT
                     return False
 

--- a/neo/SmartContract/tests/test_unclosed_while_loop.py
+++ b/neo/SmartContract/tests/test_unclosed_while_loop.py
@@ -1,0 +1,31 @@
+import os
+from boa_test.tests.boa_test import BoaTest
+from boa.compiler import Compiler
+from neo.Prompt.Commands.BuildNRun import TestBuild
+from neo.VM.ExecutionEngine import ExecutionEngine
+from mock import patch
+from neo.Settings import settings
+from logging import DEBUG, INFO
+import binascii
+
+
+class StringIn(str):
+    def __eq__(self, other):
+        return self in other
+
+
+class TestVMErrors(BoaTest):
+    engine = ExecutionEngine()
+    script = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestVMErrors, cls).setUpClass()
+        output = Compiler.instance().load('%s/sc_vm_errors.py' % os.path.dirname(__file__)).default
+        cls.script = binascii.unhexlify(b'00c56b620000')
+        settings.set_loglevel(DEBUG)
+
+    @patch('logzero.logger.error')
+    def test_invalid_array_index(self, mocked_logger):
+        tx, results, total_ops, engine = TestBuild(self.script, [], self.GetWallet1(), '', 'ff')
+        mocked_logger.assert_called_with(StringIn('Too many free operations processed'))


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- Fixes vulnerability to RPC invoke functionality that can send node into unclosed loop during 'test' invokes.

**How did you solve this problem?**
- Limit amount of 'free' operations in application engine to 500k

**How did you make sure your solution works?**
- Added a test

**Are there any special changes in the code that we should be aware of?**
- No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
