### PR TITLE
[refactor prompt] Add support for show method group (pt 2)

### DIFF
--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -308,6 +308,9 @@ class Blockchain:
     def SearchAssetState(self, query):
         pass
 
+    def ShowAllAssets(self):
+        pass
+
     def GetHeaderHash(self, height):
         pass
 

--- a/neo/Core/FunctionCode.py
+++ b/neo/Core/FunctionCode.py
@@ -1,7 +1,7 @@
 from neocore.IO.Mixins import SerializableMixin
 from neocore.Cryptography.Crypto import Crypto
 from neocore.BigInteger import BigInteger
-from neo.SmartContract.ContractParameterType import ContractParameterType
+from neo.SmartContract.ContractParameterType import ContractParameterType, ToName
 
 
 class FunctionCode(SerializableMixin):
@@ -104,9 +104,11 @@ class FunctionCode(SerializableMixin):
         Returns:
              dict:
         """
+        parameters = self.ParameterList.hex()
+        paramlist = [ToName(ContractParameterType.FromString(parameters[i:i + 2]).value) for i in range(0, len(parameters), 2)]
         return {
             'hash': self.ScriptHash().To0xString(),
             'script': self.Script.hex(),
-            'parameters': self.ParameterList.hex(),
-            'returntype': self.ReturnType if type(self.ReturnType) is int else self.ReturnType.hex()
+            'parameters': paramlist,
+            'returntype': ToName(self.ReturnType) if type(self.ReturnType) is int else ToName(int(self.ReturnType))
         }

--- a/neo/Core/State/ContractState.py
+++ b/neo/Core/State/ContractState.py
@@ -183,8 +183,6 @@ class ContractState(StateBase):
         Returns:
              dict:
         """
-        codejson = self.Code.ToJson()
-
         name = 'Contract'
 
         try:
@@ -192,10 +190,11 @@ class ContractState(StateBase):
         except Exception as e:
             pass
 
-        jsn = {
+        jsn = {'version': self.StateVersion}
 
-            'version': self.StateVersion,
-            'code': codejson,
+        jsn_code = self.Code.ToJson()
+
+        jsn_contract = {
             'name': name,
             'code_version': self.CodeVersion.decode('utf-8'),
             'author': self.Author.decode('utf-8'),
@@ -207,6 +206,9 @@ class ContractState(StateBase):
                 'payable': self.Payable
             }
         }
+
+        jsn.update(jsn_code)
+        jsn.update(jsn_contract)
 
         if self._nep_token:
             jsn['token'] = self._nep_token.ToJson()

--- a/neo/Core/TX/test_transactions.py
+++ b/neo/Core/TX/test_transactions.py
@@ -90,8 +90,8 @@ class TransactionTestCase(NeoTestCase):
         self.assertEqual(contract['description'], 'Lock your assets until a timestamp.')
 
         self.assertEqual(contract['code']['hash'], '0xffbd1a7ad1e2348b6b3822426f364bfb4bcce3b9')
-        self.assertEqual(contract['code']['returntype'], 1)
-        self.assertEqual(contract['code']['parameters'], '020500')
+        self.assertEqual(contract['code']['returntype'], "Boolean")
+        self.assertEqual(contract['code']['parameters'], ['Integer', 'ByteArray', 'Signature'])
         self.assertEqual(Fixed8.FromDecimal(settings.ALL_FEES['PublishTransaction']), tx.SystemFee())
 
     ir = b'd100644011111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111081234567890abcdef0415cd5b0769cc4ee2f1c9f4e0782756dabf246d0a4fe60a035400000000'

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -371,6 +371,12 @@ class LevelDBBlockchain(Blockchain):
 
         return asset
 
+    def ShowAllAssets(self):
+
+        assets = DBCollection(self._db, DBPrefix.ST_Asset, AssetState)
+        keys = assets.Keys
+        return keys
+
     def GetTransaction(self, hash):
 
         if type(hash) is str:

