### PR TITLE
Fix default bootstrap warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 - Add fix to ensure tx is saved to wallet when sent using RPC
 - Add bad peers to the ``getpeers`` RPC method `#715 <https://github.com/CityOfZion/neo-python/pull/715>`
 - Allow a raw tx to be build without an active blockchain db in the environment
+- Fix unnecessary default bootstrap warning for mainnet showing.
 
 
 [0.8.2] 2018-10-31

--- a/neo/Settings.py
+++ b/neo/Settings.py
@@ -165,9 +165,10 @@ class SettingsHolder:
         """ Setup settings from a JSON config file """
 
         def get_config_and_warn(key, default, abort=False):
-            value = config.get(key, default)
-            if value == default:
+            value = config.get(key, None)
+            if not value:
                 print(f"Cannot find {key} in settings, using default value: {default}")
+                value = default
                 if abort:
                     sys.exit(-1)
             return value


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
a warning about default bootstraps was given when not applicable. fixed logic

**How did you solve this problem?**

**How did you make sure your solution works?**
running the terminal myself

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
