### PR TITLE
fix for import_blocks.py block hash caching issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - Accept incoming node connections, configurable via protocol config file setting
 - Fixes vulnerability to RPC invoke functionality that can send node into unclosed loop during 'test' invokes
 - Fix issue with opening recently created wallets
+- Fix import_blocks.py block hash caching issue
 
 
 [0.7.7] 2018-08-23

--- a/neo/Core/BlockBase.py
+++ b/neo/Core/BlockBase.py
@@ -117,6 +117,7 @@ class BlockBase(VerifiableMixin):
         Args:
             reader (neo.IO.BinaryReader):
         """
+        self.__hash = None
         self.DeserializeUnsigned(reader)
         byt = reader.ReadByte()
         if int(byt) != 1:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

import_blocks.py reuses a block object when each new block is read from the chain.acc file, but once a block hash for an block object is requested for the first time, it is cached, so future deserializations of new blocks into the existing object will be associated with the wrong hash.

**How did you solve this problem?**

I added code to `Deserialize` in neo/Core/BlockBase.py to set the private `__hash` variable to `None` before deserializing a new block.

**How did you make sure your solution works?**

Tested import_blocks.py  - before the change, any imported block would have no transaction results since they were all stored with the wrong hash. After the change, blocks returned the correct list of transactions.

**Are there any special changes in the code that we should be aware of?**

No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
