### PR TITLE
[refactor-prompt] Prompt fixes

### DIFF
--- a/neo/Prompt/CommandBase.py
+++ b/neo/Prompt/CommandBase.py
@@ -69,15 +69,20 @@ class CommandBase(ABC):
     def execute_sub_command(self, id, arguments):
         self.__sub_commands[id].execute(arguments)
 
-    # ids: can be either a string or a list of strings.
-    def register_sub_command(self, ids, sub_command):
-        if isinstance(ids, list):
-            for id in ids:
-                self.__register_sub_command(id, sub_command)
-        else:
-            self.__register_sub_command(ids, sub_command)
+    def register_sub_command(self, sub_command, additional_ids=[]):
+        """
+        Register a command as a subcommand.
+        It will have it's CommandDesc.command string used as id. Additional ids can be provided.
 
-    def __register_sub_command(self, id, sub_command):
+        Args:
+            sub_command (CommandBase): Subcommand to register.
+            additional_ids (List[str]): List of additional ids. Can be empty.
+        """
+        self.__register_sub_command(sub_command, sub_command.command_desc().command)
+        for id in additional_ids:
+            self.__register_sub_command(sub_command, id)
+
+    def __register_sub_command(self, sub_command, id):
         if id in self.__sub_commands:
             raise ValueError(f"{id} is already a subcommand of {self.command_desc().command}.")
         if sub_command.__parent_command and sub_command.__parent_command != self:

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -196,7 +196,7 @@ class CommandWalletMigrate(CommandBase):
         return False
 
     def command_desc(self):
-        return CommandDesc('migrate', 'migrate an old wallet to the new format', params=[])
+        return CommandDesc('migrate', 'migrate an old wallet to the new format')
 
 
 class CommandWalletCreateAddress(CommandBase):
@@ -209,7 +209,8 @@ class CommandWalletCreateAddress(CommandBase):
         return CreateAddress(PromptData.Wallet, addresses_to_create)
 
     def command_desc(self):
-        return CommandDesc('create_addr', 'create a new wallet address')
+        p1 = ParameterDesc('number of addresses', 'number of addresses to create')
+        return CommandDesc('create_addr', 'create a new wallet address', params=[p1])
 
 
 #########################################################################
@@ -221,18 +222,18 @@ def CreateAddress(wallet, args):
         int_args = int(args)
     except (ValueError, TypeError) as error:  # for non integer args or Nonetype
         print(error)
-        return False
+        return None
 
     if wallet is None:
         print("Please open a wallet.")
-        return False
+        return None
 
     if int_args <= 0:
         print('Enter a number greater than 0.')
-        return False
+        return None
 
     address_list = []
-    for i in range(int_args):
+    for _ in range(int_args):
         keys = wallet.CreateKey()
         account = Account.get(PublicKeyHash=keys.PublicKeyHash.ToBytes())
         address_list.append(account.contract_set[0].Address.ToString())
@@ -247,7 +248,6 @@ def DeleteAddress(wallet, addr):
 
     if success:
         print("Deleted address %s " % addr)
-
     else:
         print("error deleting addr %s " % addr)
 
@@ -261,7 +261,6 @@ def DeleteToken(wallet, contract_hash):
 
     if success:
         print("Deleted token %s " % contract_hash)
-
     else:
         print("error deleting token %s " % contract_hash)
 
@@ -308,12 +307,9 @@ def ImportToken(wallet, contract_hash):
         result = token.Query()
 
         if result:
-
             wallet.AddNEP5Token(token)
             print("added token %s " % json.dumps(token.ToJson(), indent=4))
-
         else:
-
             print("Could not import token")
 
 

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -29,10 +29,10 @@ class CommandWallet(CommandBase):
     def __init__(self):
         super().__init__()
 
-        self.register_sub_command('create', CommandWalletCreate())
-        self.register_sub_command(['v', '--v', 'verbose'], CommandWalletVerbose())
-        self.register_sub_command('migrate', CommandWalletMigrate())
-        self.register_sub_command('create_addr', CommandWalletCreateAddress())
+        self.register_sub_command(CommandWalletCreate())
+        self.register_sub_command(CommandWalletVerbose(), ['v', '--v'])
+        self.register_sub_command(CommandWalletMigrate())
+        self.register_sub_command(CommandWalletCreateAddress())
 
     def command_desc(self):
         return CommandDesc('wallet', 'manage wallets')
@@ -65,8 +65,7 @@ class CommandWalletCreate(CommandBase):
     def __init__(self):
         super().__init__()
 
-    @classmethod
-    def execute(cls, arguments):
+    def execute(self, arguments):
         path = get_arg(arguments, 0)
 
         if path:
@@ -105,7 +104,6 @@ class CommandWalletCreate(CommandBase):
         else:
             print("Please specify a path")
 
-    @classmethod
     def command_desc(self):
         p1 = ParameterDesc('path', 'path to store the wallet file')
         return CommandDesc('create', 'creates a new NEO wallet address', [p1])

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -110,6 +110,7 @@ class PromptInterface:
 
     def get_completer(self):
         standard_completions = list({word for d in self._command_descs for word in d.command.split()})  # Use a set to ensure unicity of words
+        standard_completions += ['quit', 'help', 'exit']
 
         if PromptData.Wallet:
             for addr in PromptData.Wallet.Addresses:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
1. `help`, `quit` and `exit` being handled outside of `CommandBase` feature, the words were unknown from the autocompleter.

2. `CommandWalletCreateAddress.command_desc` was missing a aparameter.

**How did you solve this problem?**
1. Add these words to the autocompletion words list.

2. Added the parameter

**How did you make sure your solution works?**
Manual test.

**Are there any special changes in the code that we should be aware of?**
No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
