### PR TITLE
[refactor-prompt] Migrate command: wallet alias

### DIFF
--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -38,6 +38,7 @@ class CommandWallet(CommandBase):
         self.register_sub_command(CommandWalletSendMany())
         self.register_sub_command(CommandWalletSign())
         self.register_sub_command(CommandWalletRebuild())
+        self.register_sub_command(CommandWalletAlias())
 
     def command_desc(self):
         return CommandDesc('wallet', 'manage wallets')
@@ -219,6 +220,24 @@ class CommandWalletRebuild(CommandBase):
         return CommandDesc('rebuild', 'rebuild the wallet index', params=[p1])
 
 
+class CommandWalletAlias(CommandBase):
+
+    def __init__(self):
+        super().__init__()
+
+    def execute(self, arguments):
+        if len(arguments) < 2:
+            print("Please supply an address and an alias")
+            return False
+
+        return AddAlias(PromptData.Wallet, arguments[0], arguments[1])
+
+    def command_desc(self):
+        p1 = ParameterDesc('address', 'address to create an alias for')
+        p2 = ParameterDesc('alias', 'alias to associate with the address')
+        return CommandDesc('alias', 'create an alias for an address', params=[p1, p2])
+
+
 #########################################################################
 #########################################################################
 
@@ -323,11 +342,14 @@ def AddAlias(wallet, addr, title):
     if wallet is None:
         print("Please open a wallet")
         return False
+
     try:
         script_hash = wallet.ToScriptHash(addr)
         wallet.AddNamedAddress(script_hash, title)
+        return True
     except Exception as e:
         print(e)
+        return False
 
 
 def ClaimGas(wallet, require_password=True, args=None):

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -227,7 +227,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
         res = CommandWallet().execute(args)
         self.assertFalse(res)
 
-        # test wallet create successful
+        # test wallet create address successful
         args = ['create_addr', 1]
         res = CommandWallet().execute(args)
         self.assertTrue(res)
@@ -259,6 +259,32 @@ class UserWalletTestCase(WalletFixtureTestCase):
             args = ['rebuild', '42']
             CommandWallet().execute(args)
             self.assertEqual(PromptData.Wallet._current_height, 42)
+
+    def test_wallet_alias(self):
+        # test wallet alias with no wallet open
+        args = ['alias', 'AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'mine']
+        res = CommandWallet().execute(args)
+        self.assertFalse(res)
+
+        self.OpenWallet()
+
+        # test wallet alias with no argument
+        args = ['alias']
+        res = CommandWallet().execute(args)
+        self.assertFalse(res)
+
+        # test wallet alias with 1 argument
+        args = ['alias', 'AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3']
+        res = CommandWallet().execute(args)
+        self.assertFalse(res)
+
+        # test wallet alias successful
+        self.assertNotIn('mine', [n.Title for n in PromptData.Wallet.NamedAddr])
+
+        args = ['alias', 'AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'mine']
+        res = CommandWallet().execute(args)
+        self.assertTrue(res)
+        self.assertIn('mine', [n.Title for n in PromptData.Wallet.NamedAddr])
 
     ##########################################################
     ##########################################################


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Migrate the command `wallet alias` to the new Command system.

**How did you solve this problem?**
Implementation of `CommandWalletAlias`

**How did you make sure your solution works?**
Added unit tests & manual testing

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
