### PR TITLE
Default AcceptIncomingPeers to false

### DIFF
--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -183,7 +183,7 @@ class SettingsHolder:
         self.NODE_PORT = int(config['NodePort'])
         self.WS_PORT = config['WsPort']
         self.URI_PREFIX = config['UriPrefix']
-        self.ACCEPT_INCOMING_PEERS = config['AcceptIncomingPeers']
+        self.ACCEPT_INCOMING_PEERS = config.get('AcceptIncomingPeers', False)
 
         self.BOOTSTRAP_FILE = config['BootstrapFile']
         self.NOTIF_BOOTSTRAP_FILE = config['NotificationBootstrapFile']


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Nightly tests in [neo-local](https://github.com/CityOfZion/neo-local) were failing after the release of [v0.7.8](https://github.com/CityOfZion/neo-python/blob/master/CHANGELOG.rst#078-2018-09-06).

See [neo-local #44](https://github.com/CityOfZion/neo-local/issues/44).

This was due to the new `ApplicationConfiguration.AcceptIncomingPeers` being added. As described in @ixje's PR, it should default to `false`. 

However if it was not present then the node would bomb out with the following error:

```
Traceback (most recent call last):
  File "/neo-python/neo/bin/api_server.py", line 269, in <module>
    main()
  File "/neo-python/neo/bin/api_server.py", line 155, in main
    settings.setup(args.config)
  File "/neo-python/neo/Settings.py", line 186, in setup
    self.ACCEPT_INCOMING_PEERS = config['AcceptIncomingPeers']
KeyError: 'AcceptIncomingPeers'
``` 

**How did you solve this problem?**

Default the value of `AcceptIncomingPeers` to false. 

**How did you make sure your solution works?**

Ran the node within the neo-local Docker Compose stack. 

**Are there any special changes in the code that we should be aware of?**

No 👍 

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [ ] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)