### PR TITLE
Fix response schema of the "getaccountstate" RPC method 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ All notable changes to this project are documented in this file.
 - Make bootstrap lookup dynamic such that users don't have to update their configs from here on forward
 - Move some warnings and 'expected' errors to `DEBUG` level to avoid logging to console by default
 - Empty VerificationScripts for deployed contracts now work as intended
+- Fix RPC's ``getaccountstate`` response schema to match ``neo-cli`` `#714 <https://github.com/CityOfZion/neo-python/issues/714>`
 
 
 [0.8.2] 2018-10-31

--- a/neo/Core/State/AccountState.py
+++ b/neo/Core/State/AccountState.py
@@ -272,9 +272,9 @@ class AccountState(StateBase):
         json['frozen'] = self.IsFrozen
         json['votes'] = [v.hex() for v in self.Votes]
 
-        balances = {}
+        balances = []
         for key, value in self.Balances.items():
-            balances[key.To0xString()] = value.ToString()
+            balances.append({'asset': key.To0xString(), 'value': value.ToString()})
 
         json['balances'] = balances
         return json

--- a/neo/Prompt/Commands/tests/test_send_command.py
+++ b/neo/Prompt/Commands/tests/test_send_command.py
@@ -354,7 +354,9 @@ class UserWalletTestCase(WalletFixtureTestCase):
             args = ["2", '--from-addr=%s' % self.wallet_1_addr, '--change-addr=%s' % self.watch_addr_str, '--fee=0.005']
 
             address_from_account_state = Blockchain.Default().GetAccountState(self.wallet_1_addr).ToJson()
-            address_from_gas_bal = address_from_account_state['balances']['0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7']
+            address_from_gas = next(filter(lambda b: b['asset'] == '0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7',
+                                           address_from_account_state['balances']))
+            address_from_gas_bal = address_from_gas['value']
 
             framework = construct_send_many(wallet, args)
             res = process_transaction(wallet, contract_tx=framework[0], scripthash_from=framework[1], scripthash_change=framework[2], fee=framework[3], owners=framework[4], user_tx_attributes=framework[5])

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -116,7 +116,8 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         req = self._gen_rpc_req("getaccountstate", params=[addr_str])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
-        self.assertEqual(res['result']['balances']['0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'], '99989900.0')
+        self.assertEqual(res['result']['balances'][0]['value'], '99989900.0')
+        self.assertEqual(res['result']['balances'][0]['asset'], '0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'),
         self.assertEqual(res['result']['address'], addr_str)
 
     def test_account_state_not_existing_yet(self):
@@ -124,7 +125,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         req = self._gen_rpc_req("getaccountstate", params=[addr_str])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
-        self.assertEqual(res['result']['balances'], {})
+        self.assertEqual(res['result']['balances'], [])
         self.assertEqual(res['result']['address'], addr_str)
 
     def test_account_state_failure(self):
@@ -968,7 +969,9 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         net_fee = 0.005
         change_addr = 'AGYaEi3W6ndHPUmW7T12FFfsbQ6DWymkEm'
         address_from_account_state = GetBlockchain().GetAccountState(address_from).ToJson()
-        address_from_gas_bal = address_from_account_state['balances']['0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7']
+        address_from_gas = next(filter(lambda b: b['asset'] == '0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7',
+                                       address_from_account_state['balances']))
+        address_from_gas_bal = address_from_gas['value']
 
         req = self._gen_rpc_req("sendfrom", params=['gas', address_from, address_to, amount, net_fee, change_addr])
         mock_req = mock_request(json.dumps(req).encode("utf-8"))


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
This pull request tries to fix https://github.com/CityOfZion/neo-python/issues/713

**How did you solve this problem?**
Changed the JSON serialization of the AccountState instances

**How did you make sure your solution works?**
Tested manually and updated the automatic test

**Are there any special changes in the code that we should be aware of?**
No, I do think I fixed it everywhere, but something might be missing.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
