### PR TITLE
Address MemoryStream leaks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ All notable changes to this project are documented in this file.
 - Gracefully handle balance query failures of NEP-5 tokens.
 - Fix ``getcontractstate`` JSON output to match neo-cli 2.9.2 `#746 <https://github.com/CityOfZion/neo-python/issues/746>`_
 - Fix ``getrawtransaction`` JSON output to match neo-cli 2.9.2 `#751 https://github.com/CityOfZion/neo-python/pull/751`_
+- Fix memory leaks `#754 https://github.com/CityOfZion/neo-python/pull/754`_
 
 [0.8.2] 2018-10-31
 -------------------

--- a/neo/Core/Header.py
+++ b/neo/Core/Header.py
@@ -1,6 +1,6 @@
 from neo.Core.BlockBase import BlockBase
 from neocore.IO.BinaryReader import BinaryReader
-from neo.IO.MemoryStream import StreamManager
+from neo.IO.MemoryStream import MemoryStream
 from neo.Core.Witness import Witness
 
 
@@ -69,17 +69,14 @@ class Header(BlockBase):
         """
         header = Header()
 
-        ms = StreamManager.GetStream(data)
+        with MemoryStream(data) as ms:
+            reader = BinaryReader(ms)
+            header.DeserializeUnsigned(reader)
+            reader.ReadByte()
 
-        reader = BinaryReader(ms)
-        header.DeserializeUnsigned(reader)
-        reader.ReadByte()
-
-        witness = Witness()
-        witness.Deserialize(reader)
-        header.Script = witness
-
-        StreamManager.ReleaseStream(ms)
+            witness = Witness()
+            witness.Deserialize(reader)
+            header.Script = witness
 
         return header
 

--- a/neo/Core/State/AccountState.py
+++ b/neo/Core/State/AccountState.py
@@ -87,8 +87,7 @@ class AccountState(StateBase):
         Returns:
             int: size.
         """
-        return super(AccountState, self).Size() + s.uint160 + s.uint8 + GetVarSize(self.Votes) + GetVarSize(len(self.Balances)) + (
-                len(self.Balances) * (32 + 8))
+        return super(AccountState, self).Size() + s.uint160 + s.uint8 + GetVarSize(self.Votes) + GetVarSize(len(self.Balances)) + (len(self.Balances) * (32 + 8))
 
     @staticmethod
     def DeserializeFromDB(buffer):

--- a/neo/Core/State/AccountState.py
+++ b/neo/Core/State/AccountState.py
@@ -2,7 +2,7 @@ import sys
 from .StateBase import StateBase
 from neocore.Fixed8 import Fixed8
 from neocore.IO.BinaryReader import BinaryReader
-from neo.IO.MemoryStream import StreamManager
+from neo.IO.MemoryStream import MemoryStream
 from neocore.Cryptography.Crypto import Crypto
 from neocore.IO.BinaryWriter import BinaryWriter
 
@@ -87,7 +87,8 @@ class AccountState(StateBase):
         Returns:
             int: size.
         """
-        return super(AccountState, self).Size() + s.uint160 + s.uint8 + GetVarSize(self.Votes) + GetVarSize(len(self.Balances)) + (len(self.Balances) * (32 + 8))
+        return super(AccountState, self).Size() + s.uint160 + s.uint8 + GetVarSize(self.Votes) + GetVarSize(len(self.Balances)) + (
+                len(self.Balances) * (32 + 8))
 
     @staticmethod
     def DeserializeFromDB(buffer):
@@ -100,12 +101,10 @@ class AccountState(StateBase):
         Returns:
             AccountState:
         """
-        m = StreamManager.GetStream(buffer)
-        reader = BinaryReader(m)
-        account = AccountState()
-        account.Deserialize(reader)
-
-        StreamManager.ReleaseStream(m)
+        with MemoryStream(buffer) as ms:
+            reader = BinaryReader(ms)
+            account = AccountState()
+            account.Deserialize(reader)
 
         return account
 