--- a/neo/Implementations/Blockchains/LevelDB/test_LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/test_LevelDBBlockchain.py
@@ -75,6 +75,6 @@ class LevelDBBlockchainTest(BlockchainFixtureTestCase):
         block = self._blockchain.GetHeaderBy(invalid_bc_height)
         self.assertEqual(block, None)
 
-        def test_ShowAllAssets(self):
+    def test_ShowAllAssets(self):
         assets = Blockchain.Default().ShowAllAssets()
         self.assertEqual(len(assets), 2)

--- a/neo/Implementations/Blockchains/LevelDB/test_LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/test_LevelDBBlockchain.py
@@ -74,3 +74,7 @@ class LevelDBBlockchainTest(BlockchainFixtureTestCase):
         invalid_bc_height = self._blockchain.Height + 1
         block = self._blockchain.GetHeaderBy(invalid_bc_height)
         self.assertEqual(block, None)
+
+        def test_ShowAllAssets(self):
+        assets = Blockchain.Default().ShowAllAssets()
+        self.assertEqual(len(assets), 2)

--- a/neo/Prompt/Commands/Show.py
+++ b/neo/Prompt/Commands/Show.py
@@ -25,6 +25,11 @@ class CommandShow(CommandBase):
         self.register_sub_command(CommandShowTx())
         self.register_sub_command(CommandShowMem())
         self.register_sub_command(CommandShowNodes(), ['node'])
+        self.register_sub_command(CommandShowState())
+        self.register_sub_command(CommandShowNotifications())
+        self.register_sub_command(CommandShowAccount())
+        self.register_sub_command(CommandShowAsset())
+        self.register_sub_command(CommandShowContract())
 
     def command_desc(self):
         return CommandDesc('show', 'show useful data')
@@ -167,3 +172,171 @@ class CommandShowNodes(CommandBase):
 
     def command_desc(self):
         return CommandDesc('nodes', 'show connected peers')
