### PR TITLE
Wallet sync fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ All notable changes to this project are documented in this file.
 - Add raw transaction building examples in ``\examples\`` folder
 - Add ExtendedJsonRpcApi, Add ``getnodestate`` RPC extended method, Add ``gettxhistory`` RPC extended method
 - Fix return types of ``claimGas`` function.
-- Update compiler version ``v0.5.4``
+- Update compiler version ``v0.5.6``
 - Add the option -u (unittest-net) to prompt.py
 - Add fixtures guidelines and add the smart contract source codes (UnitTest-SM.zip) to the fixtures package
 - Adds ``sendmany`` feature to prompt.py, integrates with ``send`` feature, and adds provisions for sending with a negative fee and bad from_address
@@ -24,7 +24,8 @@ All notable changes to this project are documented in this file.
 - Fix cleaning up tasks for disconnected peers `#687 <https://github.com/CityOfZion/neo-python/issues/687>`_
 - Fix duplicate task starting for requesting blocks
 - Add ``getblockheader`` RPC method
-
+- Remove ``Neo.Witness.GetInvocationScript``
+- Allow wallets to sync past corrupt blocks
 
 
 [0.8.1] 2018-10-06

--- a/neo/Core/Block.py
+++ b/neo/Core/Block.py
@@ -236,7 +236,7 @@ class Block(BlockBase, InventoryMixin):
             tx_list.append(tx)
 
         if len(tx_list) < 1:
-            raise Exception("Invalid block, no transactions found")
+            raise Exception("Invalid block, no transactions found for block %s " % block.Index)
 
         block.Transactions = tx_list
 

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -126,7 +126,6 @@ class StateReader(InteropService):
         self.Register("Neo.Transaction.GetUnspentCoins", self.Transaction_GetUnspentCoins)
         self.Register("Neo.Transaction.GetWitnesses", self.Transaction_GetWitnesses)
         self.Register("Neo.InvocationTransaction.GetScript", self.InvocationTransaction_GetScript)
-        self.Register("Neo.Witness.GetInvocationScript", self.Witness_GetInvocationScript)
         self.Register("Neo.Witness.GetVerificationScript", self.Witness_GetVerificationScript)
         self.Register("Neo.Attribute.GetUsage", self.Attribute_GetUsage)
         self.Register("Neo.Attribute.GetData", self.Attribute_GetData)
@@ -772,13 +771,6 @@ class StateReader(InteropService):
         if tx is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(tx.Script)
-        return True
-
-    def Witness_GetInvocationScript(self, engine: ExecutionEngine):
-        witness = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
-        if witness is None:
-            return False
-        engine.CurrentContext.EvaluationStack.PushT(witness.InvocationScript)
         return True
 
     def Witness_GetVerificationScript(self, engine: ExecutionEngine):

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -656,6 +656,8 @@ class Wallet:
 
                 if block is not None:
                     self.ProcessNewBlock(block)
+                else:
+                    self._current_height += 1
 
                 blockcount += 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ memory-profiler==0.54.0
 mmh3==2.5.1
 mock==2.0.0
 mpmath==1.0.0
-neo-boa==0.5.5
+neo-boa==0.5.6
 neo-python-rpc==0.2.1
 neocore==0.5.3
 pbr==4.2.0


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- Fix issue with walls of text not allowing syncing of wallets past corrupt blocks.  
- Also removed `Neo.Witness.GetInvocationScript` functionality, closes #695  
- Update to compiler version with `Neo.Witness.GetInvocationScript` functionality removed

**How did you solve this problem?**
- Wallets can now skip corrupt blocks

**How did you make sure your solution works?**
- Manual tests

**Are there any special changes in the code that we should be aware of?**
- No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