@@ -248,12 +247,11 @@ class AccountState(StateBase):
         Returns:
             bytes: serialized object.
         """
-        ms = StreamManager.GetStream()
-        writer = BinaryWriter(ms)
-        self.Serialize(writer)
+        with MemoryStream() as ms:
+            writer = BinaryWriter(ms)
+            self.Serialize(writer)
 
-        retval = ms.ToArray()
-        StreamManager.ReleaseStream(ms)
+            retval = ms.ToArray()
 
         return retval
 

--- a/neo/Core/State/AssetState.py
+++ b/neo/Core/State/AssetState.py
@@ -1,7 +1,7 @@
 from .StateBase import StateBase
 from neocore.Fixed8 import Fixed8
 from neocore.IO.BinaryReader import BinaryReader
-from neo.IO.MemoryStream import StreamManager
+from neo.IO.MemoryStream import MemoryStream
 from neo.Core.AssetType import AssetType
 from neocore.UInt160 import UInt160
 from neocore.Cryptography.Crypto import Crypto
@@ -27,7 +27,8 @@ class AssetState(StateBase):
     IsFrozen = False
 
     def Size(self):
-        return super(AssetState, self).Size() + s.uint256 + s.uint8 + GetVarSize(self.Name) + self.Amount.Size() + self.Available.Size() + s.uint8 + s.uint8 + self.Fee.Size() + s.uint160 + self.Owner.Size() + s.uint160 + s.uint160 + s.uint32 + s.uint8
+        return super(AssetState, self).Size() + s.uint256 + s.uint8 + GetVarSize(
+            self.Name) + self.Amount.Size() + self.Available.Size() + s.uint8 + s.uint8 + self.Fee.Size() + s.uint160 + self.Owner.Size() + s.uint160 + s.uint160 + s.uint32 + s.uint8
 
     def __init__(self, asset_id=None, asset_type=None, name=None, amount=Fixed8(0), available=Fixed8(0),
                  precision=0, fee_mode=0, fee=Fixed8(0), fee_addr=UInt160(data=bytearray(20)), owner=None,
@@ -85,12 +86,10 @@ class AssetState(StateBase):
         Returns:
             AssetState:
         """
-        m = StreamManager.GetStream(buffer)
-        reader = BinaryReader(m)
-        account = AssetState()
-        account.Deserialize(reader)
-
-        StreamManager.ReleaseStream(m)
+        with MemoryStream(buffer) as ms:
+            reader = BinaryReader(ms)
+            account = AssetState()
+            account.Deserialize(reader)
 
         return account
 

--- a/neo/Core/State/ContractState.py
+++ b/neo/Core/State/ContractState.py
@@ -1,6 +1,6 @@
 from .StateBase import StateBase
 from neocore.IO.BinaryReader import BinaryReader
-from neo.IO.MemoryStream import StreamManager
+from neo.IO.MemoryStream import MemoryStream
 from neo.Core.FunctionCode import FunctionCode
 from enum import IntEnum
 import binascii
@@ -102,7 +102,8 @@ class ContractState(StateBase):
         parameterlist_size = GetVarSize(self.Code.ParameterList)
         parameterreturntype_size = s.uint8
 
-        return super(ContractState, self).Size() + script_size + parameterlist_size + parameterreturntype_size + s.uint8 + GetVarSize(self.Name) + GetVarSize(self.CodeVersion) + GetVarSize(self.Author) + GetVarSize(self.Email) + GetVarSize(self.Description)
+        return super(ContractState, self).Size() + script_size + parameterlist_size + parameterreturntype_size + s.uint8 + GetVarSize(self.Name) + GetVarSize(
+            self.CodeVersion) + GetVarSize(self.Author) + GetVarSize(self.Email) + GetVarSize(self.Description)
 
     def Deserialize(self, reader):
         """
@@ -135,12 +136,10 @@ class ContractState(StateBase):
         Returns:
             ContractState:
         """