+
+
+class CommandShowState(CommandBase):
+    def __init__(self):
+        super().__init__()
+
+    def execute(self, arguments=None):
+        height = Blockchain.Default().Height
+        headers = Blockchain.Default().HeaderHeight
+
+        diff = height - PromptData.Prompt.start_height
+        now = datetime.datetime.utcnow()
+        difftime = now - PromptData.Prompt.start_dt
+
+        mins = difftime / datetime.timedelta(minutes=1)
+        secs = mins * 60
+
+        bpm = 0
+        tps = 0
+        if diff > 0 and mins > 0:
+            bpm = diff / mins
+            tps = Blockchain.Default().TXProcessed / secs
+
+        out = "Progress: %s / %s\n" % (height, headers)
+        out += "Block-cache length %s\n" % Blockchain.Default().BlockCacheCount
+        out += "Blocks since program start %s\n" % diff
+        out += "Time elapsed %s mins\n" % mins
+        out += "Blocks per min %s \n" % bpm
+        out += "TPS: %s \n" % tps
+        print(out)
+        return out
+
+    def command_desc(self):
+        return CommandDesc('state', 'show the status of the node')
+
+
+class CommandShowNotifications(CommandBase):
+    def __init__(self):
+        super().__init__()
+
+    def execute(self, arguments):
+        if NotificationDB.instance() is None:
+            print("No notification DB Configured")
+            return
+
+        item = get_arg(arguments, 0)
+        events = []
+        if len(item) == 34 and item[0] == 'A':
+            addr = item
+            events = NotificationDB.instance().get_by_addr(addr)
+        else:
+            try:
+                block_height = int(item)
+                if block_height < Blockchain.Default().Height:
+                    events = NotificationDB.instance().get_by_block(block_height)
+                else:
+                    print("Block %s not found" % block_height)
+                    return
+            except Exception as e:
+                print("Could not parse block height %s" % e)
+                return
+
+        if len(events):
+            [print(json.dumps(e.ToJson(), indent=4)) for e in events]
+            return events
+        else:
+            print("No events found for %s" % item)
+            return
+
+    def command_desc(self):
+        p1 = ParameterDesc('block_index/address', 'the block or address to show notifications for')
+        return CommandDesc('notifications', 'show specified contract execution notifications', [p1])
+
+
+class CommandShowAccount(CommandBase):
+    def __init__(self):
+        super().__init__()
+
+    def execute(self, arguments):
+        item = get_arg(arguments)
+        if item is not None:
+            account = Blockchain.Default().GetAccountState(item, print_all_accounts=True)
+
+            if account is not None:
+                print(json.dumps(account.ToJson(), indent=4))
+                return account.ToJson()
+            else:
+                print("Account %s not found" % item)
+                return
+        else:
+            print("Please specify an account address")
+            return
+
+    def command_desc(self):
+        p1 = ParameterDesc('address', 'the address to show')
+        return CommandDesc('account', 'show the assets (NEO/GAS) held by a specified address', [p1])
+
+
+class CommandShowAsset(CommandBase):
+    def __init__(self):
+        super().__init__()
+
+    def execute(self, arguments):
+        item = get_arg(arguments)
+        if item is not None:
+            if item.lower() == "all":
+                assets = Blockchain.Default().ShowAllAssets()
+                print("Assets: %s" % assets)
+                return assets
+
+            if item.lower() == 'neo':
+                assetId = Blockchain.Default().SystemShare().Hash
+            elif item.lower() == 'gas':
+                assetId = Blockchain.Default().SystemCoin().Hash
+            else:
+                try:
+                    assetId = UInt256.ParseString(item)
+                except Exception as e:
+                    print("Could not find assetId from args: %s (%s)" % (e, arguments))
+                    return
+
+            asset = Blockchain.Default().GetAssetState(assetId.ToBytes())
+
+            if asset is not None:
+                print(json.dumps(asset.ToJson(), indent=4))
+                return asset.ToJson()
+            else:
+                print("Asset %s not found" % item)
+                return
+        else:
+            print("Please specify an asset hash or name")
+            return
+
+    def command_desc(self):
+        p1 = ParameterDesc('name/assetId/all', 'the name or assetId of the asset, or "all" shows all assets\n\n')
+        f"{' ':>17} Example:\n"
+        f"{' ':>20} 'neo' or 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'\n"
+        f"{' ':>20} 'gas' or '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'\n"
+        return CommandDesc('asset', 'show a specified asset', [p1])
+
+
+class CommandShowContract(CommandBase):
+    def __init__(self):
+        super().__init__()
+
+    def execute(self, arguments):
+        item = get_arg(arguments)
+        if item is not None:
+            if item.lower() == "all":
+                contracts = Blockchain.Default().ShowAllContracts()
+                print("Contracts: %s" % contracts)
+                return contracts
+
+            contract = Blockchain.Default().GetContract(item)
+
+            if contract is not None:
+                contract.DetermineIsNEP5()
+                print(json.dumps(contract.ToJson(), indent=4))
+                return contract.ToJson()
+            else:
+                print("Contract %s not found" % item)
+                return
+        else:
+            print("Please specify a contract")
+
+    def command_desc(self):
+        p1 = ParameterDesc('hash/all', 'the scripthash of the contract, or "all" shows all contracts')
+        return CommandDesc('contract', 'show a specified smart contract', [p1])

--- a/neo/Prompt/Commands/Show.py
+++ b/neo/Prompt/Commands/Show.py
@@ -76,11 +76,11 @@ class CommandShowBlock(CommandBase):
                 print("Could not locate block %s" % item)
                 return
         else:
-            print("please specify a block")
+            print("please specify a supported block attribute: index or scripthash")
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('index/hash', 'the index or scripthash of the block')
+        p1 = ParameterDesc('attribute', 'the block index or scripthash')
         p2 = ParameterDesc('tx', 'arg to only show block transactions', optional=True)
         return CommandDesc('block', 'show a specified block', [p1, p2])
 
@@ -100,11 +100,11 @@ class CommandShowHeader(CommandBase):
                 print("Could not locate header %s\n" % item)
                 return
         else:
-            print("Please specify a header")
+            print("Please specify a supported header attribute: index or scripthash")
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('index/hash', 'the index or scripthash of the block header')
+        p1 = ParameterDesc('attribute', 'the header index or scripthash')
         return CommandDesc('header', 'show the header of a specified block', [p1])
 
 
