### PR TITLE
Fix various issues related to signing with multi-signature addresses 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ All notable changes to this project are documented in this file.
 - Fix confirmed tx not being purged from mempool `#703 <https://github.com/CityOfZion/neo-python/issues/703>`_
 - Fix bootstrap thread joining failure on Ubuntu systems
 - Make bootstrap lookup dynamic such that users don't have to update their configs from here on forward
-
+- Fix various issues related to signing multi-signature transactions
 
 [0.8.2] 2018-10-31
 -------------------

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -321,6 +321,12 @@ class NodeLeader:
 
         elif type(inventory) is Transaction or issubclass(type(inventory), Transaction):
             if not self.AddTransaction(inventory):
+                # if we fail to add the transaction for whatever reason, remove it from the known hashes list or we cannot retry the same transaction again
+                try:
+                    self.KnownHashes.remove(inventory.Hash.ToBytes())
+                except ValueError:
+                    # it not found
+                    pass
                 return False
         else:
             # consensus

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -176,7 +176,6 @@ def process_transaction(wallet, contract_tx, scripthash_from=None, scripthash_ch
             signer_contract = wallet.GetContract(standard_contract)
 
         if not signer_contract.IsMultiSigContract and owners is None:
-
             data = standard_contract.Data
             tx.Attributes = [TransactionAttribute(usage=TransactionAttributeUsage.Script,
                                                   data=data)]
@@ -201,7 +200,7 @@ def process_transaction(wallet, contract_tx, scripthash_from=None, scripthash_ch
 
             tx.scripts = context.GetScripts()
 
-#            print("will send tx: %s " % json.dumps(tx.ToJson(),indent=4))
+            #            print("will send tx: %s " % json.dumps(tx.ToJson(),indent=4))
 
             relayed = NodeLeader.Instance().Relay(tx)
 
@@ -228,7 +227,6 @@ def process_transaction(wallet, contract_tx, scripthash_from=None, scripthash_ch
 
 
 def parse_and_sign(wallet, jsn):
-
     try:
         context = ContractParametersContext.FromJson(jsn)
         if context is None:

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -1183,6 +1183,7 @@ class Wallet:
 
             contract = self.GetContract(hash)
             if contract is None:
+                logger.info(f"Cannot find key belonging to script_hash {hash}. Make sure the source address you're trying to sign the transaction for is imported in the wallet.")
                 continue
 
             key = self.GetKeyByScriptHash(hash)

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -304,13 +304,15 @@ class PromptInterface:
     def start_wallet_loop(self):
         if self.wallet_loop_deferred:
             self.stop_wallet_loop()
-        walletdb_loop = task.LoopingCall(self.Wallet.ProcessBlocks)
-        self.wallet_loop_deferred = walletdb_loop.start(1)
+        self.walletdb_loop = task.LoopingCall(self.Wallet.ProcessBlocks)
+        self.wallet_loop_deferred = self.walletdb_loop.start(1)
         self.wallet_loop_deferred.addErrback(self.on_looperror)
 
     def stop_wallet_loop(self):
         self.wallet_loop_deferred.cancel()
         self.wallet_loop_deferred = None
+        if self.walletdb_loop and self.walletdb_loop.running:
+            self.walletdb_loop.stop()
 
     def do_close_wallet(self):
         if self.Wallet:
@@ -559,6 +561,8 @@ class PromptInterface:
             process_transaction(self.Wallet, contract_tx=framework[0], scripthash_from=framework[1], scripthash_change=framework[2], fee=framework[3], owners=framework[4], user_tx_attributes=framework[5])
 
     def do_sign(self, arguments):
+        if not self.Wallet:
+            print("Please open a wallet before trying to sign")
         jsn = get_arg(arguments)
         parse_and_sign(self.Wallet, jsn)
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
There are a bunch of issues with signing using a multi-signature account

- calling `sign` without a wallet throws an exception
- calling `sign` without having the multi-signature address in the wallet silently fails with a non-related message `relaying tx failed`
- The `CHECKMULTISIG` operation failed because public key and signature pairs where mismatched on the stack 'non-deterministic' (e.g. pubkey_a was compared with signature_c, pubkey_b with signature_a, etc)

2 other errors also solved while working on it
- when sending assets from `wallet_a` and then quickly opening `wallet_b` left a ghost thread running that tried to update Coin references that only existed in `wallet_a` causing exceptions.
- if a transaction fails to be added, it does not get cleared from the internal `KnownHashes` list, which prevent retries of the same tx without restarting the client.
 
**How did you solve this problem?**
- add check for open wallet
- print hint explaining why signing fails
- change sorting based on compressed ECPoint data (the bytearray) to sorting based on `ECPoint.X and ECPoint.Y` data (the `ECPoint` object) such that both public keys and signatures are sorted equally.
- stop the `loopingTask` and not only cancel the `deferred`
- check if transaction adding succeeded and if not remove from the `KnownHashes` list.

**How did you make sure your solution works?**
`make test` and too many manual runs

**Are there any special changes in the code that we should be aware of?**
no
**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
