### PR TITLE
Fixed #687 cleaning up after disconnected peers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ All notable changes to this project are documented in this file.
 - Various updates to inaccuracies in ``ToJson`` output of ``AccountState``
 - Add documentation support for Python 3.7
 - Change execution fail event payload to give more meaningful error messages
+- Fix cleaning up tasks for disconnected peers `#687 <https://github.com/CityOfZion/neo-python/issues/687>`_
 
 [0.8.0] 2018-09-28
 ------------------

--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -132,7 +132,7 @@ class NeoNode(Protocol):
             if self.peer_loop_deferred:
                 self.peer_loop_deferred.cancel()
 
-            if self.block_loop:
+            if self.block_loop.running:
                 self.block_loop.stop()
             if self.peer_loop:
                 self.peer_loop.stop()

--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -134,7 +134,7 @@ class NeoNode(Protocol):
 
             if self.block_loop.running:
                 self.block_loop.stop()
-            if self.peer_loop:
+            if self.peer_loop.running:
                 self.peer_loop.stop()
 
             self.ReleaseBlockRequests()

--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -132,10 +132,12 @@ class NeoNode(Protocol):
             if self.peer_loop_deferred:
                 self.peer_loop_deferred.cancel()
 
-            if self.block_loop.running:
-                self.block_loop.stop()
-            if self.peer_loop.running:
-                self.peer_loop.stop()
+            if self.block_loop:
+                if self.block_loop.running:
+                    self.block_loop.stop()
+            if self.peer_loop:
+                if self.peer_loop.running:
+                    self.peer_loop.stop()
 
             self.ReleaseBlockRequests()
             self.leader.RemoveConnectedPeer(self)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
#687 
**How did you solve this problem?**
Added a `.stop()` to the tasks when cleaning up the disconnected peers.

**How did you make sure your solution works?**
Tested, problem is resolved

**Are there any special changes in the code that we should be aware of?**
There is currently no reconnection option active, so once disconnected the peer will be gone until restart. This may be a new issue created by fixing the current issue.

**Please check the following, if applicable:**
- [x] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