@@ -250,11 +250,11 @@ class CommandShowNotifications(CommandBase):
                 print("No events found for %s" % item)
                 return
         else:
-            print("Please specify a block index, address, or contract hash")
+            print("Please specify a supported attribute: a block index, an address, or contract scripthash")
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('block_index/address/contract_hash', 'the block, address, or contract to show notifications for')
+        p1 = ParameterDesc('attribute', 'the block index, an address, or contract scripthash to show notifications for')
         return CommandDesc('notifications', 'show specified contract execution notifications', [p1])
 
 
@@ -291,8 +291,13 @@ class CommandShowAsset(CommandBase):
         if item is not None:
             if item.lower() == "all":
                 assets = Blockchain.Default().ShowAllAssets()
-                print("Assets: %s" % assets)
-                return assets
+                assetlist = []
+                for asset in assets:
+                    state = Blockchain.Default().GetAssetState(asset.decode('utf-8')).ToJson()
+                    asset_dict = {state['name']: state['assetId']}
+                    assetlist.append(asset_dict)
+                print(json.dumps(assetlist, indent=4))
+                return assetlist
 
             if item.lower() == 'neo':
                 assetId = Blockchain.Default().SystemShare().Hash
@@ -314,14 +319,14 @@ class CommandShowAsset(CommandBase):
                 print("Asset %s not found" % item)
                 return
         else:
-            print("Please specify an asset hash or name")
+            print('Please specify a supported attribute: asset name, assetId, or "all" shows all assets')
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('name/assetId/all', 'the name or assetId of the asset, or "all" shows all assets\n\n')
-        f"{' ':>17} Example:\n"
-        f"{' ':>20} 'neo' or 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'\n"
-        f"{' ':>20} 'gas' or '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'\n"
+        p1 = ParameterDesc('attribute', 'the asset name, assetId, or "all" shows all assets\n\n'
+                           f"{' ':>17} Example:\n"
+                           f"{' ':>20} 'neo' or 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'\n"
+                           f"{' ':>20} 'gas' or '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'\n")
         return CommandDesc('asset', 'show a specified asset', [p1])
 
 
@@ -334,8 +339,13 @@ class CommandShowContract(CommandBase):
         if item is not None:
             if item.lower() == "all":
                 contracts = Blockchain.Default().ShowAllContracts()
-                print("Contracts: %s" % contracts)
-                return contracts
+                contractlist = []
+                for contract in contracts:
+                    state = Blockchain.Default().GetContract(contract.decode('utf-8')).ToJson()
+                    contract_dict = {state['name']: state['code']['hash']}
+                    contractlist.append(contract_dict)
+                print(json.dumps(contractlist, indent=4))
+                return contractlist
 
             try:
                 hash = UInt160.ParseString(item).ToBytes()
@@ -353,9 +363,9 @@ class CommandShowContract(CommandBase):
                 print("Contract %s not found" % item)
                 return
         else:
-            print("Please specify a contract")
+            print('Please specify a supported attribute: contract scripthash or "all"')
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('hash/all', 'the scripthash of the contract, or "all" shows all contracts')
+        p1 = ParameterDesc('attribute', 'the contract scripthash, or "all" shows all contracts')
         return CommandDesc('contract', 'show a specified smart contract', [p1])

--- a/neo/Prompt/Commands/Show.py
+++ b/neo/Prompt/Commands/Show.py
@@ -342,7 +342,7 @@ class CommandShowContract(CommandBase):
                 contractlist = []
                 for contract in contracts:
                     state = Blockchain.Default().GetContract(contract.decode('utf-8')).ToJson()
-                    contract_dict = {state['name']: state['code']['hash']}
+                    contract_dict = {state['name']: state['hash']}
                     contractlist.append(contract_dict)
                 print(json.dumps(contractlist, indent=4))
                 return contractlist

--- a/neo/Prompt/Commands/tests/test_show_commands.py
+++ b/neo/Prompt/Commands/tests/test_show_commands.py
@@ -175,6 +175,11 @@ class CommandShowTestCase(BlockchainFixtureTestCase):
             res = CommandShow().execute(args)
             self.assertFalse(res)
 
