### PR TITLE
Prevent duplicate looptask

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ All notable changes to this project are documented in this file.
 - Add fixtures guidelines and add the smart contract source codes (UnitTest-SM.zip) to the fixtures package
 - Adds ``sendmany`` feature to prompt.py, integrates with ``send`` feature, and adds provisions for sending with a negative fee and bad from_address
 - Fix ``ExtendedJsonRpcApi``
+- Fix cleaning up tasks for disconnected peers `#687 <https://github.com/CityOfZion/neo-python/issues/687>`_
+- Fix duplicate task starting for requesting blocks
 
 
 [0.8.1] 2018-10-06
@@ -30,7 +32,7 @@ All notable changes to this project are documented in this file.
 - Various updates to inaccuracies in ``ToJson`` output of ``AccountState``
 - Add documentation support for Python 3.7
 - Change execution fail event payload to give more meaningful error messages
-- Fix cleaning up tasks for disconnected peers `#687 <https://github.com/CityOfZion/neo-python/issues/687>`_
+
 
 [0.8.0] 2018-09-28
 ------------------

--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -307,6 +307,8 @@ class NeoNode(Protocol):
             self.sync_mode = MODE_MAINTAIN
 
         if self.sync_mode != current_mode:
+            if self.block_loop and self.block_loop.running:
+                self.block_loop.stop()
             self.block_loop_deferred.cancel()
             self.block_loop = task.LoopingCall(self.AskForMoreBlocks)
             self.block_loop_deferred = self.block_loop.start(self.sync_mode)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
the looping task for `AskForMoreBlocks` starts multiple times in some cases. this prevents that from happening by not only stopping the deferred call, but also stopping the looping task before restarting it again.
 
**How did you solve this problem?**
stop running task before starting

**How did you make sure your solution works?**
manually verifying. previously debug output showed the "ask for more blocks" task (with `maxpeers=1`)  to running up to 3 or 4 times within 10K blocks (on privnet)

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
