### PR TITLE
Fix getpeers RPC not matching maxpeers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.8.2] In Progress
 -------------------
+- Fix discrepancy between `getpeers` RPC call and the `maxpeers` setting
 - Update ``CreateAddress`` functionality and tests
 - Add VM sanity checks for operations on ``BigInteger``'s
 - Add raw transaction building examples in ``\examples\`` folder

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -44,7 +44,7 @@ class NeoClientFactory(ReconnectingClientFactory):
 
 
 class NodeLeader:
-    __LEAD = None
+    _LEAD = None
 
     Peers = []
 
@@ -79,9 +79,9 @@ class NodeLeader:
         Returns:
             NodeLeader: instance.
         """
-        if NodeLeader.__LEAD is None:
-            NodeLeader.__LEAD = NodeLeader()
-        return NodeLeader.__LEAD
+        if NodeLeader._LEAD is None:
+            NodeLeader._LEAD = NodeLeader()
+        return NodeLeader._LEAD
 
     def __init__(self):
         """

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -210,6 +210,9 @@ class NodeLeader:
         if peer in self.Peers:
             self.Peers.remove(peer)
 
+        if peer.Address in self.ADDRS:
+            self.ADDRS.remove(peer.Address)
+
     def onSetupConnectionErr(self, err):
         logger.debug("On setup connection error! %s" % err)
 

--- a/neo/Network/test_node_leader.py
+++ b/neo/Network/test_node_leader.py
@@ -25,6 +25,13 @@ class Endpoint:
 
 class NodeLeaderConnectionTest(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        # clean up left over of other tests classes
+        leader = NodeLeader.Instance()
+        leader.Peers = []
+        leader.ADDRS = []
+
     def _add_new_node(self, host, port):
         self.tr.getPeer.side_effect = [IPv4Address('TCP', host, port)]
         node = self.factory.buildProtocol(('127.0.0.1', 0))
@@ -36,7 +43,6 @@ class NodeLeaderConnectionTest(unittest.TestCase):
         self.factory = NeoClientFactory()
         self.tr = proto_helpers.StringTransport()
         self.tr.getPeer = MagicMock()
-
         self.leader = NodeLeader.Instance()
 
     def test_getpeer_list_vs_maxpeer_list(self):
@@ -103,7 +109,6 @@ class LeaderTestCase(WalletFixtureTestCase):
             with patch('twisted.internet.reactor.callLater', mock_call_later):
                 with patch('neo.Network.NeoNode.NeoNode.Disconnect', mock_disconnect):
                     with patch('neo.Network.NeoNode.NeoNode.SendSerializedMessage', mock_send_msg):
-
                         leader.Start()
                         self.assertEqual(len(leader.Peers), len(settings.SEED_LIST))
 
@@ -126,7 +131,7 @@ class LeaderTestCase(WalletFixtureTestCase):
                         leader.RemoveConnectedPeer(peer)
 
                         self.assertEqual(len(leader.Peers), len(settings.SEED_LIST) - 1)
-                        self.assertEqual(len(leader.ADDRS), len(settings.SEED_LIST))
+                        self.assertEqual(len(leader.ADDRS), len(settings.SEED_LIST) - 1)
 
                         # now test adding another
                         leader.RemoteNodePeerReceived('hello.com', 1234, 6)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Fix #678 

**How did you solve this problem?**
if a peer disconnects or loses connection for whatever reason, then also remove it from the `ADDRS` list, on top of the `Peers` list.

**How did you make sure your solution works?**
wrote a test pre-fix, failed, fix, works

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