+        # test with no input
+        args = ['notifications']
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
         # good test with address
         args = ['notifications', wallet_1_addr]
         res = CommandShow().execute(args)
@@ -189,6 +194,32 @@ class CommandShowTestCase(BlockchainFixtureTestCase):
         res = CommandShow().execute(args)
         self.assertFalse(res)
 
+        # good test with contract
+        contract_hash = "31730cc9a1844891a3bafd1aa929a4142860d8d3"
+        args = ['notifications', contract_hash]
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+        self.assertEqual(len(res), 1)
+        jsn = res[0].ToJson()
+        self.assertEqual(jsn['notify_type'], 'transfer')
+        self.assertIn(contract_hash, jsn['contract'])
+
+        # good test with contract 0x hash
+        contract_hash = "0x31730cc9a1844891a3bafd1aa929a4142860d8d3"
+        args = ['notifications', contract_hash]
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+        self.assertEqual(len(res), 1)
+        jsn = res[0].ToJson()
+        self.assertEqual(jsn['notify_type'], 'transfer')
+        self.assertEqual(contract_hash, jsn['contract'])
+
+        # test contract not on the blockchain
+        contract_hash = "3a4acd3647086e7c44398aac0349802e6a171129"  # NEX token hash
+        args = ['notifications', contract_hash]
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
         # good test with block index
         args = ['notifications', "12337"]
         res = CommandShow().execute(args)
@@ -198,13 +229,18 @@ class CommandShowTestCase(BlockchainFixtureTestCase):
         self.assertEqual(jsn['notify_type'], 'transfer')
         self.assertEqual(jsn['block'], 12337)
 
+        # test block with no notifications
+        args = ['notifications', "1"]
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
         # test bad block
         index = Blockchain.Default().Height + 1
         args = ['notifications', str(index)]
         res = CommandShow().execute(args)
         self.assertFalse(res)
 
-        # test invalid block input
+        # test invalid input
         args = ['notifications', "blah"]
         res = CommandShow().execute(args)
         self.assertFalse(res)
@@ -305,6 +341,11 @@ class CommandShowTestCase(BlockchainFixtureTestCase):
         self.assertEqual(res['name'], "test NEX Template V4")
         self.assertEqual(res['token']['name'], "NEX Template V4")
         self.assertEqual(res['token']['symbol'], "NXT4")
+
+        # query with a contract scripthash not on the blockchain
+        args = ['contract', '3a4acd3647086e7c44398aac0349802e6a171129']  # NEX token hash
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
 
         # query bad input
         args = ['contract', 'blah']

--- a/neo/Prompt/Commands/tests/test_show_commands.py
+++ b/neo/Prompt/Commands/tests/test_show_commands.py
@@ -287,8 +287,9 @@ class CommandShowTestCase(BlockchainFixtureTestCase):
         args = ['asset', 'all']
         res = CommandShow().execute(args)
         self.assertTrue(res)
-        self.assertIn("602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7", str(res))
-        self.assertIn("c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b", str(res))
+        self.assertEqual(len(res), 2)
+        self.assertEqual(res[1]['NEO'], "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b")
+        self.assertEqual(res[0]['NEOGas'], "0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7")
 
         # query with "neo"
         args = ['asset', 'neo']
@@ -331,8 +332,8 @@ class CommandShowTestCase(BlockchainFixtureTestCase):
         args = ['contract', 'all']
         res = CommandShow().execute(args)
         self.assertTrue(res)
-        res = list(res)
         self.assertEqual(len(res), 6)
+        self.assertEqual(res[0]["test NEX Template V4"], '0x31730cc9a1844891a3bafd1aa929a4142860d8d3')
 
         # query with contract scripthash
         args = ['contract', '31730cc9a1844891a3bafd1aa929a4142860d8d3']

--- a/neo/Prompt/Commands/tests/test_show_commands.py
+++ b/neo/Prompt/Commands/tests/test_show_commands.py
@@ -156,3 +156,157 @@ class CommandShowTestCase(BlockchainFixtureTestCase):
 
         # restore whatever state the instance was in
         NodeLeader._LEAD = old_leader
