### PR TITLE
Initial Django inspired component loading

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,9 @@ All notable changes to this project are documented in this file.
 - Move some warnings and 'expected' errors to `DEBUG` level to avoid logging to console by default
 - Empty VerificationScripts for deployed contracts now work as intended
 - Fix RPC's ``getaccountstate`` response schema to match ``neo-cli`` `#714 <https://github.com/CityOfZion/neo-python/issues/714>`
+- Add fix to ensure tx is saved to wallet when sent using RPC
 - Add bad peers to the ``getpeers`` RPC method `#715 <https://github.com/CityOfZion/neo-python/pull/715>`
+
 
 [0.8.2] 2018-10-31
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ All notable changes to this project are documented in this file.
 - Fix RPC's ``getaccountstate`` response schema to match ``neo-cli`` `#714 <https://github.com/CityOfZion/neo-python/issues/714>`
 - Add fix to ensure tx is saved to wallet when sent using RPC
 - Add bad peers to the ``getpeers`` RPC method `#715 <https://github.com/CityOfZion/neo-python/pull/715>`
-
+- Introduce Django inspired component loading for REST and RPC server
 
 [0.8.2] 2018-10-31
 -------------------

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -382,3 +382,6 @@ settings.set_loglevel(logging.INFO)
 if not os.getenv("SKIP_PY_CHECK"):
     if sys.version_info < (3, 6):
         raise SystemCheckError("Needs Python 3.6+. Currently used: %s" % sys.version)
+
+RPC_SERVER = 'neo.api.JSONRPC.JsonRpcApi.JsonRpcApi'
+REST_SERVER = 'neo.api.REST.RestApi.RestApi'

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -107,6 +107,11 @@ class SettingsHolder:
 
     VERSION_NAME = "/NEO-PYTHON:%s/" % __version__
 
+    RPC_SERVER = None
+    REST_SERVER = None
+    DEFAULT_RPC_SERVER = 'neo.api.JSONRPC.JsonRpcApi.JsonRpcApi'
+    DEFAULT_REST_SERVER = 'neo.api.REST.RestApi.RestApi'
+
     # Logging settings
     log_level = None
     log_smart_contract_events = False
@@ -210,6 +215,8 @@ class SettingsHolder:
         self.NOTIFICATION_DB_PATH = config.get('NotificationDataPath', 'Chains/notification_data')
         self.SERVICE_ENABLED = config.get('ServiceEnabled', False)
         self.COMPILER_NEP_8 = config.get('CompilerNep8', False)
+        self.REST_SERVER = config.get('RestServer', self.DEFAULT_REST_SERVER)
+        self.RPC_SERVER = config.get('RPCServer', self.DEFAULT_RPC_SERVER)
 
     def setup_mainnet(self):
         """ Load settings from the mainnet JSON config file """
@@ -382,6 +389,3 @@ settings.set_loglevel(logging.INFO)
 if not os.getenv("SKIP_PY_CHECK"):
     if sys.version_info < (3, 6):
         raise SystemCheckError("Needs Python 3.6+. Currently used: %s" % sys.version)
-
-RPC_SERVER = 'neo.api.JSONRPC.JsonRpcApi.JsonRpcApi'
-REST_SERVER = 'neo.api.REST.RestApi.RestApi'

--- a/neo/Utils/plugin.py
+++ b/neo/Utils/plugin.py
@@ -9,6 +9,9 @@ def load_class_from_path(path_and_class: str):
         path_and_class: relative path where to find the module and its class name
         i.e. 'neo.<package>.<package>.<module>.<class name>'
 
+    Raises:
+        ValueError: if the Module or Class is not found.
+
     Returns:
         class object
     """

--- a/neo/Utils/plugin.py
+++ b/neo/Utils/plugin.py
@@ -1,0 +1,26 @@
+import importlib
+
+
+def load_class_from_path(path_and_class: str):
+    """
+    Dynamically load a class from a module at the specified path
+
+    Args:
+        path_and_class: relative path where to find the module and its class name
+        i.e. 'neo.<package>.<package>.<module>.<class name>'
+
+    Returns:
+        class object
+    """
+    try:
+        module_path = '.'.join(path_and_class.split('.')[:-1])
+        module = importlib.import_module(module_path)
+    except ImportError as err:
+        raise ValueError(f"Failed to import module {module_path} with error: {err}")
+
+    try:
+        class_name = path_and_class.split('.')[-1]
+        class_obj = getattr(module, class_name)
+        return class_obj
+    except AttributeError as err:
+        raise ValueError(f"Failed to get class {class_name} with error: {err}")

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -562,6 +562,7 @@ class JsonRpcApi:
         self.wallet.Sign(context)
         if context.Completed:
             tx.scripts = context.GetScripts()
+            self.wallet.SaveTransaction(tx)
             NodeLeader.Instance().Relay(tx)
             return tx.ToJson()
         else:

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -248,7 +248,7 @@ def main():
     if args.port_rpc:
         logger.info("Starting json-rpc api server on http://%s:%s" % (args.host, args.port_rpc))
         try:
-            rpc_class = load_class_from_path(neo.Settings.RPC_SERVER)
+            rpc_class = load_class_from_path(settings.RPC_SERVER)
         except ValueError as err:
             logger.error(err)
             sys.exit()
@@ -260,7 +260,7 @@ def main():
     if args.port_rest:
         logger.info("Starting REST api server on http://%s:%s" % (args.host, args.port_rest))
         try:
-            rest_api = load_class_from_path(neo.Settings.REST_SERVER)
+            rest_api = load_class_from_path(settings.REST_SERVER)
         except ValueError as err:
             logger.error(err)
             sys.exit()

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -2,7 +2,7 @@
 """
 API server to run the JSON-RPC and REST API.
 
