### PR TITLE
[refactor-prompt] Migrate command: wallet delete_addr

### DIFF
--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -445,7 +445,6 @@ class UserWallet(Wallet):
         todelete = bytes(script_hash.ToArray())
 
         for c in Contract.select():
-
             address = c.Address
             if address.ScriptHash == todelete:
                 c.delete_instance()

--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -456,7 +456,7 @@ class UserWallet(Wallet):
         except Exception as e:
             pass
 
-        return True, coins_toremove
+        return success, coins_toremove
 
     def ToJson(self, verbose=False):
         assets = self.GetCoinAssets()

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -288,14 +288,19 @@ def CreateAddress(wallet, args):
 
 
 def DeleteAddress(wallet, addr):
-    scripthash = wallet.ToScriptHash(addr)
+    try:
+        scripthash = wallet.ToScriptHash(addr)
+        error_str = ""
 
-    success, coins = wallet.DeleteAddress(scripthash)
+        success, _ = wallet.DeleteAddress(scripthash)
+    except ValueError as e:
+        success = False
+        error_str = f" with error: {e}"
 
     if success:
-        print("Deleted address %s " % addr)
+        print(f"Deleted address {addr}")
     else:
-        print("error deleting addr %s " % addr)
+        print(f"Error deleting addr {addr}{error_str}")
 
     return success
 

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -34,6 +34,7 @@ class CommandWallet(CommandBase):
         self.register_sub_command(CommandWalletClose())
         self.register_sub_command(CommandWalletVerbose(), ['v', '--v'])
         self.register_sub_command(CommandWalletCreateAddress())
+        self.register_sub_command(CommandWalletDeleteAddress())
         self.register_sub_command(CommandWalletSend())
         self.register_sub_command(CommandWalletSendMany())
         self.register_sub_command(CommandWalletSign())
@@ -195,6 +196,25 @@ class CommandWalletCreateAddress(CommandBase):
     def command_desc(self):
         p1 = ParameterDesc('number of addresses', 'number of addresses to create')
         return CommandDesc('create_addr', 'create a new wallet address', params=[p1])
+
+
+class CommandWalletDeleteAddress(CommandBase):
+
+    def __init__(self):
+        super().__init__()
+
+    def execute(self, arguments):
+        addr_to_delete = get_arg(arguments, 0)
+
+        if not addr_to_delete:
+            print("Please specify an address to delete.")
+            return False
+
+        return DeleteAddress(PromptData.Wallet, addr_to_delete)
+
+    def command_desc(self):
+        p1 = ParameterDesc('address', 'address to delete')
+        return CommandDesc('delete_addr', 'delete a wallet address', params=[p1])
 
 
 class CommandWalletRebuild(CommandBase):

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -240,6 +240,32 @@ class UserWalletTestCase(WalletFixtureTestCase):
         self.assertEqual(type(res), UserWallet)
         self.assertEqual(len(res.Addresses), 9)
 
+    def test_wallet_delete_address(self):
+        # test wallet delete address with no wallet open
+        args = ['delete_addr']
+        res = CommandWallet().execute(args)
+        self.assertFalse(res)
+
+        self.OpenWallet()
+
+        # test wallet delete address with no argument
+        args = ['delete_addr']
+        res = CommandWallet().execute(args)
+        self.assertFalse(res)
+
+        # test wallet delete address with unknown address
+        args = ['delete_addr', self.watch_addr_str]
+        res = CommandWallet().execute(args)
+        self.assertTrue(res)  # Current specs.
+
+        # test wallet delete successful
+        self.assertTrue(len(PromptData.Wallet.Addresses), 1)
+        args = ['delete_addr', PromptData.Wallet.Addresses[0]]
+        res = CommandWallet().execute(args)
+        self.assertTrue(res)
+        self.assertEqual(type(res), bool)
+        self.assertEqual(len(PromptData.Wallet.Addresses), 0)
+
     def test_wallet_rebuild(self):
         with patch('neo.Prompt.PromptData.PromptData.Prompt'):
             # test wallet rebuild with no wallet open

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -270,10 +270,15 @@ class UserWalletTestCase(WalletFixtureTestCase):
         res = CommandWallet().execute(args)
         self.assertFalse(res)
 
+        # test wallet delete address with invalid address
+        args = ['delete_addr', '1234']
+        res = CommandWallet().execute(args)
+        self.assertFalse(res)
+
         # test wallet delete address with unknown address
         args = ['delete_addr', self.watch_addr_str]
         res = CommandWallet().execute(args)
-        self.assertTrue(res)  # Current specs.
+        self.assertFalse(res)
 
         # test wallet delete successful
         self.assertTrue(len(PromptData.Wallet.Addresses), 1)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Migrate the command `wallet delete_addr` to the new Command system.

**How did you solve this problem?**
Implementation of `CommandWalletDeleteAddress`

**How did you make sure your solution works?**
Added unit tests & manual testing

**Are there any special changes in the code that we should be aware of?**
Not a change but `UserWallet.DeleteAddress` always returns True so even when using `wallet delete_addr unknown_address`, the prompt output is `Deleted address unknown_address`.
If we want to change this behaviour, let's discuss the details.

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