+
+    def test_show_state(self):
+        # setup
+        PromptInterface()
+
+        args = ['state']
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+
+    def test_show_notifications(self):
+        # setup
+        wallet_1_addr = 'AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3'
+
+        # test with no NotificationDB
+        with patch('neo.Implementations.Notifications.LevelDB.NotificationDB.NotificationDB.instance', return_value=None):
+            args = ['notifications', wallet_1_addr]
+            res = CommandShow().execute(args)
+            self.assertFalse(res)
+
+        # good test with address
+        args = ['notifications', wallet_1_addr]
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+        self.assertEqual(len(res), 1)
+        jsn = res[0].ToJson()
+        self.assertEqual(jsn['notify_type'], 'transfer')
+        self.assertEqual(jsn['addr_from'], wallet_1_addr)
+
+        # test an address with no notifications
+        args = ['notifications', 'AZiE7xfyJALW7KmADWtCJXGGcnduYhGiCX']
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
+        # good test with block index
+        args = ['notifications', "12337"]
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+        self.assertEqual(len(res), 1)
+        jsn = res[0].ToJson()
+        self.assertEqual(jsn['notify_type'], 'transfer')
+        self.assertEqual(jsn['block'], 12337)
+
+        # test bad block
+        index = Blockchain.Default().Height + 1
+        args = ['notifications', str(index)]
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
+        # test invalid block input
+        args = ['notifications', "blah"]
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
+    def test_show_account(self):
+        # setup
+        wallet_1_addr = 'AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3'
+
+        # test no account address entered
+        args = ['account']
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
+        # test good account
+        args = ['account', wallet_1_addr]
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+        self.assertEqual(res['address'], wallet_1_addr)
+        self.assertIn('balances', res)
+
+        # test empty account
+        with patch('neo.Prompt.PromptData.PromptData.Prompt'):
+            with patch('neo.Prompt.Commands.Wallet.prompt', side_effect=["testpassword", "testpassword"]):
+                args = ['create', 'testwallet.wallet']
+                res = CommandWallet().execute(args)
+                self.assertTrue(res)
+                self.assertIsInstance(res, UserWallet)
+
+        addr = res.Addresses[0]
+        args = ['account', addr]
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
+        # remove test wallet
+        os.remove("testwallet.wallet")
+
+    def test_show_asset(self):
+        # test no asset entered
+        args = ['asset']
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
+        # show all assets
+        args = ['asset', 'all']
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+        self.assertIn("602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7", str(res))
+        self.assertIn("c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b", str(res))
+
+        # query with "neo"
+        args = ['asset', 'neo']
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+        self.assertEqual(res['assetId'], "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b")
+        self.assertEqual(res['name'], "NEO")
+
+        # query with "gas"
+        args = ['asset', 'gas']
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+        self.assertEqual(res['assetId'], "0x602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7")
+        self.assertEqual(res['name'], "NEOGas")
+
+        # query with scripthash
+        args = ['asset', 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b']
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+        self.assertEqual(res['assetId'], "0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b")
+        self.assertEqual(res['name'], "NEO")
+
+        # query with bad asset
+        args = ['asset', 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9e']
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
+        # query with bad input
+        args = ['asset', 'blah']
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
+    def test_show_contract(self):
+        # test no contract entered
+        args = ['contract']
+        res = CommandShow().execute(args)
+        self.assertFalse(res)
+
+        # show all contracts
+        args = ['contract', 'all']
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+        res = list(res)
+        self.assertEqual(len(res), 6)
+
+        # query with contract scripthash
+        args = ['contract', '31730cc9a1844891a3bafd1aa929a4142860d8d3']
+        res = CommandShow().execute(args)
+        self.assertTrue(res)
+        self.assertEqual(res['name'], "test NEX Template V4")
+        self.assertEqual(res['token']['name'], "NEX Template V4")
+        self.assertEqual(res['token']['symbol'], "NXT4")
+
+        # query bad input
+        args = ['contract', 'blah']
+        res = CommandShow().execute(args)
+        self.assertFalse(res)

--- a/neo/SmartContract/ContractParameterType.py
+++ b/neo/SmartContract/ContractParameterType.py
@@ -96,7 +96,7 @@ def ToName(param_type):
 
     for item in items:
         name = item[0]
-        val = int(item[1])
+        val = int(item[1].value)
 
         if val == param_type:
             return name

--- a/neo/SmartContract/SmartContractEvent.py
+++ b/neo/SmartContract/SmartContractEvent.py
@@ -161,7 +161,7 @@ class SmartContractEvent(SerializableMixin):
 
         if self.event_type in [SmartContractEvent.CONTRACT_CREATED, SmartContractEvent.CONTRACT_MIGRATED]:
             jsn['contract'] = self.contract.ToJson()
-            del jsn['contract']['code']['script']
+            del jsn['contract']['script']
 
         if self.token:
             jsn['token'] = self.token.ToJson()

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -255,9 +255,9 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         res = json.loads(self.app.home(mock_req))
         self.assertEqual(res['result']['code_version'], '')
         self.assertEqual(res['result']['properties']['storage'], True)
-        self.assertEqual(res['result']['code']['hash'], '0xb9fbcff6e50fd381160b822207231233dd3c56c2')
-        self.assertEqual(res['result']['code']['returntype'], 5)
-        self.assertEqual(res['result']['code']['parameters'], '0710')
+        self.assertEqual(res['result']['hash'], '0xb9fbcff6e50fd381160b822207231233dd3c56c2')
+        self.assertEqual(res['result']['returntype'], "ByteArray")
+        self.assertEqual(res['result']['parameters'], ["String", "Array"])
 
     def test_get_contract_state_0x(self):
         contract_hash = "0xb9fbcff6e50fd381160b822207231233dd3c56c2"

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -16,8 +16,6 @@ from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlo
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
 from neo.Network.NodeLeader import NodeLeader
 from neo.Prompt.Commands.Wallet import CommandWallet
-from neo.Prompt.Commands.Show import CommandShow
-from neo.Prompt.Commands.Search import CommandSearch
 from neo.Prompt.PromptData import PromptData
 from neo.Prompt.InputParser import InputParser
 from neo.Settings import settings, PrivnetConnectionError
@@ -72,7 +70,7 @@ class PromptInterface:
     _known_things = []
 
     _commands = [
-        CommandWallet(), CommandShow(), CommandSearch()
+        CommandWallet(),
     ]
 
     _command_descs = [desc for c in _commands for desc in c.command_descs_with_sub_commands()]

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -16,6 +16,8 @@ from neo.Implementations.Blockchains.LevelDB.LevelDBBlockchain import LevelDBBlo
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
 from neo.Network.NodeLeader import NodeLeader
 from neo.Prompt.Commands.Wallet import CommandWallet
+from neo.Prompt.Commands.Show import CommandShow
+from neo.Prompt.Commands.Search import CommandSearch
 from neo.Prompt.PromptData import PromptData
 from neo.Prompt.InputParser import InputParser
 from neo.Settings import settings, PrivnetConnectionError
@@ -70,7 +72,7 @@ class PromptInterface:
     _known_things = []
 
     _commands = [
-        CommandWallet(),
+        CommandWallet(), CommandShow(), CommandSearch()
     ]
 
     _command_descs = [desc for c in _commands for desc in c.command_descs_with_sub_commands()]


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- Reference https://github.com/CityOfZion/neo-python/pull/737

- This PR supports the last five methods from the `show` method group (see https://github.com/CityOfZion/neo-python/issues/623#issue-362278030)

**How did you solve this problem?**
Trial and Error

**How did you make sure your solution works?**
Unittest

**Are there any special changes in the code that we should be aware of?**
- `ShowAllAssets` was added so `show assets` mirrors `show contracts`
  - originally implemented here https://github.com/CityOfZion/neo-python/pull/667

- Added the ability to use 'neo' or 'gas' to show the corresponding assets
  -  originally implemented here https://github.com/CityOfZion/neo-python/pull/667

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