-Uses servers specified in neo.Settings.RPC_SERVER and neo.Settings.REST_SERVER
+Uses servers specified in protocol.xxx.json files
 
 Print the help and all possible arguments:
 

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -2,7 +2,7 @@
 """
 API server to run the JSON-RPC and REST API.
 
-Uses neo.api.JSONRPC.JsonRpcApi or neo.api.JSONRPC.ExtendedJsonRpcApi and neo.api.REST.RestApi
+Uses servers specified in neo.Settings.RPC_SERVER and neo.Settings.REST_SERVER
 
 Print the help and all possible arguments:
 
@@ -52,16 +52,14 @@ from twisted.web.server import Site
 # neo methods and modules
 from neo.Core.Blockchain import Blockchain
 from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlockchain
-from neo.api.JSONRPC.JsonRpcApi import JsonRpcApi
-from neo.api.JSONRPC.ExtendedJsonRpcApi import ExtendedJsonRpcApi
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
-from neo.api.REST.RestApi import RestApi
 from neo.Wallets.utils import to_aes_key
 from neo.Implementations.Wallets.peewee.UserWallet import UserWallet
 
 from neo.Network.NodeLeader import NodeLeader
 from neo.Settings import settings
-
+from neo.Utils.plugin import load_class_from_path
+import neo.Settings
 
 # Logfile default settings (only used if --logfile arg is used)
 LOGFILE_MAX_BYTES = 5e7  # 50 MB
@@ -127,9 +125,6 @@ def main():
 
     # host
     parser.add_argument("--host", action="store", type=str, help="Hostname ( for example 127.0.0.1)", default="0.0.0.0")
-
-    # extended json-rpc api
-    parser.add_argument("--extended-rpc", action="store_true", default=False, help="Use extended json-rpc api")
 
     # Now parse
     args = parser.parse_args()
@@ -249,28 +244,20 @@ def main():
     d.setDaemon(True)  # daemonizing the thread will kill it when the main thread is quit
     d.start()
 
-    if args.port_rpc and args.extended_rpc:
-        logger.info("Starting extended json-rpc api server on http://%s:%s" % (args.host, args.port_rpc))
-        api_server_rpc = ExtendedJsonRpcApi(args.port_rpc, wallet=wallet)
-        endpoint_rpc = "tcp:port={0}:interface={1}".format(args.port_rpc, args.host)
-        endpoints.serverFromString(reactor, endpoint_rpc).listen(Site(api_server_rpc.app.resource()))
-#        reactor.listenTCP(int(args.port_rpc), server.Site(api_server_rpc))
-#        api_server_rpc.app.run(args.host, args.port_rpc)
-
-    elif args.port_rpc:
+    if args.port_rpc:
         logger.info("Starting json-rpc api server on http://%s:%s" % (args.host, args.port_rpc))
-        api_server_rpc = JsonRpcApi(args.port_rpc, wallet=wallet)
+        rpc_class = load_class_from_path(neo.Settings.RPC_SERVER)
+        api_server_rpc = rpc_class(args.port_rpc, wallet=wallet)
+
         endpoint_rpc = "tcp:port={0}:interface={1}".format(args.port_rpc, args.host)
         endpoints.serverFromString(reactor, endpoint_rpc).listen(Site(api_server_rpc.app.resource()))
-#        reactor.listenTCP(int(args.port_rpc), server.Site(api_server_rpc))
-#        api_server_rpc.app.run(args.host, args.port_rpc)
 
     if args.port_rest:
         logger.info("Starting REST api server on http://%s:%s" % (args.host, args.port_rest))
-        api_server_rest = RestApi()
+        rest_api = load_class_from_path(neo.Settings.REST_SERVER)
+        api_server_rest = rest_api()
         endpoint_rest = "tcp:port={0}:interface={1}".format(args.port_rest, args.host)
         endpoints.serverFromString(reactor, endpoint_rest).listen(Site(api_server_rest.app.resource()))
-#        api_server_rest.app.run(args.host, args.port_rest)
 
     reactor.run()
 

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -33,6 +33,7 @@ to reuse our logzero logging setup. See also:
 * https://twistedmatrix.com/documents/17.9.0/api/twisted.logger.STDLibLogObserver.html
 """
 import os
