### PR TITLE
Fix NodeLeader was not reset between test cases.

### DIFF
--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -63,7 +63,6 @@ class NodeLeader:
     BREQMAX = 10000
 
     KnownHashes = []
-    MissionsGlobal = []
     MemPool = {}
     RelayCache = {}
 
@@ -104,7 +103,10 @@ class NodeLeader:
         self.UnconnectedPeers = []
         self.ADDRS = []
         self.DEAD_ADDRS = []
-        self.MissionsGlobal = []
+        self._MissedBlocks = []
+        self.KnownHashes = []
+        self.MemPool = {}
+        self.RelayCache = {}
         self.NodeId = random.randint(1294967200, 4294967200)
 
     def Restart(self):
@@ -235,7 +237,6 @@ class NodeLeader:
     def ResetBlockRequestsAndCache(self):
         """Reset the block request counter and its cache."""
         logger.debug("Resetting Block requests")
-        self.MissionsGlobal = []
         BC.Default().BlockSearchTries = 0
         for p in self.Peers:
             p.myblockrequests = set()

--- a/neo/Utils/BlockchainFixtureTestCase.py
+++ b/neo/Utils/BlockchainFixtureTestCase.py
@@ -9,6 +9,7 @@ from neo.Core.Blockchain import Blockchain
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
 from neo.Settings import settings
 from neo.logging import log_manager
+from neo.Network.NodeLeader import NodeLeader
 
 logger = log_manager.getLogger()
 
@@ -35,6 +36,8 @@ class BlockchainFixtureTestCase(NeoTestCase):
         Blockchain.DeregisterBlockchain()
 
         super(BlockchainFixtureTestCase, cls).setUpClass()
+
+        NodeLeader.Instance().Setup()
 
         # setup Blockchain DB
         if not os.path.exists(cls.FIXTURE_FILENAME):


### PR DESCRIPTION




**What current issue(s) does this address, or what feature is it adding?**
Related to https://github.com/CityOfZion/neo-python/pull/740#discussion_r239346845

`NodeLeader` was not reset between test cases.
This would lead to some problems when the blockchain is reset but the `NodeLeader` instance members are not, especially `NodeLeader.KnownHashes` and `MemPool`.
Transactions were still considered as known.

**How did you solve this problem?**
1. Add missing members in `NodeLeader.Setup()`
2. Call `NodeLeader.Instance().Setup()` in `BlockchainFixtureTestCase.setUpClass()`
3. Also removed the unsued member `NodeLeader.MissionsGlobal`

**How did you make sure your solution works?**
Unit tests succeed.

**Are there any special changes in the code that we should be aware of?**
Note: maybe this could be merged into develop if the problem is confirmed and the fix correct.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
