### PR TITLE
Add multi-request JSON-RPC support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,12 +8,13 @@ All notable changes to this project are documented in this file.
 ----------------------
 - Prefix ``vin`` JSON output format to match C#
 - Update ``neo-boa`` to v0.5.0 for Python 3.7 compatibility
-- Update pexpect to 4.6.0 to be compatible with Python 3.7
+- Update ``pexpect`` to 4.6.0 to be compatible with Python 3.7
 - Accept incoming node connections, configurable via protocol config file setting (default: OFF)
 - Fixes vulnerability to RPC invoke functionality that can send node into unclosed loop during 'test' invokes
 - Fix issue with opening recently created wallets
-- Fix import_blocks.py block hash caching issue
+- Fix ``import_blocks.py`` block hash caching issue
 - Update prompt.py: add ``account`` to help, update help, update standard completions, add ``config maxpeers`` functionality, update ``configure`` function arguments to behave as intended
+- Add support for multiple requests in one transaction for JSON-RPC
 
 
 [0.7.7] 2018-08-23

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -288,6 +288,12 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         res = json.loads(self.app.home(mock_req))
         self.assertTrue(res["result"]["isvalid"])
 
+        # address with invalid checksum
+        req = self._gen_rpc_req("validateaddress", params=["AQVh2pG732YvtNaxEGkQUei3YA4cvo7d2x"])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+        self.assertFalse(res["result"]["isvalid"])
+
         # example from docs.neo.org
         req = self._gen_rpc_req("validateaddress", params=["152f1muMCNa7goXYhYAQC61hxEgGacmncB"])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
@@ -537,6 +543,23 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         self.app.wallet = None
         os.remove(test_wallet_path)
 
+    def test_getbalance_invalid_params(self):
+        test_wallet_path = os.path.join(mkdtemp(), "getbalance.db3")
+        self.app.wallet = UserWallet.Create(
+            test_wallet_path,
+            to_aes_key('awesomepassword')
+        )
+
+        # max param length should be one, we provide 2
+        req = self._gen_rpc_req("getbalance", params=[1, 2])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+
+        error = res.get('error', {})
+
+        self.assertEqual(error.get('code', None), -400)
+        self.assertEqual(error.get('message', None), "Params should contain 1 id.")
+
     def test_getbalance_token_with_wallet(self):
         test_wallet_path = os.path.join(mkdtemp(), "getbalance.db3")
         self.app.wallet = UserWallet.Create(
@@ -614,3 +637,42 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         self.app.wallet.Close()
         self.app.wallet = None
         os.remove(test_wallet_path)
+
+    def test_valid_multirequest(self):
+        raw_block_request = {"jsonrpc": "2.0", "method": "getblock", "params": [1], "id": 1}
+        verbose_block_request = {"jsonrpc": "2.0", "method": "getblock", "params": [1, 1], "id": 2}
+
+        multi_request = json.dumps([raw_block_request, verbose_block_request])
+        mock_req = mock_request(multi_request.encode())
+        res = json.loads(self.app.home(mock_req))
+
+        self.assertEqual(type(res), list)
+        self.assertEqual(len(res), 2)
+        expected_raw_block = '00000000ef1f8f66a16fba100ed760f4ac6aa5a0d0bb8f4a0e92705b106761ef181718b3d0765298ceb5f57de7d2b0dab00ed25be4134706ada2d90adb8b7e3aba323a8e1abd125901000000d11f7a289214bdaff3812db982f3b0089a21a278988efeec6a027b2501fd450140884037dd265cb5f5a54802f53c2c8593b31d5b8a9c0bad4c7e366b153d878989d168080ac36b930036a9eb966b48c70bb41792e698fa021116f27c09643563b840e83ab14404d964a91dbac45f5460e88ad57196b1779478e3475334af8c1b49cd9f0213257895c60b5b92a4800eb32d785cbb39ae1f022528943909fd37deba63403677848bf98cc9dbd8fbfd7f2e4f34471866ea82ca6bffbf0f778b6931483700c17829b4bd066eb04983d3aac0bd46b9c8d03a73a8e714d3119de93cd9522e314054d16853b22014190063f77d9edf6fbccefcf71fffd1234f688823b4e429ae5fa639d0a664c842fbdfcb4d6e21f39d81c23563b92cffa09696d93c95bc4893a6401a43071d00d3e854f7f1f321afa7d5301d36f2195dc1e2643463f34ae637d2b02ae0eb11d4256c507a4f8304cea6396a7fce640f50acb301c2f6336d27717e84f155210209e7fd41dfb5c2f8dc72eb30358ac100ea8c72da18847befe06eade68cebfcb9210327da12b5c40200e9f65569476bbff2218da4f32548ff43b6387ec1416a231ee821034ff5ceeac41acf22cd5ed2da17a6df4dd8358fcb2bfb1a43208ad0feaab2746b21026ce35b29147ad09e4afe4ec4a7319095f08198fa8babbe3c56e970b143528d2221038dddc06ce687677a53d54f096d2591ba2302068cf123c1f2d75c2dddc542557921039dafd8571a641058ccc832c5e2111ea39b09c0bde36050914384f7a48bce9bf92102d02b1873a0863cd042cc717da31cea0d7cf9db32b74d4c72c01b0011503e2e2257ae010000d11f7a2800000000'
+        self.assertEqual(res[0]['result'], expected_raw_block)
+        expected_verbose_hash = '0x0012f8566567a9d7ddf25acb5cf98286c9703297de675d01ba73fbfe6bcb841c'
+        self.assertEqual(res[1]['result']['hash'], expected_verbose_hash)
+
+    def test_multirequest_with_1_invalid_request(self):
+        """
+        We provide 2 requests, first one invalid and should return and error, second one  valid and should still come up with correct results
+        """
+        # block request of invalid block, should fail
+        raw_block_request = {"jsonrpc": "2.0", "method": "getblock", "params": [10000000000], "id": 1}
+        verbose_block_request = {"jsonrpc": "2.0", "method": "getblock", "params": [1, 1], "id": 2}
+
+        multi_request = json.dumps([raw_block_request, verbose_block_request])
+        mock_req = mock_request(multi_request.encode())
+        res = json.loads(self.app.home(mock_req))
+
+        self.assertEqual(type(res), list)
+        self.assertEqual(len(res), 2)
+
+        # test for errors in first invalid request
+        error = res[0].get('error', {})
+        self.assertEqual(error.get('code', None), -100)
+        self.assertEqual(error.get('message', None), "Unknown block")
+
+        # test for success in second valid request
+        expected_verbose_hash = '0x0012f8566567a9d7ddf25acb5cf98286c9703297de675d01ba73fbfe6bcb841c'
+        self.assertEqual(res[1]['result']['hash'], expected_verbose_hash)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
the C# client supports multiple requests in one call whereas neo-python does not i.e.
```
[
{
  "jsonrpc": "2.0",
  "method": "getblock",
  "params": [1],
  "id": 1
},
{
  "jsonrpc": "2.0",
  "method": "getblock",
  "params": [1,1],
  "id": 2
}
]
```


**How did you solve this problem?**
add support by detecting list input

**How did you make sure your solution works?**
add tests

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)

It also adds a couple of extra tests to increase the coverage of other calls.