### PR TITLE
Fix blockchain deregistration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 - Gracefully handle network packet deserialization failures
 - Fix issue resetting storage between Smart Contract invocations
 - Default ``ApplicationConfiguration.AcceptIncomingPeers`` to ``False``, if config value is not present
+- Fix ``Blockchain.DeregisterBlockchain`` not clearing all static variables
 
 [0.7.8] 2018-09-06
 ------------------

--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -221,8 +221,7 @@ class Blockchain:
                 continue
 
             for coinref in group:
-                if coinref.PrevIndex >= len(tx.outputs) or tx.outputs[
-                    coinref.PrevIndex].AssetId != Blockchain.SystemShare().Hash:
+                if coinref.PrevIndex >= len(tx.outputs) or tx.outputs[coinref.PrevIndex].AssetId != Blockchain.SystemShare().Hash:
                     raise Exception("Invalid coin reference")
                 spent_coin = SpentCoin(output=tx.outputs[coinref.PrevIndex], start_height=height_start,
                                        end_height=height_end)

--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -28,15 +28,15 @@ class Blockchain:
 
     GENERATION_AMOUNT = [8, 7, 6, 5, 4, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
 
-    __blockchain = None
+    _blockchain = None
 
-    __validators = []
+    _validators = []
 
-    __genesis_block = None
+    _genesis_block = None
 
-    __instance = None
+    _instance = None
 
-    __blockrequests = set()
+    _blockrequests = set()
 
     _paused = False
 
@@ -52,12 +52,12 @@ class Blockchain:
 
     @staticmethod
     def StandbyValidators():
-        if len(Blockchain.__validators) < 1:
+        if len(Blockchain._validators) < 1:
             vlist = settings.STANDBY_VALIDATORS
             for pkey in settings.STANDBY_VALIDATORS:
-                Blockchain.__validators.append(ECDSA.decode_secp256r1(pkey).G)
+                Blockchain._validators.append(ECDSA.decode_secp256r1(pkey).G)
 
-        return Blockchain.__validators
+        return Blockchain._validators
 
     @staticmethod
     @lru_cache(maxsize=2)
@@ -135,11 +135,11 @@ class Blockchain:
         Returns:
             obj: Currently set to `neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain`.
         """
-        if Blockchain.__instance is None:
-            Blockchain.__instance = Blockchain()
+        if Blockchain._instance is None:
+            Blockchain._instance = Blockchain()
             Blockchain.GenesisBlock().RebuildMerkleRoot()
 
-        return Blockchain.__instance
+        return Blockchain._instance
 
     @property
     def CurrentBlockHash(self):
@@ -178,10 +178,10 @@ class Blockchain:
         Returns:
             set:
         """
-        return self.__blockrequests
+        return self._blockrequests
 
     def ResetBlockRequests(self):
-        self.__blockrequests = set()
+        self._blockrequests = set()
 
     @staticmethod
     def CalculateBonusIgnoreClaimed(inputs, ignore_claimed=True):
@@ -222,7 +222,7 @@ class Blockchain:
 
             for coinref in group:
                 if coinref.PrevIndex >= len(tx.outputs) or tx.outputs[
-                        coinref.PrevIndex].AssetId != Blockchain.SystemShare().Hash:
+                    coinref.PrevIndex].AssetId != Blockchain.SystemShare().Hash:
                     raise Exception("Invalid coin reference")
                 spent_coin = SpentCoin(output=tx.outputs[coinref.PrevIndex], start_height=height_start,
                                        end_height=height_end)
@@ -465,12 +465,27 @@ class Blockchain:
         Args:
             blockchain: a blockchain instance. E.g. neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain
         """
-        if Blockchain.__instance is None:
-            Blockchain.__instance = blockchain
+        if Blockchain._instance is None:
+            Blockchain._instance = blockchain
 
     @staticmethod
     def DeregisterBlockchain():
         """
         Remove the default blockchain instance.
         """
-        Blockchain.__instance = None
+        Blockchain.SECONDS_PER_BLOCK = 15
+        Blockchain.DECREMENT_INTERVAL = 2000000
+        Blockchain.GENERATION_AMOUNT = [8, 7, 6, 5, 4, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        Blockchain._blockchain = None
+        Blockchain._validators = []
+        Blockchain._genesis_block = None
+        Blockchain._instance = None
+        Blockchain._blockrequests = set()
+        Blockchain._paused = False
+        Blockchain.BlockSearchTries = 0
+        Blockchain.CACHELIM = 4000
+        Blockchain.CMISSLIM = 5
+        Blockchain.LOOPTIME = .1
+        Blockchain.PersistCompleted = Events()
+        Blockchain.Notify = Events()
+        Blockchain._instance = None


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
The `BlockchainFixtureTestCase` heavily depends on deregistering the old blockchain for resetting. It actually never worked in full because static variables were not cleared in the `Blockchain` class. It just happened to be that the original testfixtures used equalled the testnet, which is the first Blockchain registered by default in the settings file
https://github.com/CityOfZion/neo-python/blob/978f77922247d2d85c63dfe8db66e856fcb56582/neo/Settings.py#L349

**How did you solve this problem?**
clear all static variables. 
I also refactored all double underscored variables and made them 'normal private` because they prevent IDEs from reading the values while debugging

**How did you make sure your solution works?**
`unittest discover` using privnet testfixtures now works where it previously failed

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
