### PR TITLE
resolve simultaneous port usage for #522

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ All notable changes to this project are documented in this file.
 - Prefix ``vin`` JSON output format to match C#
 - Update ``neo-boa`` to v0.5.0 for Python 3.7 compatibility
 - Update pexpect to 4.6.0 to be compatible with Python 3.7
-- Accept incoming node connections, configurable via protocol config file setting
+- Accept incoming node connections, configurable via protocol config file setting (default: OFF)
 - Fixes vulnerability to RPC invoke functionality that can send node into unclosed loop during 'test' invokes
 
 [0.7.7] 2018-08-23

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -130,8 +130,7 @@ class NodeLeader:
         self.peer_check_loop.start(240, now=False)
 
         if settings.ACCEPT_INCOMING_PEERS:
-            endpoint = TCP4ServerEndpoint(reactor, settings.NODE_PORT)
-            endpoint.listen(NeoClientFactory(incoming_client=True))
+            reactor.listenTCP(settings.NODE_PORT, NeoClientFactory(incoming_client=True))
 
     def setBlockReqSizeAndMax(self, breqpart=0, breqmax=0):
         if breqpart > 0 and breqmax > 0 and breqmax > breqpart:

--- a/neo/data/protocol.mainnet.json
+++ b/neo/data/protocol.mainnet.json
@@ -48,7 +48,7 @@
     "SslCertPassword": "",
     "BootstrapFile": "https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/Main2600xxx.tar.gz",
     "NotificationBootstrapFile": "https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/MainNotif2600xxx.tar.gz",
-    "DebugStorage":1,
-    "AcceptIncomingPeers": true
+    "DebugStorage": 1,
+    "AcceptIncomingPeers": false
   }
 }

--- a/neo/data/protocol.privnet.json
+++ b/neo/data/protocol.privnet.json
@@ -28,7 +28,7 @@
     "DataDirectoryPath": "Chains/privnet",
     "NotificationDataPath": "Chains/privnet_notif",
     "RPCPort": 20332,
-    "NodePort": 20339,
+    "NodePort": 20333,
     "WsPort": 20334,
     "UriPrefix": [
       "http://*:20332"
@@ -38,6 +38,6 @@
     "BootstrapFile": "",
     "NotificationBootstrapFile": "",
     "DebugStorage": 1,
-    "AcceptIncomingPeers": true
+    "AcceptIncomingPeers": false
   }
 }

--- a/neo/data/protocol.testnet.json
+++ b/neo/data/protocol.testnet.json
@@ -13,7 +13,7 @@
         "BootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/Test168xxxx.tar.gz",
         "NotificationBootstrapFile":"https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_main/TestNotif168xxxx.tar.gz",
         "DebugStorage":1,
-        "AcceptIncomingPeers": true
+        "AcceptIncomingPeers": false
 
     },
     "ProtocolConfiguration": {


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Resolve simultaneous connecting from and to the same port. Part of addressing https://github.com/CityOfZion/neo-python/issues/522

**How did you solve this problem?**
changed from using the `endpoint` API to lower level `reactor` API. While the original code works in standalone mode, it seems to conflict when used in conjunction with `connectTCP`
https://github.com/CityOfZion/neo-python/blob/f003f0a66cdd10cef91f30a6cda5549844ebd013/neo/Network/NodeLeader.py#L151

**How did you make sure your solution works?**
manual by running the node, then typing `nodes` to verify that we connected to our seeds, then run `nc localhost 20333` and see a `version` reply.
```
Eriks-Air:~ erik$ nc 127.0.0.1 20333
Anttversion2
�7��[mO��x�/NEO-PYTHON:0.7.8-dev/
```

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)

no new changelog entry, just polishing old PR