### PR TITLE
Bugfix open newly created wallet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ All notable changes to this project are documented in this file.
 - Update pexpect to 4.6.0 to be compatible with Python 3.7
 - Accept incoming node connections, configurable via protocol config file setting
 - Fixes vulnerability to RPC invoke functionality that can send node into unclosed loop during 'test' invokes
+- Fix issue with opening recently created wallets
+
 
 [0.7.7] 2018-08-23
 ------------------

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -111,8 +111,7 @@ class Wallet:
                 raise Exception("Password hash not found in database")
 
             hkey = hashlib.sha256(passwordKey).digest()
-
-            if self.LoadStoredData('MigrationState') != '1':
+            if int(self.LoadStoredData('MigrationState')) != 1:
                 raise Exception("This wallet is currently vulnerable. Please "
                                 "execute the \"reencrypt_wallet.py\" script "
                                 "on this wallet before continuing")


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- Wallets created after the PeeWee updates have a `MigrationState` of `b'1'` instead of `'1'` as previously, which made it impossible to open a newly created wallet. 

**How did you solve this problem?**
- This change coerces the value to an integer and compares `MigrationState` to `1` so that both versions will work.

**How did you make sure your solution works?**
- manual testing

**Are there any special changes in the code that we should be aware of?**
- I would not be surprised if there are other similar bugs related to the wallet.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