-        m = StreamManager.GetStream(buffer)
-        reader = BinaryReader(m)
-        c = ContractState()
-        c.Deserialize(reader)
-
-        StreamManager.ReleaseStream(m)
+        with MemoryStream(buffer) as ms:
+            reader = BinaryReader(ms)
+            c = ContractState()
+            c.Deserialize(reader)
 
         return c
 

--- a/neo/Core/State/SpentCoinState.py
+++ b/neo/Core/State/SpentCoinState.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from .StateBase import StateBase
 from neocore.IO.BinaryReader import BinaryReader
-from neo.IO.MemoryStream import StreamManager
+from neo.IO.MemoryStream import MemoryStream
 
 
 class SpentCoinItem:
@@ -138,12 +138,10 @@ class SpentCoinState(StateBase):
         Returns:
             SpentCoinState:
         """
-        m = StreamManager.GetStream(buffer)
-        reader = BinaryReader(m)
-        spentcoin = SpentCoinState()
-        spentcoin.Deserialize(reader)
-
-        StreamManager.ReleaseStream(m)
+        with MemoryStream(buffer) as ms:
+            reader = BinaryReader(ms)
+            spentcoin = SpentCoinState()
+            spentcoin.Deserialize(reader)
 
         return spentcoin
 

--- a/neo/Core/State/StateBase.py
+++ b/neo/Core/State/StateBase.py
@@ -1,6 +1,6 @@
 from neocore.IO.Mixins import SerializableMixin
 from neocore.IO.BinaryWriter import BinaryWriter
-from neo.IO.MemoryStream import StreamManager
+from neo.IO.MemoryStream import MemoryStream
 from neo.Core.Size import Size as s
 
 
@@ -56,12 +56,10 @@ class StateBase(SerializableMixin):
         Returns:
             bytes: serialized object.
         """
-        ms = StreamManager.GetStream()
-        writer = BinaryWriter(ms)
-        self.Serialize(writer)
-
-        retval = ms.ToArray()
-        StreamManager.ReleaseStream(ms)
+        with MemoryStream() as ms:
+            writer = BinaryWriter(ms)
+            self.Serialize(writer)
+            retval = ms.ToArray()
 
         return retval
 

--- a/neo/Core/State/StateDescriptor.py
+++ b/neo/Core/State/StateDescriptor.py
@@ -1,7 +1,7 @@
 from neocore.IO.BinaryReader import BinaryReader
 from neocore.IO.BinaryWriter import BinaryWriter
 from neo.Core.Mixins import SerializableMixin
-from neo.IO.MemoryStream import StreamManager
+from neo.IO.MemoryStream import MemoryStream
 from neocore.Fixed8 import Fixed8
 
 from enum import Enum
@@ -67,12 +67,10 @@ class StateDescriptor(SerializableMixin):
         Returns:
             ValidatorState:
         """
-        m = StreamManager.GetStream(buffer)
-        reader = BinaryReader(m)
-        v = StateDescriptor()
-        v.Deserialize(reader)
-
-        StreamManager.ReleaseStream(m)
+        with MemoryStream(buffer) as ms:
+            reader = BinaryReader(ms)
+            v = StateDescriptor()
+            v.Deserialize(reader)
 
         return v
 

--- a/neo/Core/State/StorageItem.py
+++ b/neo/Core/State/StorageItem.py
@@ -1,6 +1,6 @@
 from .StateBase import StateBase
 from neocore.IO.BinaryReader import BinaryReader
-from neo.IO.MemoryStream import StreamManager
+from neo.IO.MemoryStream import MemoryStream
 from neo.Core.Size import GetVarSize
 
 
@@ -69,11 +69,10 @@ class StorageItem(StateBase):
         Returns:
             StorageItem:
         """
