### PR TITLE
Add `getnodestate` RPC method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.7.9-dev] in progress
 -----------------------
--
+- Add `getnodestate` RPC method
 
 
 [0.7.8] 2018-09-06

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.7.9-dev] in progress
 -----------------------
-- Add `getnodestate` RPC method
+- Add ``getnodestate`` RPC method
 
 
 [0.7.8] 2018-09-06

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -215,12 +215,12 @@ class JsonRpcApi:
                 tps = Blockchain.Default().TXProcessed / secs
             
             return {
-                'Progress': "%s / %s" % (height, headers),
-                'Block-cache length': "%s" % Blockchain.Default().BlockCacheCount,
-                'Blocks since program start': "%s" % diff,
-                'Time elapsed': "%s mins" % mins,
-                'Blocks per min': "%s" % bpm,
-                'TPS': "%s" % tps
+                'Progress': [height, "/", headers],
+                'Block-cache length': Blockchain.Default().BlockCacheCount,
+                'Blocks since program start': diff,
+                'Time elapsed (minutes)': mins,
+                'Blocks per min': bpm,
+                'TPS': tps
             }
 
         elif method == "getrawmempool":

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -213,7 +213,7 @@ class JsonRpcApi:
             if diff > 0 and mins > 0:
                 bpm = diff / mins
                 tps = Blockchain.Default().TXProcessed / secs
-            
+
             return {
                 'Progress': [height, "/", headers],
                 'Block-cache length': Blockchain.Default().BlockCacheCount,

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -7,6 +7,7 @@ See also:
 * http://www.jsonrpc.org/specification
 """
 import json
+import datetime
 import base58
 import binascii
 from json.decoder import JSONDecodeError
@@ -79,6 +80,8 @@ class JsonRpcApi:
     def __init__(self, port, wallet=None):
         self.port = port
         self.wallet = wallet
+        self.start_height = Blockchain.Default().Height
+        self.start_dt = datetime.datetime.utcnow()
 
     def get_data(self, body: dict):
 
@@ -193,6 +196,32 @@ class JsonRpcApi:
             if contract is None:
                 raise JsonRpcError(-100, "Unknown contract")
             return contract.ToJson()
+
+        elif method == "getnodestate":
+            height = Blockchain.Default().Height
+            headers = Blockchain.Default().HeaderHeight
+
+            diff = height - self.start_height
+            now = datetime.datetime.utcnow()
+            difftime = now - self.start_dt
+
+            mins = difftime / datetime.timedelta(minutes=1)
+            secs = mins * 60
+
+            bpm = 0
+            tps = 0
+            if diff > 0 and mins > 0:
+                bpm = diff / mins
+                tps = Blockchain.Default().TXProcessed / secs
+            
+            return {
+                'Progress': "%s / %s" % (height, headers),
+                'Block-cache length': "%s" % Blockchain.Default().BlockCacheCount,
+                'Blocks since program start': "%s" % diff,
+                'Time elapsed': "%s mins" % mins,
+                'Blocks per min': "%s" % bpm,
+                'TPS': "%s" % tps
+            }
 
         elif method == "getrawmempool":
             return list(map(lambda hash: "0x%s" % hash.decode('utf-8'), NodeLeader.Instance().MemPool.keys()))

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -259,6 +259,14 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         self.assertTrue('error' in res)
         self.assertEqual(res['error']['message'], 'Unknown contract')
 
+    def test_node_state(self):
+        req = self._gen_rpc_req("getnodestate", params=[])
+        mock_req = mock_request(json.dumps(req).encode("utf-8"))
+        res = json.loads(self.app.home(mock_req))
+        self.assertGreater(res['result']['Progress'][0], 0)
+        self.assertGreater(res['result']['Progress'][2], 0)
+        self.assertGreater(res['result']['Time elapsed (minutes)'], 0)
+
     def test_get_raw_mempool(self):
         # TODO: currently returns empty list. test with list would be great
         req = self._gen_rpc_req("getrawmempool", params=[])


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Adds `getnodestate` RPC method

Follows the `state` method from Prompt.py. This is very useful for finding out the real-time status of the node.

Additionally, the data could be fed to programs. Example below:
```
{
    "jsonrpc": "2.0",
    "id": "2",
    "result": {
        "Progress": [
            758986,
            "/",
            1383999
        ],
        "Block-cache length": 0,
        "Blocks since program start": 0,
        "Time elapsed (minutes)": 9.75e-06,
        "Blocks per min": 0,
        "TPS": 0
    }
}
```

Helps address Issue #189 

**How did you solve this problem?**
Trial and Error.

**How did you make sure your solution works?**
Unittest. Also, ran  it on my local RPC node to verify "Block-cache-length", "Blocks since program start", "Blocks per min", and "TPS".

**Are there any special changes in the code that we should be aware of?**
No.

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
