### PR TITLE
Added bad addresses to getpeers RPC endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ All notable changes to this project are documented in this file.
 - Move some warnings and 'expected' errors to `DEBUG` level to avoid logging to console by default
 - Empty VerificationScripts for deployed contracts now work as intended
 - Fix RPC's ``getaccountstate`` response schema to match ``neo-cli`` `#714 <https://github.com/CityOfZion/neo-python/issues/714>`
-
+- Add bad peers to the ``getpeers`` RPC method `#715 <https://github.com/CityOfZion/neo-python/pull/715>`
 
 [0.8.2] 2018-10-31
 -------------------

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -385,11 +385,7 @@ class JsonRpcApi:
         return {"address": params[0], "isvalid": isValid}
 
     def get_peers(self):
-        """Get all known nodes and their "state"
-
-        In the current implementation of NodeLeader there is no way
-        to know which nodes are bad.
-        """
+        """Get all known nodes and their 'state' """
         node = NodeLeader.Instance()
         result = {"connected": [], "unconnected": [], "bad": []}
         connected_peers = []
@@ -399,12 +395,16 @@ class JsonRpcApi:
                                         "port": peer.port})
             connected_peers.append("{}:{}".format(peer.host, peer.port))
 
+        for addr in node.DEAD_ADDRS:
+            host, port = addr.rsplit(':', 1)
+            result['bad'].append({"address": host, "port": port})
+
         # "UnconnectedPeers" is never used. So a check is needed to
         # verify that a given address:port does not belong to a connected peer
-        for peer in node.ADDRS:
-            addr, port = peer.split(':')
-            if peer not in connected_peers:
-                result['unconnected'].append({"address": addr,
+        for addr in node.ADDRS:
+            host, port = addr.rsplit(':', 1)
+            if addr not in connected_peers:
+                result['unconnected'].append({"address": host,
                                               "port": int(port)})
 
         return result

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -486,6 +486,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         # lets simulate that at least some addresses are known
         node = NodeLeader.Instance()
         node.ADDRS = ["127.0.0.1:20333", "127.0.0.2:20334"]
+        node.DEAD_ADDRS = ["127.0.0.1:20335"]
         test_node = NeoNode()
         test_node.host = "127.0.0.1"
         test_node.port = 20333
@@ -500,9 +501,11 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         print("addrs:{} peers:{}".format(len(node.ADDRS), len(node.Peers)))
         self.assertEqual(len(res['result']['unconnected']),
                          len(node.ADDRS) - len(node.Peers))
+        self.assertEqual(len(res['result']['bad']), 1)
         # To avoid messing up the next tests
         node.Peers = []
         node.ADDRS = []
+        node.DEAD_ADDRS = []
 
     def test_getwalletheight_no_wallet(self):
         req = self._gen_rpc_req("getwalletheight", params=["some id here"])


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
This pull request completes the `getpeers` RPC functionality. At the time of the implementation, `neo-python` didn't track bad peers so it wasn't able to provide that information, since then that functionality was added so we must update the RPC method.

**How did you solve this problem?**
Added `bad` peers based on the `DEAD_ADDRS` list on the `NodeLeader`.

**How did you make sure your solution works?**
Updated the `getpeers` test

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