-        m = StreamManager.GetStream(buffer)
-        reader = BinaryReader(m)
-        v = StorageItem()
-        v.Deserialize(reader)
-        StreamManager.ReleaseStream(m)
+        with MemoryStream(buffer) as ms:
+            reader = BinaryReader(ms)
+            v = StorageItem()
+            v.Deserialize(reader)
         return v
 
     def Serialize(self, writer):

--- a/neo/Core/State/UnspentCoinState.py
+++ b/neo/Core/State/UnspentCoinState.py
@@ -2,7 +2,7 @@ import sys
 from .StateBase import StateBase
 from .CoinState import CoinState
 from neocore.IO.BinaryReader import BinaryReader
-from neo.IO.MemoryStream import StreamManager
+from neo.IO.MemoryStream import MemoryStream
 from neo.Core.Size import Size as s
 from neo.Core.Size import GetVarSize
 from neo.Core.State.CoinState import CoinState
@@ -97,12 +97,10 @@ class UnspentCoinState(StateBase):
         Returns:
             UnspentCoinState:
         """
-        m = StreamManager.GetStream(buffer)
-        reader = BinaryReader(m)
-        uns = UnspentCoinState()
-        uns.Deserialize(reader)
-
-        StreamManager.ReleaseStream(m)
+        with MemoryStream(buffer) as ms:
+            reader = BinaryReader(ms)
+            uns = UnspentCoinState()
+            uns.Deserialize(reader)
 
         return uns
 

--- a/neo/Core/State/ValidatorState.py
+++ b/neo/Core/State/ValidatorState.py
@@ -1,7 +1,7 @@
 from .StateBase import StateBase
 from neocore.IO.BinaryReader import BinaryReader
 from neocore.IO.BinaryWriter import BinaryWriter
-from neo.IO.MemoryStream import StreamManager
+from neo.IO.MemoryStream import MemoryStream
 from neocore.Cryptography.ECCurve import EllipticCurve, ECDSA
 from neo.Core.Size import Size as s
 from neo.Core.Size import GetVarSize
@@ -60,12 +60,10 @@ class ValidatorState(StateBase):
         Returns:
             ValidatorState:
         """
-        m = StreamManager.GetStream(buffer)
-        reader = BinaryReader(m)
-        v = ValidatorState()
-        v.Deserialize(reader)
-
-        StreamManager.ReleaseStream(m)
+        with MemoryStream(buffer) as ms:
+            reader = BinaryReader(ms)
+            v = ValidatorState()
+            v.Deserialize(reader)
 
         return v
 

--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -17,7 +17,7 @@ from neo.Network.InventoryType import InventoryType
 from neo.Network.Mixins import InventoryMixin
 from neocore.Cryptography.Crypto import Crypto
 from neocore.IO.Mixins import SerializableMixin
-from neo.IO.MemoryStream import StreamManager
+from neo.IO.MemoryStream import MemoryStream
 from neocore.IO.BinaryReader import BinaryReader
 from neo.Core.Mixins import EquatableMixin
 from neo.Core.Helper import Helper
@@ -443,11 +443,10 @@ class Transaction(InventoryMixin):
         Returns:
             Transaction:
         """
-        mstream = StreamManager.GetStream(buffer)
-        reader = BinaryReader(mstream)
-        tx = Transaction.DeserializeFrom(reader)
+        with MemoryStream(buffer) as mstream:
+            reader = BinaryReader(mstream)
+            tx = Transaction.DeserializeFrom(reader)
 
-        StreamManager.ReleaseStream(mstream)
         return tx
 
     @staticmethod

--- a/neo/IO/Helper.py
+++ b/neo/IO/Helper.py
@@ -1,5 +1,5 @@
 import importlib
-from .MemoryStream import MemoryStream, StreamManager
+from .MemoryStream import MemoryStream
 from neocore.IO.BinaryReader import BinaryReader
 from neo.Core.TX.Transaction import Transaction
 from neo.logging import log_manager
@@ -24,17 +24,15 @@ class Helper:
         module = '.'.join(class_name.split('.')[:-1])
         klassname = class_name.split('.')[-1]
         klass = getattr(importlib.import_module(module), klassname)
-        mstream = StreamManager.GetStream(buffer)
-        reader = BinaryReader(mstream)
+        with MemoryStream(buffer) as mstream:
+            reader = BinaryReader(mstream)
 
-        try:
-            serializable = klass()
-            serializable.Deserialize(reader)
-            return serializable
-        except Exception as e:
-            logger.error("Could not deserialize: %s %s" % (e, class_name))
-        finally:
-            StreamManager.ReleaseStream(mstream)
+            try:
+                serializable = klass()
+                serializable.Deserialize(reader)
+                return serializable
+            except Exception as e:
+                logger.error("Could not deserialize: %s %s" % (e, class_name))
 
         return None
 
@@ -49,9 +47,8 @@ class Helper:
         Returns:
             neo.Core.TX.Transaction:
         """