+import sys
 import argparse
 import threading
 from time import sleep
@@ -246,7 +247,11 @@ def main():
 
     if args.port_rpc:
         logger.info("Starting json-rpc api server on http://%s:%s" % (args.host, args.port_rpc))
-        rpc_class = load_class_from_path(neo.Settings.RPC_SERVER)
+        try:
+            rpc_class = load_class_from_path(neo.Settings.RPC_SERVER)
+        except ValueError as err:
+            logger.error(err)
+            sys.exit()
         api_server_rpc = rpc_class(args.port_rpc, wallet=wallet)
 
         endpoint_rpc = "tcp:port={0}:interface={1}".format(args.port_rpc, args.host)
@@ -254,7 +259,11 @@ def main():
 
     if args.port_rest:
         logger.info("Starting REST api server on http://%s:%s" % (args.host, args.port_rest))
-        rest_api = load_class_from_path(neo.Settings.REST_SERVER)
+        try:
+            rest_api = load_class_from_path(neo.Settings.REST_SERVER)
+        except ValueError as err:
+            logger.error(err)
+            sys.exit()
         api_server_rest = rest_api()
         endpoint_rest = "tcp:port={0}:interface={1}".format(args.port_rest, args.host)
         endpoints.serverFromString(reactor, endpoint_rest).listen(Site(api_server_rest.app.resource()))

--- a/neo/data/protocol.mainnet.json
+++ b/neo/data/protocol.mainnet.json
@@ -57,6 +57,8 @@
     "BootstrapFiles": "https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_latest",
     "DebugStorage": 1,
     "AcceptIncomingPeers": false,
-    "CompilerNep8": false
+    "CompilerNep8": false,
+    "RestServer": "neo.api.REST.RestApi.RestApi",
+    "RPCServer": "neo.api.JSONRPC.JsonRpcApi.JsonRpcApi"
   }
 }

--- a/neo/data/protocol.privnet.json
+++ b/neo/data/protocol.privnet.json
@@ -35,10 +35,12 @@
     ],
     "SslCert": "",
     "SslCertPassword": "",
-    "BootstrapName": "mainnet",
+    "BootstrapName": "privnet",
     "BootstrapFiles": "https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_latest",
     "DebugStorage": 1,
     "AcceptIncomingPeers": false,
-    "CompilerNep8":false
+    "CompilerNep8": false,
+    "RestServer": "neo.api.REST.RestApi.RestApi",
+    "RPCServer": "neo.api.JSONRPC.JsonRpcApi.JsonRpcApi"
   }
 }

--- a/neo/data/protocol.testnet.json
+++ b/neo/data/protocol.testnet.json
@@ -14,7 +14,9 @@
     "BootstrapFiles": "https://s3.us-east-2.amazonaws.com/cityofzion/bootstrap_latest",
     "DebugStorage": 1,
     "AcceptIncomingPeers": false,
-    "CompilerNep8": false
+    "CompilerNep8": false,
+    "RestServer": "neo.api.REST.RestApi.RestApi",
+    "RPCServer": "neo.api.JSONRPC.JsonRpcApi.JsonRpcApi"
   },
   "ProtocolConfiguration": {
     "AddressVersion": 23,

--- a/neo/data/protocol.unittest-net.json
+++ b/neo/data/protocol.unittest-net.json
@@ -41,6 +41,8 @@
     "AcceptIncomingPeers": false,
     "CompilerNep8": true,
     "BootstrapName": "fauxnet",
-    "BootstrapFiles": "this_does_not_exist_for_this_network"
+    "BootstrapFiles": "this_does_not_exist_for_this_network",
+    "RestServer": "neo.api.REST.RestApi.RestApi",
+    "RPCServer": "neo.api.JSONRPC.JsonRpcApi.JsonRpcApi"
   }
 }


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
A different approach for loading plugins as suggested in #699, Django inspired

**How did you solve this problem?**
add a class loader

**How did you make sure your solution works?**
manually run `api_server.py` with Rest and RPC servers

**Are there any special changes in the code that we should be aware of?**
Yes; the `RPC_SERVER` and `REST_SERVER` variables are now stored at module level and not part of the `SettingsHolder` class. The implication is that all networks (main/test/priv) use the same settings. The alternative is moving it into the `SettingsHolder` which means we need to update all `protocol.xxx.json` files to include new keys to load from and otherwise have a sane default.

What approach would be preferred here (requesting extra opinions 🙏 ): @metachris @jseagrave21 @ThomasLobker @dethos 
choice 1: all networks have the same plugin loading settings
choice 2: all network can have individual plugin loading settings as defined in their `protocol.xxx.json`

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
