### PR TITLE
Silence - change logging levels on certain parts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 - Fix confirmed tx not being purged from mempool `#703 <https://github.com/CityOfZion/neo-python/issues/703>`_
 - Fix bootstrap thread joining failure on Ubuntu systems
 - Make bootstrap lookup dynamic such that users don't have to update their configs from here on forward
+- Move some warnings and 'expected' errors to `DEBUG` level to avoid logging to console by default
 
 
 [0.8.2] 2018-10-31

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -380,7 +380,6 @@ class LevelDBBlockchain(Blockchain):
             outhex = binascii.unhexlify(out)
             return Transaction.DeserializeFromBufer(outhex, 0), height
 
-        logger.info("Could not find transaction for hash %s " % hash)
         return None, -1
 
     def AddBlockDirectly(self, block, do_persist_complete=True):

--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -113,7 +113,7 @@ class ApplicationEngine(ExecutionEngine):
 
         if opcode == CALL or opcode == APPCALL:
             if self.InvocationStack.Count >= maxInvocationStackSize:
-                logger.error("INVOCATION STACK TOO BIG, RETURN FALSE")
+                logger.debug("INVOCATION STACK TOO BIG, RETURN FALSE")
                 return False
 
             return True
@@ -222,7 +222,7 @@ class ApplicationEngine(ExecutionEngine):
             length = int.from_bytes(lengthpointer, 'little')
 
             if length > self.maxItemSize:
-                logger.error("ITEM IS GREATER THAN MAX ITEM SIZE!")
+                logger.debug("ITEM IS GREATER THAN MAX ITEM SIZE!")
                 return False
 
             return True
@@ -230,7 +230,7 @@ class ApplicationEngine(ExecutionEngine):
         elif opcode == CAT:
 
             if cx.EvaluationStack.Count < 2:
-                logger.error("NOT ENOUGH ITEMS TO CONCAT")
+                logger.debug("NOT ENOUGH ITEMS TO CONCAT")
                 return False
 
             length = 0
@@ -238,11 +238,11 @@ class ApplicationEngine(ExecutionEngine):
             try:
                 length = len(cx.EvaluationStack.Peek(0).GetByteArray()) + len(cx.EvaluationStack.Peek(1).GetByteArray())
             except Exception as e:
-                logger.error("COULD NOT GET STR LENGTH!")
+                logger.debug("COULD NOT GET STR LENGTH!")
                 raise e
 
             if length > self.maxItemSize:
-                logger.error("ITEM IS GREATER THAN MAX SIZE!!!")
+                logger.debug("ITEM IS GREATER THAN MAX SIZE!!!")
                 return False
 
             return True

--- a/neo/SmartContract/SmartContractEvent.py
+++ b/neo/SmartContract/SmartContractEvent.py
@@ -115,7 +115,7 @@ class SmartContractEvent(SerializableMixin):
                 token.Deserialize(reader)
                 self.token = token
             except Exception as e:
-                logger.error("Couldnt deserialize token %s " % e)
+                logger.debug("Couldnt deserialize token %s " % e)
 
     def __str__(self):
         return "SmartContractEvent(event_type=%s, event_payload=%s, contract_hash=%s, block_number=%s, tx_hash=%s, execution_success=%s, test_mode=%s)" \
@@ -230,9 +230,9 @@ class NotifyEvent(SmartContractEvent):
                 if plen == 4 and self.notify_type in [NotifyType.TRANSFER, NotifyType.APPROVE]:
                     if payload[1].Value is None:
                         self.addr_from = empty
-                        logger.info("Using contract addr from address %s " % self.event_payload)
+                        logger.debug("Using contract addr from address %s " % self.event_payload)
                     elif payload[1].Value is False:
-                        logger.info("Using contract addr from address %s " % self.event_payload)
+                        logger.debug("Using contract addr from address %s " % self.event_payload)
                         self.addr_from = empty
                     else:
                         self.addr_from = UInt160(data=payload[1].Value) if len(payload[1].Value) == 20 else empty
@@ -253,7 +253,7 @@ class NotifyEvent(SmartContractEvent):
                     self.is_standard_notify = True
 
             except Exception as e:
-                logger.info("Could not determine notify event: %s %s" % (e, self.event_payload))
+                logger.debug("Could not determine notify event: %s %s" % (e, self.event_payload))
 
         elif self.event_payload.Type == ContractParameterType.String:
             self.notify_type = self.event_payload.Value
@@ -270,19 +270,19 @@ class NotifyEvent(SmartContractEvent):
             writer.WriteUInt160(self.addr_to)
 
             if self.Amount < 0:
-                logger.warn("Transfer Amount less than 0")
+                logger.debug("Transfer Amount less than 0")
                 writer.WriteVarInt(0)
             elif self.Amount < 0xffffffffffffffff:
                 writer.WriteVarInt(self.amount)
             else:
-                logger.warn("Writing Payload value amount greater than ulong long is not allowed.  Setting to ulong long max")
+                logger.debug("Writing Payload value amount greater than ulong long is not allowed.  Setting to ulong long max")
                 writer.WriteVarInt(0xffffffffffffffff)
 
     def DeserializePayload(self, reader):
         try:
             self.notify_type = reader.ReadVarString()
         except Exception as e:
