### PR TITLE
Add BigInteger sanity checks for VM

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.8.2] In Progress
 -------------------
+- Add VM sanity checks for operations on ``BigInteger``'s
 - Add raw transaction building examples in ``\examples\`` folder
 - Add ExtendedJsonRpcApi, Add ``getnodestate`` RPC extended method, Add ``gettxhistory`` RPC extended method
 - Fix return types of ``claimGas`` function.


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Closes https://github.com/CityOfZion/neo-python/issues/566 and adds feature parity with C# on BigInteger checking: [C# ref](https://github.com/neo-project/neo/blob/807d0e439740074e8be8809ac265357f760d30ef/neo/SmartContract/ApplicationEngine.cs#L159-L268)

**How did you solve this problem?**
write code. 
Requires:
https://github.com/CityOfZion/neo-python-core/pull/81
and 
https://github.com/CityOfZion/neo-boa/pull/106

**How did you make sure your solution works?**
`make test` and run node for a while

**Are there any special changes in the code that we should be aware of?**
no
**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
