### PR TITLE
Gracefully handle network deserialization failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.7.9-dev] in progress
 -----------------------
--
+- Gracefully handle network packet deserialization failures
 
 
 [0.7.8] 2018-09-06

--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -344,6 +344,9 @@ class NeoNode(Protocol):
         """Process response of `self.RequestPeerInfo`."""
         addrs = IOHelper.AsSerializableWithType(payload, 'neo.Network.Payloads.AddrPayload.AddrPayload')
 
+        if not addrs:
+            return
+
         for index, nawt in enumerate(addrs.NetworkAddressesWithTime):
             self.leader.RemoteNodePeerReceived(nawt.Address, nawt.Port, index)
 
@@ -383,6 +386,9 @@ class NeoNode(Protocol):
         """Process the response of `self.RequestVersion`."""
         self.Version = IOHelper.AsSerializableWithType(payload, "neo.Network.Payloads.VersionPayload.VersionPayload")
 
+        if not self.Version:
+            return
+
         if self.incoming_client:
             if self.Version.Nonce == self.nodeid:
                 self.Disconnect()
@@ -409,6 +415,8 @@ class NeoNode(Protocol):
             return
 
         inventory = IOHelper.AsSerializableWithType(payload, 'neo.Network.Payloads.InvPayload.InvPayload')
+        if not inventory:
+            return
 
         if inventory.Type == InventoryType.BlockInt:
 
@@ -471,6 +479,8 @@ class NeoNode(Protocol):
             inventory (neo.Network.Inventory):
         """
         block = IOHelper.AsSerializableWithType(inventory, 'neo.Core.Block.Block')
+        if not block:
+            return
 
         blockhash = block.Hash.ToBytes()
         if blockhash in BC.Default().BlockRequests:
@@ -523,6 +533,8 @@ class NeoNode(Protocol):
             payload (neo.Network.Inventory):
         """
         inventory = IOHelper.AsSerializableWithType(payload, 'neo.Network.Payloads.InvPayload.InvPayload')
+        if not inventory:
+            return
 
         for hash in inventory.Hashes:
             hash = hash.encode('utf-8')
@@ -564,6 +576,8 @@ class NeoNode(Protocol):
             return
 
         inventory = IOHelper.AsSerializableWithType(payload, 'neo.Network.Payloads.GetBlocksPayload.GetBlocksPayload')
+        if not inventory:
+            return
 
         blockchain = BC.Default()
         hash = inventory.HashStart[0]


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
While syncing over the last few days i noticed a couple of malformed network packets resulted in exceptions when trying to deserialize them. 

**How did you solve this problem?**
This pr checks the deserialization results before proceeding and returns otherwise.

**How did you make sure your solution works?**
no test, just common sense 🤔 

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
