### PR TITLE
Fix JSON output of invocation transaction

### DIFF
--- a/neo/Core/TX/InvocationTransaction.py
+++ b/neo/Core/TX/InvocationTransaction.py
@@ -15,7 +15,7 @@ class InvocationTransaction(Transaction):
         Returns:
             Fixed8:
         """
-        return self.Gas // Fixed8.FD()
+        return self.Gas
 
     def __init__(self, *args, **kwargs):
         """
@@ -97,5 +97,5 @@ class InvocationTransaction(Transaction):
         """
         jsn = super(InvocationTransaction, self).ToJson()
         jsn['script'] = self.Script.hex()
-        jsn['gas'] = self.Gas.value
+        jsn['gas'] = self.Gas.ToNeoJsonString()
         return jsn


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Fix #749

**How did you solve this problem?**
Fix return value of systemfee, change JSON print format of GAS key. 
Note that fixing the `system_fee` results in fixing the `net_fee`, because 
`network_fee = input - output - SystemFee`

**How did you make sure your solution works?**
`make test` and manually query tx to match output with neo-cli output shown in the issue.

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
