### PR TITLE
Gracefully handle NEP-5 balance query failures

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ All notable changes to this project are documented in this file.
 - Fix unnecessary default bootstrap warning for mainnet showing.
 - Add GET and OPTIONS request functionality for JSON-RPC servers
 - Fix ``gzip`` failure in current implementation of ExtendedJsonRpcApi
+- Gracefully handle balance query failures of NEP-5 tokens.
 
 
 [0.8.2] 2018-10-31

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -167,7 +167,7 @@ def TestInvokeContract(wallet, args, withdrawal_tx=None,
             for index, iarg in enumerate(contract.Code.ParameterList):
                 param, abort = gather_param(index, iarg)
                 if abort:
-                    return None, None, None, None
+                    return None, None, None, None, False
                 params.append(param)
             params.reverse()
 
@@ -225,7 +225,7 @@ def TestInvokeContract(wallet, args, withdrawal_tx=None,
 
         print("Contract %s not found" % args[0])
 
-    return None, None, None, None
+    return None, None, None, None, False
 
 
 def make_unique_script_attr(attributes):
@@ -368,18 +368,18 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None,
             wallet_tx.outputs = outputs
             wallet_tx.Attributes = [] if invoke_attrs is None else deepcopy(invoke_attrs)
 
-            return wallet_tx, net_fee, engine.ResultStack.Items, engine.ops_processed
+            return wallet_tx, net_fee, engine.ResultStack.Items, engine.ops_processed, success
 
         # this allows you to to test invocations that fail
         else:
             wallet_tx.outputs = outputs
             wallet_tx.Attributes = [] if invoke_attrs is None else deepcopy(invoke_attrs)
-            return wallet_tx, min_fee, [], engine.ops_processed
+            return wallet_tx, min_fee, [], engine.ops_processed, success
 
     except Exception as e:
         service.ExecutionCompleted(engine, False, e)
 
-    return None, None, None, None
+    return None, None, None, None, False
 
 
 def test_deploy_and_invoke(deploy_script, invoke_args, wallet,

--- a/neo/Wallets/NEP5Token.py
+++ b/neo/Wallets/NEP5Token.py
@@ -133,20 +133,24 @@ class NEP5Token(VerificationCode, SerializableMixin):
         sb = ScriptBuilder()
         sb.EmitAppCallWithOperationAndArgs(self.ScriptHash, 'balanceOf', [addr])
 
-        tx, fee, results, num_ops = test_invoke(sb.ToArray(), wallet, [])
-
-        try:
-            val = results[0].GetBigInteger()
-            precision_divisor = pow(10, self.decimals)
-            balance = Decimal(val) / Decimal(precision_divisor)
-            if as_string:
-                formatter_str = '.%sf' % self.decimals
-                balance_str = format(balance, formatter_str)
-                return balance_str
-            return balance
-        except Exception as e:
-            logger.error("could not get balance: %s " % e)
-            traceback.print_stack()
+        tx, fee, results, num_ops, engine_success = test_invoke(sb.ToArray(), wallet, [])
+        if engine_success:
+            try:
+                val = results[0].GetBigInteger()
+                precision_divisor = pow(10, self.decimals)
+                balance = Decimal(val) / Decimal(precision_divisor)
+                if as_string:
+                    formatter_str = '.%sf' % self.decimals
+                    balance_str = format(balance, formatter_str)
+                    return balance_str
+                return balance
+            except Exception as e:
+                logger.error("could not get balance: %s " % e)
+                traceback.print_stack()
+        else:
+            addr_str = Crypto.ToAddress(UInt160(data=addr))
+            logger.error(
+                f"Could not get balance of address {addr_str} for token contract {self.ScriptHash}. VM execution failed. Make sure the contract exists on the network and that it adheres to the NEP-5 standard")
 
         return 0
 
@@ -175,7 +179,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
                                            [parse_param(from_addr, wallet), parse_param(to_addr, wallet),
                                             parse_param(amount)])
 
-        tx, fee, results, num_ops = test_invoke(sb.ToArray(), wallet, [], from_addr=from_addr, invoke_attrs=tx_attributes)
+        tx, fee, results, num_ops, engine_success = test_invoke(sb.ToArray(), wallet, [], from_addr=from_addr, invoke_attrs=tx_attributes)
 
         return tx, fee, results
 
@@ -199,7 +203,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
         invoke_args = [self.ScriptHash.ToString(), 'transferFrom',
                        [parse_param(from_addr, wallet), parse_param(to_addr, wallet), parse_param(amount)]]
 
-        tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True)
+        tx, fee, results, num_ops, engine_success = TestInvokeContract(wallet, invoke_args, None, True)
 
         return tx, fee, results
 
@@ -221,7 +225,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
         invoke_args = [self.ScriptHash.ToString(), 'allowance',
                        [parse_param(owner_addr, wallet), parse_param(requestor_addr, wallet)]]
 
-        tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True)
+        tx, fee, results, num_ops, engine_success = TestInvokeContract(wallet, invoke_args, None, True)
 
         return tx, fee, results
 
@@ -244,7 +248,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
         invoke_args = [self.ScriptHash.ToString(), 'approve',
                        [parse_param(owner_addr, wallet), parse_param(requestor_addr, wallet), parse_param(amount)]]
 
-        tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True)
+        tx, fee, results, num_ops, engine_success = TestInvokeContract(wallet, invoke_args, None, True)
 
         return tx, fee, results
 
@@ -267,7 +271,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
 
         invoke_args = invoke_args + attachment_args
 
-        tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True, from_addr=mint_to_addr, invoke_attrs=invoke_attrs)
+        tx, fee, results, num_ops, engine_success = TestInvokeContract(wallet, invoke_args, None, True, from_addr=mint_to_addr, invoke_attrs=invoke_attrs)
 
         return tx, fee, results
 
@@ -288,7 +292,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
         invoke_args = [self.ScriptHash.ToString(), 'crowdsale_register',
                        [parse_param(p, wallet) for p in register_addresses]]
 
-        tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True, from_addr)
+        tx, fee, results, num_ops, engine_success = TestInvokeContract(wallet, invoke_args, None, True, from_addr)
 
         return tx, fee, results
 

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -741,7 +741,7 @@ class PromptInterface:
         args, invoke_attrs = get_tx_attr_from_args(args)
         args, owners = get_owners_from_params(args)
         if args and len(args) > 0:
-            tx, fee, results, num_ops = TestInvokeContract(self.Wallet, args, from_addr=from_addr, invoke_attrs=invoke_attrs, owners=owners)
+            tx, fee, results, num_ops, engine_success = TestInvokeContract(self.Wallet, args, from_addr=from_addr, invoke_attrs=invoke_attrs, owners=owners)
 
             if tx is not None and results is not None:
 
@@ -787,7 +787,7 @@ class PromptInterface:
 
             if contract_script is not None:
 
-                tx, fee, results, num_ops = test_invoke(contract_script, self.Wallet, [], from_addr=from_addr)
+                tx, fee, results, num_ops, engine_success = test_invoke(contract_script, self.Wallet, [], from_addr=from_addr)
 
                 if tx is not None and results is not None:
                     print(


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Say you have a wallet with "custom token x", that you've been developing on your network. If you switch network (e.g. to mainnet or a place that does not have that token) and try to use `wallet` to view the contents it will throw a flurry of exceptions. 

**How did you solve this problem?**
apply error checking, print a useful error message.

**How did you make sure your solution works?**
`make test`

**Are there any special changes in the code that we should be aware of?**
`test_invoke` now returns an additional boolean indicating the VM execution status

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
