### PR TITLE
Improve CommandBase.register_sub_command to use the subcommand's Comm…

### DIFF
--- a/neo/Prompt/CommandBase.py
+++ b/neo/Prompt/CommandBase.py
@@ -69,15 +69,20 @@ class CommandBase(ABC):
     def execute_sub_command(self, id, arguments):
         self.__sub_commands[id].execute(arguments)
 
-    # ids: can be either a string or a list of strings.
-    def register_sub_command(self, ids, sub_command):
-        if isinstance(ids, list):
-            for id in ids:
-                self.__register_sub_command(id, sub_command)
-        else:
-            self.__register_sub_command(ids, sub_command)
+    def register_sub_command(self, sub_command, additional_ids=[]):
+        """
+        Register a command as a subcommand.
+        It will have it's CommandDesc.command string used as id. Additional ids can be provided.
 
-    def __register_sub_command(self, id, sub_command):
+        Args:
+            sub_command (CommandBase): Subcommand to register.
+            additional_ids (List[str]): List of additional ids. Can be empty.
+        """
+        self.__register_sub_command(sub_command, sub_command.command_desc().command)
+        for id in additional_ids:
+            self.__register_sub_command(sub_command, id)
+
+    def __register_sub_command(self, sub_command, id):
         if id in self.__sub_commands:
             raise ValueError(f"{id} is already a subcommand of {self.command_desc().command}.")
         if sub_command.__parent_command and sub_command.__parent_command != self:

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -29,10 +29,10 @@ class CommandWallet(CommandBase):
     def __init__(self):
         super().__init__()
 
-        self.register_sub_command('create', CommandWalletCreate())
-        self.register_sub_command(['v', '--v', 'verbose'], CommandWalletVerbose())
-        self.register_sub_command('migrate', CommandWalletMigrate())
-        self.register_sub_command('create_addr', CommandWalletCreateAddress())
+        self.register_sub_command(CommandWalletCreate())
+        self.register_sub_command(CommandWalletVerbose(), ['v', '--v'])
+        self.register_sub_command(CommandWalletMigrate())
+        self.register_sub_command(CommandWalletCreateAddress())
 
     def command_desc(self):
         return CommandDesc('wallet', 'manage wallets')
@@ -65,8 +65,7 @@ class CommandWalletCreate(CommandBase):
     def __init__(self):
         super().__init__()
 
-    @classmethod
-    def execute(cls, arguments):
+    def execute(self, arguments):
         path = get_arg(arguments, 0)
 
         if path:
@@ -105,7 +104,6 @@ class CommandWalletCreate(CommandBase):
         else:
             print("Please specify a path")
 
-    @classmethod
     def command_desc(self):
         p1 = ParameterDesc('path', 'path to store the wallet file')
         return CommandDesc('create', 'creates a new NEO wallet address', [p1])


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Registering a `subcommand` and declaring the `subcommand`'s `CommandDesc` was repeating the `subcommand`'s `id`.

For example we had:
```
self.register_sub_command('create', CommandWalletCreate())
```
and 
```
def command_desc(self):
        p1 = ParameterDesc('path', 'path to store the wallet file')
        return CommandDesc('create', 'creates a new NEO wallet address', [p1])
```

The same `id` has to be specified twice which could lead to errors.

**How did you solve this problem?**
Use the `subcommand`'s `CommandDesc.command` directly when registering a subcommand.

**How did you make sure your solution works?**
I tested np-prompt.

**Are there any special changes in the code that we should be aware of?**
No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [ ] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
