### PR TITLE
Update docs toctree and add instructions for contributing [recreated]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -298,7 +298,7 @@ All notable changes to this project are documented in this file.
 
 
 
-[0.4.8] 2018-02-21
+[0.4.9] 2018-02-21
 ------------------
 - wallet sync error and password fixes related to encryption changes (`PR #245 <https://github.com/CityOfZion/neo-python/pull/245>`_)
 - import contract_addr and build ... test fixes (`PR #237 <https://github.com/CityOfZion/neo-python/pull/237>`_)
@@ -310,7 +310,7 @@ All notable changes to this project are documented in this file.
 - Bugfix for smart contract storage events (`PR #228 <https://github.com/CityOfZion/neo-python/pull/228>`_)
 
 
-[0.4.6] 2018-02-15
+[0.4.8] 2018-02-15
 ------------------
 
 - Fix Gas Cost Calculation (`PR #220 <https://github.com/CityOfZion/neo-python/pull/220>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 - Fix issue with opening recently created wallets
 - Fix import_blocks.py block hash caching issue
 - Update prompt.py: add ``account`` to help, update help, update standard completions, add ``config maxpeers`` functionality, update ``configure`` function arguments to behave as intended
+- Update docs ``toctree`` so all pages are indexed & added instructions for contributing to docs
 
 
 [0.7.7] 2018-08-23

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -298,7 +298,7 @@ All notable changes to this project are documented in this file.
 
 
 
-[0.4.7] 2018-02-21
+[0.4.8] 2018-02-21
 ------------------
 - wallet sync error and password fixes related to encryption changes (`PR #245 <https://github.com/CityOfZion/neo-python/pull/245>`_)
 - import contract_addr and build ... test fixes (`PR #237 <https://github.com/CityOfZion/neo-python/pull/237>`_)
@@ -322,7 +322,7 @@ All notable changes to this project are documented in this file.
 - upstream neocore update
 
 
-[0.4.5] 2018-01-24
+[0.4.6] 2018-01-24
 ------------------
 
 - Added support for StateTransaction and StateDescriptors (`PR #193 <https://github.com/CityOfZion/neo-python/pull/193>`_)
@@ -332,7 +332,7 @@ All notable changes to this project are documented in this file.
 - Minor cleanups and documentation updates
 
 
-[0.4.4] 2018-01-18
+[0.4.5] 2018-01-18
 ------------------
 
 - updated ``neo-boa`` to ``0.2.2``, added support for array ``REMOVE`` VM opcodes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -298,7 +298,7 @@ All notable changes to this project are documented in this file.
 
 
 
-[0.4.9] 2018-02-21
+[0.4.7] 2018-02-21
 ------------------
 - wallet sync error and password fixes related to encryption changes (`PR #245 <https://github.com/CityOfZion/neo-python/pull/245>`_)
 - import contract_addr and build ... test fixes (`PR #237 <https://github.com/CityOfZion/neo-python/pull/237>`_)
@@ -310,7 +310,7 @@ All notable changes to this project are documented in this file.
 - Bugfix for smart contract storage events (`PR #228 <https://github.com/CityOfZion/neo-python/pull/228>`_)
 
 
-[0.4.8] 2018-02-15
+[0.4.6] 2018-02-15
 ------------------
 
 - Fix Gas Cost Calculation (`PR #220 <https://github.com/CityOfZion/neo-python/pull/220>`_)
@@ -322,7 +322,7 @@ All notable changes to this project are documented in this file.
 - upstream neocore update
 
 
-[0.4.6] 2018-01-24
+[0.4.5] 2018-01-24
 ------------------
 
 - Added support for StateTransaction and StateDescriptors (`PR #193 <https://github.com/CityOfZion/neo-python/pull/193>`_)
@@ -332,7 +332,7 @@ All notable changes to this project are documented in this file.
 - Minor cleanups and documentation updates
 
 
-[0.4.5] 2018-01-18
+[0.4.4] 2018-01-18
 ------------------
 
 - updated ``neo-boa`` to ``0.2.2``, added support for array ``REMOVE`` VM opcodes
@@ -343,14 +343,6 @@ All notable changes to this project are documented in this file.
 - ability to claim GAS from SC address
 - lots of documentation
 - various small bugfixes
-
-
-[0.4.4] 2017-12-21
-------------------
-
-- updated ``neo-boa`` to ``0.2.1``
-- added support for array ``REVERSE`` and ``APPEND`` VM opcodes
-
 
 [0.4.3] 2017-12-21
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -345,7 +345,7 @@ All notable changes to this project are documented in this file.
 - various small bugfixes
 
 
-[0.4.3] 2017-12-21
+[0.4.4] 2017-12-21
 ------------------
 
 - updated ``neo-boa`` to ``0.2.1``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -223,10 +223,10 @@ All notable changes to this project are documented in this file.
   - move ``prompt.py`` and other scripts to ``neo/bin``
   - default chain data path is now in ``~/.neopython/Chains``.  ``prompt.log`` and ``prompt.history`` files are also stored there
   - the following console scripts are now on the ``venv`` path after running ``pip install neo-python`` or ``pip install -e .`` for github based installs:
-    - ``np-prompt``
-    - ``np-api-server``
-    - ``np-bootstrap``
-    - ``np-reencrypt-wallet``
+     - ``np-prompt``
+     - ``np-api-server``
+     - ``np-bootstrap``
+     - ``np-reencrypt-wallet``
   - updated docs for Pypi changes
 
 

--- a/docs/Readme.rst
+++ b/docs/Readme.rst
@@ -1,0 +1,19 @@
+Contributing
+============
+
+Contributions are always welcome!
+
+Guidelines
+----------
+When contributing please note the following:
+
+1.  NEO-Python Docs use the sphinx module to build https://neo-python.readthedocs.io/en/latest/. So, make sure every docucment you add uses reStructuredText (e.g. <yourfile>.rst).
+
+2.  After creating your document, be sure to update the ``toctree`` in index.rst. **Failing to do so will result in your document missing from the readthedocs website.**
+
+3.  Before submitting a pull request to add your new document, run ``make docs`` to verify your build is successful and includes no warnings. You will need to install the sphinx module and rtd theme:
+
+::
+
+    pip install sphinx
+    pip install sphinx_rtd_theme

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,15 +29,18 @@ neo-python - Python Node and SDK for the NEO blockchain
 
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 3
 
     overview
     install
     installwindows
+    Seedlist
     basicusage
     prompt
     settings-and-logging
+    neo/Core/TX/Transaction
     neo/SmartContract/smartcontracts
+    neo/SmartContract/application-vs-verification
     data-types
     contribute
     license

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -126,7 +126,7 @@ The solution probably is
 
 
 Install from PyPi
-================
+=================
 
 The easiest way to install ``neo-python`` on your machine is to download it and install from PyPi using ``pip``. First, we recommend you to create a virtual environment in order to isolate this installation from your system directories and then install it as you normally would do:
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Updates the `toctree` so all info is displayed on the "readthedocs" website

Recreated from #591 for compatibility issue cc @ixje 

When running `make docs` now, the only warning I receive is:
`WARNING: html_static_path entry '/mnt/c/users/jseag/neo/neo-python-dev/docs/source/_static' does not exist`
I don't think I can eliminate this warning.

Also added instructions for making contributions to neo-python/docs

**How did you solve this problem?**
@localhuman prompted me to run `make docs` then Google to figure out how to update a toctree

**How did you make sure your solution works?**
Personal Testing

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
