### PR TITLE
Fix exceeding max recursion depth

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ All notable changes to this project are documented in this file.
 
 [0.8.2] In Progress
 -------------------
+- Fix max recursion depth exceeding when network data inflow exceeds processing speed
 - Add log output control via the new ``config output_level`` command. The old ``config debug`` command is removed.
 - Update Readme and Prompt.py ``help``
 - Update documentation to include new ``IsPayable`` contract flag in the examples

--- a/neo/Network/test_node.py
+++ b/neo/Network/test_node.py
@@ -1,10 +1,15 @@
 from unittest import TestCase
+from twisted.trial import unittest as twisted_unittest
 from neo.Network.NeoNode import NeoNode
 from mock import patch
 from neo.Network.Payloads.VersionPayload import VersionPayload
 from neo.Network.Message import Message
 from neo.IO.MemoryStream import StreamManager
 from neocore.IO.BinaryWriter import BinaryWriter
+from neo.Network.NodeLeader import NeoClientFactory, NodeLeader
+from twisted.test import proto_helpers
+
+import sys
 
 
 class Endpoint:
@@ -13,11 +18,38 @@ class Endpoint:
         self.port = port
 
 
+class NodeNetworkingTestCase(twisted_unittest.TestCase):
+    def setUp(self):
+        factory = NeoClientFactory()
+        self.proto = factory.buildProtocol(('127.0.0.1', 0))
+        self.tr = proto_helpers.StringTransport()
+        self.proto.makeConnection(self.tr)
+
+    def test_max_recursion_on_datareceived(self):
+        """
+            TDD: if the data buffer receives network data faster than it can clear it then eventually
+            `CheckDataReceived()` in `NeoNode` exceeded the max recursion depth
+        """
+        old_limit = sys.getrecursionlimit()
+        raw_message = b"\xb1\xdd\x00\x00version\x00\x00\x00\x00\x00'\x00\x00\x00a\xbb\x9av\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x0ef\x9e[mO3\xe7q\x08\x0b/NEO:2.7.4/=\x8b\x00\x00\x01"
+
+        sys.setrecursionlimit(100)
+        # we fill the buffer with 102 packets, which exceeds the 100 recursion depth limit
+        self.proto.dataReceived(raw_message * 102)
+        # no need to assert anything. If the bug still exists then we get a Python core dump and the process will stop automatically
+        # otherwise restore old limit
+        sys.setrecursionlimit(old_limit)
+
+    def tearDown(self):
+        leader = NodeLeader.Instance()
+        leader.Peers = []
+        leader.ADDRS = []
+
+
 class NodeTestCase(TestCase):
 
     @patch.object(NeoNode, 'MessageReceived')
     def test_handle_message(self, mock):
-
         node = NeoNode()
         node.endpoint = Endpoint('hello.com', 1234)
         node.host = node.endpoint.host
@@ -44,8 +76,8 @@ class NodeTestCase(TestCase):
         node.dataReceived(out2)
 
         self.assertEqual(node.buffer_in, out1 + out2)
-#        import pdb
-#        pdb.set_trace()
+        #        import pdb
+        #        pdb.set_trace()
 
         self.assertEqual(node.bytes_in, 20)
 
@@ -54,13 +86,12 @@ class NodeTestCase(TestCase):
         node.dataReceived(out3)
 
         self.assertEqual(node.bytes_in, len(out))
-#        mock.assert_called_with(message)
+        #        mock.assert_called_with(message)
 
         mock.assert_called_once()
 
     @patch.object(NeoNode, 'SendVersion')
     def test_data_received(self, mock):
-
         node = NeoNode()
         node.endpoint = Endpoint('hello.com', 1234)
         node.host = node.endpoint.host

--- a/neo/Network/test_node_leader.py
+++ b/neo/Network/test_node_leader.py
@@ -78,7 +78,6 @@ class LeaderTestCase(WalletFixtureTestCase):
         NodeLeader.__LEAD = None
 
     def test_initialize(self):
-
         leader = NodeLeader.Instance()
         self.assertEqual(leader.Peers, [])
         self.assertEqual(leader.ADDRS, [])


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
When data flows in faster than neo-python can process it we eventually hit the max recursion depth of CPython and get a core dump.

**How did you solve this problem?**
instead of using recursion to parse further available data, used a while loop to check if more data exist for parsing

**How did you make sure your solution works?**
write test first, then solve issue, test no longer crashes the CPython core

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
