### PR TITLE
Add `getaddresstxs` RPC method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - Accept incoming node connections, configurable via protocol config file setting
 - Fixes vulnerability to RPC invoke functionality that can send node into unclosed loop during 'test' invokes
 - Fix issue with opening recently created wallets
+- Add `getaddresstxs` RPC method
 
 
 [0.7.7] 2018-08-23

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -153,7 +153,7 @@ class JsonRpcApi:
 
                     for info in req[p]['vout']:
                         address = info['address']
-        
+
                         if address == params[0]:
                             txid = req[p]['txid']
                             tx_type = req[p]['type']

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -134,6 +134,35 @@ class JsonRpcApi:
                     raise JsonRpcError(-2146233033, "One of the identified items was in an invalid format.")
 
             return acct.ToJson()
+        
+        elif method == "getaddresstxs":
+            if params[1] <= 0:
+                return JsonRpcError(-32600, "Invalid Request")
+
+            first_block = Blockchain.Default().Height
+
+            all_transactions = []
+            block_transactions = {}
+
+            q = first_block - 1
+            while q >= 0 and len(all_transactions) < params[1]:
+                blk = self.get_block(q)
+                req = blk['tx']
+                p = 0
+                while p <= len(req) - 1:
+
+                    for info in req[p]['vout']:
+                        address = info['address']
+        
+                        if address == params[0]:
+                            txid = req[p]['txid']
+                            tx_type = req[p]['type']
+                            block_transactions = {"addr": address, "txid": txid, "type": tx_type, "block": blk['index']}
+
+                            all_transactions.append(block_transactions)
+                    p += 1
+                q -= 1
+            return all_transactions
 
         elif method == "getassetstate":
             asset_id = UInt256.ParseString(params[0])
@@ -277,6 +306,15 @@ class JsonRpcApi:
                 raise JsonRpcError(-400, "Access denied.")
 
         raise JsonRpcError.methodNotFound()
+
+    def get_block(self, block):
+        query = Blockchain.Default().GetBlock(block)
+        if not query:
+            raise JsonRpcError(-100, "Unknown block")
+        query.LoadTransactions()
+        jsn = query.ToJson()
+        return jsn
+
 
     def get_custom_error_payload(self, request_id, code, message):
         return {

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -134,7 +134,7 @@ class JsonRpcApi:
                     raise JsonRpcError(-2146233033, "One of the identified items was in an invalid format.")
 
             return acct.ToJson()
-        
+
         elif method == "getaddresstxs":
             if params[1] <= 0:
                 return JsonRpcError(-32600, "Invalid Request")
@@ -314,7 +314,6 @@ class JsonRpcApi:
         query.LoadTransactions()
         jsn = query.ToJson()
         return jsn
-
 
     def get_custom_error_payload(self, request_id, code, message):
         return {

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -131,6 +131,26 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         self.assertEqual(-2146233033, res['error']['code'])
         self.assertEqual('One of the identified items was in an invalid format.', res['error']['message'])
 
+    def test_get_address_txs(self):
+        addr = "AXjaFSP23Jkbe6Pk9pPGT6NBDs1HVdqaXK"
+        num_tx = 5
+        req = self._gen_rpc_req("getaddresstxs", params=[addr, num_tx])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+        self.assertEqual(5, len(res['result']))
+        for data in res['result']:
+            address = data['addr']
+            self.assertEqual(addr, address)
+        self.assertNotEqual(res['result'][0]['block'], res['result'][1]['block'])
+
+    def test_get_address_txs_bad(self):
+        addr = "AXjaFSP23Jkbe6Pk9pPGT6NBDs1HVdqaXK"
+        # missing number of tx
+        req = self._gen_rpc_req("getaddresstxs", params=[addr])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+        self.assertIn("error", res)
+
     def test_get_asset_state(self):
         asset_str = '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'
         req = self._gen_rpc_req("getassetstate", params=[asset_str])


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Adds `getaddresstxs` RPC method
Keep in mind the user must designate how many tx he/she is looking for (e.g. the last 5 txs).
This is because crawling the entire blockchain for every tx for an address takes a long time.

This helps address issue #189 

**How did you solve this problem?**
Trial and Error

**How did you make sure your solution works?**
Unittest

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