-            logger.info("Could not read notify type")
+            logger.debug("Could not read notify type")
 
         if self.notify_type in [NotifyType.REFUND, NotifyType.APPROVE, NotifyType.TRANSFER]:
             try:
@@ -291,7 +291,7 @@ class NotifyEvent(SmartContractEvent):
                 self.amount = reader.ReadVarInt()
                 self.is_standard_notify = True
             except Exception as e:
-                logger.info("Could not transfer notification data")
+                logger.debug("Could not transfer notification data")
 
     def ToJson(self):
         jsn = super(NotifyEvent, self).ToJson()

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -601,7 +601,7 @@ class ExecutionEngine:
                     estack.PushT(res)
                 except Exception as e:
                     estack.PushT(False)
-                    logger.error("Could not checksig: %s " % e)
+                    logger.debug("Could not checksig: %s " % e)
 
             elif opcode == VERIFY:
                 pubkey = estack.Pop().GetByteArray()
@@ -612,7 +612,7 @@ class ExecutionEngine:
                     estack.PushT(res)
                 except Exception as e:
                     estack.PushT(False)
-                    logger.error("Could not checksig: %s " % e)
+                    logger.debug("Could not verify: %s " % e)
 
             elif opcode == CHECKMULTISIG:
 
@@ -924,7 +924,7 @@ class ExecutionEngine:
                 script = self._Table.GetScript(UInt160(data=script_hash).ToBytes())
 
                 if script is None:
-                    logger.error("Could not find script from script table: %s " % script_hash)
+                    logger.debug("Could not find script from script table: %s " % script_hash)
                     return self.VM_FAULT_and_report(VMFault.INVALID_CONTRACT, script_hash)
 
                 context_new = self.LoadScript(script, rvcount)
@@ -1093,6 +1093,6 @@ class ExecutionEngine:
         if id in [VMFault.THROW, VMFault.THROWIFNOT]:
             logger.debug("({}) {}".format(self.ops_processed, id))
         else:
-            logger.error("({}) {}".format(self.ops_processed, error_msg))
+            logger.debug("({}) {}".format(self.ops_processed, error_msg))
 
         return

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -44,7 +44,7 @@ class StackItem(EquatableMixin):
         return False
 
     def GetArray(self):
-        logger.info("trying to get array:: %s " % self)
+        logger.debug("trying to get array:: %s " % self)
         raise Exception('Not supported')
 
     def GetMap(self):
@@ -187,14 +187,14 @@ class Array(StackItem, CollectionMixin):
         return self._array
 
     def GetBigInteger(self):
-        logger.info("Trying to get big integer %s " % self)
+        logger.debug("Trying to get big integer %s " % self)
         raise Exception("Not Supported")
 
     def GetBoolean(self):
         return len(self._array) > 0
 
     def GetByteArray(self):
-        logger.info("Trying to get bytearray integer %s " % self)
+        logger.debug("Trying to get bytearray integer %s " % self)
 
         raise Exception("Not supported")
 
@@ -536,7 +536,6 @@ class InteropService:
         if method not in self._dictionary.keys():
             logger.warn("method %s not found" % method)
         func = self._dictionary[method]
-        # logger.info("[InteropService Method] %s " % func)
         return func(engine)
 
     @staticmethod

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -534,7 +534,7 @@ class InteropService:
 
     def Invoke(self, method, engine):
         if method not in self._dictionary.keys():
-            logger.warn("method %s not found" % method)
+            logger.debug("method %s not found" % method)
         func = self._dictionary[method]
         return func(engine)
 

--- a/neo/VM/tests/test_interop_map.py
+++ b/neo/VM/tests/test_interop_map.py
@@ -122,7 +122,7 @@ class InteropTest(NeoTestCase):
             self.assertEqual(self.engine.State, VMState.FAULT | VMState.BREAK)
 
             self.assertTrue(len(log_context.output) > 0)
-            self.assertEqual(log_context.records[0].levelname, 'ERROR')
+            self.assertEqual(log_context.records[0].levelname, 'DEBUG')
             self.assertTrue('VMFault.SETITEM_INVALID_TYPE' in log_context.output[0])
 
     def test_op_map6(self):

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -643,6 +643,8 @@ class PromptInterface:
                     tokens = [("class:command", json.dumps(jsn, indent=4))]
                     print_formatted_text(FormattedText(tokens), style=self.token_style)
                     print('\n')
+                else:
+                    print(f"Could not find transaction for hash {txid}")
             except Exception as e:
                 print("Could not find transaction from args: %s (%s)" % (e, args))
         else:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
When people deploy faulty smart contracts on the blockchain or commit transactions that talk to them in the wrong way then errors can be thrown in the console. There's a good group of users that look at this log output and think their `neo-python` install is malfunctioning or broken. To list some examples:
> [W 181107 08:37:51 SmartContractEvent:278] Writing Payload value amount greater than ulong long is not allowed. Setting to ulong long max

> [E 181107 08:37:47 ApplicationEngine:233] NOT ENOUGH ITEMS TO CONCAT

> [I 181107 08:41:51 InteropService:190] Trying to get big integer Array [..omitted..]

> [I 181107 08:41:58 LevelDBBlockchain:383] Could not find transaction for hash b'insert hash'

**How did you solve this problem?**
I changed the log levels on the above and some others to `DEBUG` such that they don't show to the user by default. 

**How did you make sure your solution works?**
make test

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