-        mstream = MemoryStream(buffer)
-        reader = BinaryReader(mstream)
-
-        tx = Transaction.DeserializeFrom(reader)
+        with MemoryStream(buffer) as mstream:
+            reader = BinaryReader(mstream)
+            tx = Transaction.DeserializeFrom(reader)
 
         return tx

--- a/neo/IO/MemoryStream.py
+++ b/neo/IO/MemoryStream.py
@@ -68,7 +68,7 @@ class StreamManager:
 class MemoryStream(BytesIO):
     """docstring for MemoryStream"""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, data=None):
         """
         Create an instance.
 
@@ -76,7 +76,15 @@ class MemoryStream(BytesIO):
             *args:
             **kwargs:
         """
-        super(MemoryStream, self).__init__(*args, **kwargs)
+        super(MemoryStream, self).__init__(data)
+        self.seek(0)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.truncate(0)
+        self.close()
 
     def canRead(self):
         """

--- a/neo/Prompt/Commands/LoadSmartContract.py
+++ b/neo/Prompt/Commands/LoadSmartContract.py
@@ -156,7 +156,6 @@ def GatherLoadedContractParams(args, script):
 
 
 def GatherContractDetails(function_code):
-
     print("Please fill out the following contract details:")
 
     from neo.bin.prompt import PromptInterface
@@ -188,32 +187,32 @@ def GatherContractDetails(function_code):
 
 def generate_deploy_script(script, name='test', version='test', author='test', email='test',
                            description='test', contract_properties=0, return_type=BigInteger(255), parameter_list=[]):
-    sb = ScriptBuilder()
+    with ScriptBuilder() as sb:
+        plist = parameter_list
+        try:
+            plist = bytearray(binascii.unhexlify(parameter_list))
+        except Exception as e:
+            pass
 
-    plist = parameter_list
-    try:
-        plist = bytearray(binascii.unhexlify(parameter_list))
-    except Exception as e:
-        pass
-
-    sb.push(binascii.hexlify(description.encode('utf-8')))
-    sb.push(binascii.hexlify(email.encode('utf-8')))
-    sb.push(binascii.hexlify(author.encode('utf-8')))
-    sb.push(binascii.hexlify(version.encode('utf-8')))
-    sb.push(binascii.hexlify(name.encode('utf-8')))
-    sb.push(contract_properties)
-    sb.push(return_type)
-    sb.push(plist)
-    sb.WriteVarData(script)
-    sb.EmitSysCall("Neo.Contract.Create")
-    script = sb.ToArray()
+        sb.push(binascii.hexlify(description.encode('utf-8')))
+        sb.push(binascii.hexlify(email.encode('utf-8')))
+        sb.push(binascii.hexlify(author.encode('utf-8')))
+        sb.push(binascii.hexlify(version.encode('utf-8')))
+        sb.push(binascii.hexlify(name.encode('utf-8')))
+        sb.push(contract_properties)
+        sb.push(return_type)
+        sb.push(plist)
+        sb.WriteVarData(script)
+        sb.EmitSysCall("Neo.Contract.Create")
+        script = sb.ToArray()
 
     return script
 
 
 def ImportMultiSigContractAddr(wallet, args):
     if len(args) < 4:
-        print("please specify multisig contract like such: 'import multisig_addr {pubkey in wallet} {minimum # of signatures required} {signing pubkey 1} {signing pubkey 2}...'")
+        print(
+            "please specify multisig contract like such: 'import multisig_addr {pubkey in wallet} {minimum # of signatures required} {signing pubkey 1} {signing pubkey 2}...'")
         return
 
     if wallet is None:

--- a/neo/SmartContract/Contract.py
+++ b/neo/SmartContract/Contract.py
@@ -97,20 +97,22 @@ class Contract(SerializableMixin, VerificationCode):
         if len(publicKeys) > 1024:
             raise Exception("Supplied public key count ({}) exceeds maximum of 1024.".format(len(publicKeys)))
 
-        sb = ScriptBuilder()
-        sb.push(m)
+        with ScriptBuilder() as sb:
+            sb.push(m)
 
-        pkeys = [point for point in publicKeys]
-        pkeys.sort()
-        keys = [p.encode_point().decode() for p in pkeys]
+            pkeys = [point for point in publicKeys]
+            pkeys.sort()
+            keys = [p.encode_point().decode() for p in pkeys]
 
-        for key in keys:
-            sb.push(key)
+            for key in keys:
+                sb.push(key)
 
-        sb.push(len(publicKeys))
-        sb.add(CHECKMULTISIG)
+            sb.push(len(publicKeys))
+            sb.add(CHECKMULTISIG)
 
-        return sb.ToArray()
+            result = sb.ToArray()
+
+        return result
 
     @staticmethod
     def CreateMultiSigContract(publicKeyHash, m, publicKeys):
@@ -140,10 +142,11 @@ class Contract(SerializableMixin, VerificationCode):
 
     @staticmethod
     def CreateSignatureRedeemScript(publicKey):
-        sb = ScriptBuilder()
-        sb.push(publicKey.encode_point(compressed=True))
-        sb.add(CHECKSIG)
-        return sb.ToArray()
+        with ScriptBuilder() as sb:
+            sb.push(publicKey.encode_point(compressed=True))
+            sb.add(CHECKSIG)
+            result = sb.ToArray()
+        return result
 
     def Equals(self, other):
         if id(self) == id(other):

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -1011,6 +1011,7 @@ class ExecutionEngine:
             self.write_log(error_msg)
 
             if self._exit_on_error:
+                self.Dispose()  # make sure to cleanup MemoryStreams in the ExecutionContexts'
                 self._VMState |= VMState.FAULT
 
     def VM_FAULT_and_report(self, id, *args):

--- a/neo/VM/ScriptBuilder.py
+++ b/neo/VM/ScriptBuilder.py
@@ -19,6 +19,14 @@ class ScriptBuilder:
         super(ScriptBuilder, self).__init__()
         self.ms = MemoryStream()  # MemoryStream
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.ms:
+            self.ms.Cleanup()
+            self.ms.close()
+
     def WriteUInt16(self, value, endian="<"):
         return self.pack('%sH' % endian, value)
 
@@ -229,8 +237,5 @@ class ScriptBuilder:
 
     def ToArray(self, cleanup=True):
         retval = self.ms.ToArray()
-        if cleanup:
-            self.ms.Cleanup()
-            self.ms = None
 
         return retval


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
The usage of `ScriptBuilder` and `StreamManger` has a lot of potential to leak memory (and did in some places). 

**How did you solve this problem?**
Turned `ScriptBuilder` and `MemoryStream` (the class used by StreamManager internally) into context managers. Then used them as context managers everywhere (except in the tests, it was already a hell of a lot of typing).

I'm aware that `ApplicationEngine` and `ExecutionEngine` can also leak via the `ExecutionContext`. I need more time to test the impact/correct working when making those context managers.

**How did you make sure your solution works?**
make test

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
