### PR TITLE
[refactor-prompt] add wallet token history

### DIFF
--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -4,8 +4,7 @@ from neo.Blockchain import GetBlockchain
 from neo.VM.ScriptBuilder import ScriptBuilder
 from neo.VM.InteropService import InteropInterface
 from neo.Network.NodeLeader import NodeLeader
-from neo.Prompt.Utils import parse_param, get_asset_attachments, lookup_addr_str, get_owners_from_params, gather_param, get_parse_addresses
-
+from neo.Prompt import Utils as PromptUtils
 from neo.Implementations.Blockchains.LevelDB.DBCollection import DBCollection
 from neo.Implementations.Blockchains.LevelDB.DBPrefix import DBPrefix
 from neo.Implementations.Blockchains.LevelDB.CachedScriptTable import CachedScriptTable
@@ -47,7 +46,7 @@ DEFAULT_MIN_FEE = Fixed8.FromDecimal(.0001)
 
 def InvokeContract(wallet, tx, fee=Fixed8.Zero(), from_addr=None, owners=None):
     if from_addr is not None:
-        from_addr = lookup_addr_str(wallet, from_addr)
+        from_addr = PromptUtils.lookup_addr_str(wallet, from_addr)
 
     wallet_tx = wallet.MakeTransaction(tx=tx, fee=fee, use_standard=True, from_addr=from_addr)
 
@@ -158,14 +157,14 @@ def TestInvokeContract(wallet, args, withdrawal_tx=None,
         #
         params = args[1:] if len(args) > 1 else []
 
-        params, neo_to_attach, gas_to_attach = get_asset_attachments(params)
-        params, parse_addresses = get_parse_addresses(params)
+        params, neo_to_attach, gas_to_attach = PromptUtils.get_asset_attachments(params)
+        params, parse_addresses = PromptUtils.get_parse_addresses(params)
         params.reverse()
 
         if '--i' in params:
             params = []
             for index, iarg in enumerate(contract.Code.ParameterList):
-                param, abort = gather_param(index, iarg)
+                param, abort = PromptUtils.gather_param(index, iarg)
                 if abort:
                     return None, None, None, None
                 params.append(param)
@@ -176,18 +175,18 @@ def TestInvokeContract(wallet, args, withdrawal_tx=None,
         for p in params:
 
             if parse_params:
-                item = parse_param(p, wallet, parse_addr=parse_addresses)
+                item = PromptUtils.parse_param(p, wallet, parse_addr=parse_addresses)
             else:
                 item = p
             if type(item) is list:
                 item.reverse()
                 listlength = len(item)
                 for listitem in item:
-                    subitem = parse_param(listitem, wallet, parse_addr=parse_addresses)
+                    subitem = PromptUtils.parse_param(listitem, wallet, parse_addr=parse_addresses)
                     if type(subitem) is list:
                         subitem.reverse()
                         for listitem2 in subitem:
-                            subsub = parse_param(listitem2, wallet, parse_addr=parse_addresses)
+                            subsub = PromptUtils.parse_param(listitem2, wallet, parse_addr=parse_addresses)
                             sb.push(subsub)
                         sb.push(len(subitem))
                         sb.Emit(PACK)
@@ -262,7 +261,7 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None,
     # print("invoke script %s " % script)
 
     if from_addr is not None:
-        from_addr = lookup_addr_str(wallet, from_addr)
+        from_addr = PromptUtils.lookup_addr_str(wallet, from_addr)
 
     bc = GetBlockchain()
 
@@ -406,7 +405,7 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet,
     dtx.Script = binascii.unhexlify(deploy_script)
 
     if from_addr is not None:
-        from_addr = lookup_addr_str(wallet, from_addr)
+        from_addr = PromptUtils.lookup_addr_str(wallet, from_addr)
 
     dtx = wallet.MakeTransaction(tx=dtx, from_addr=from_addr)
     context = ContractParametersContext(dtx)
@@ -455,15 +454,15 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet,
 
         shash = contract_state.Code.ScriptHash()
 
-        invoke_args, neo_to_attach, gas_to_attach = get_asset_attachments(invoke_args)
-        invoke_args, no_parse_addresses = get_parse_addresses(invoke_args)
+        invoke_args, neo_to_attach, gas_to_attach = PromptUtils.get_asset_attachments(invoke_args)
+        invoke_args, no_parse_addresses = PromptUtils.get_parse_addresses(invoke_args)
 
         invoke_args.reverse()
 
         if '--i' in invoke_args:
             invoke_args = []
             for index, iarg in enumerate(contract_state.Code.ParameterList):
-                param, abort = gather_param(index, iarg)
+                param, abort = PromptUtils.gather_param(index, iarg)
                 if abort:
                     return None, [], 0, None
                 else:
@@ -473,16 +472,16 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet,
         sb = ScriptBuilder()
 
         for p in invoke_args:
-            item = parse_param(p, wallet, parse_addr=no_parse_addresses)
+            item = PromptUtils.parse_param(p, wallet, parse_addr=no_parse_addresses)
             if type(item) is list:
                 item.reverse()
                 listlength = len(item)
                 for listitem in item:
-                    subitem = parse_param(listitem, wallet, parse_addr=no_parse_addresses)
+                    subitem = PromptUtils.parse_param(listitem, wallet, parse_addr=no_parse_addresses)
                     if type(subitem) is list:
                         subitem.reverse()
                         for listitem2 in subitem:
-                            subsub = parse_param(listitem2, wallet, parse_addr=no_parse_addresses)
+                            subsub = PromptUtils.parse_param(listitem2, wallet, parse_addr=no_parse_addresses)
                             sb.push(subsub)
                         sb.push(len(subitem))
                         sb.Emit(PACK)

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -1,12 +1,12 @@
 from neo.Core.Blockchain import Blockchain
-from neo.Wallets.NEP5Token import NEP5Token
+from neo.Wallets import NEP5Token
 from neo.Core.TX.ClaimTransaction import ClaimTransaction
 from neo.Core.TX.Transaction import ContractTransaction
 from neo.Core.TX.Transaction import TransactionOutput
 from neo.Core.TX.TransactionAttribute import TransactionAttribute, TransactionAttributeUsage
 from neo.SmartContract.ContractParameterContext import ContractParametersContext
 from neo.Network.NodeLeader import NodeLeader
-from neo.Prompt.Utils import get_asset_id, get_from_addr, get_arg
+from neo.Prompt import Utils as PromptUtils
 from neo.Wallets.utils import to_aes_key
 from neo.Implementations.Wallets.peewee.UserWallet import UserWallet
 from neocore.Fixed8 import Fixed8
@@ -15,7 +15,6 @@ from prompt_toolkit import prompt
 import binascii
 import json
 import os
-import math
 from neo.Implementations.Wallets.peewee.Models import Account
 from neo.Prompt.CommandBase import CommandBase, CommandDesc, ParameterDesc
 from neo.Prompt.PromptData import PromptData
@@ -49,7 +48,7 @@ class CommandWallet(CommandBase):
 
     def execute(self, arguments):
         wallet = PromptData.Wallet
-        item = get_arg(arguments)
+        item = PromptUtils.get_arg(arguments)
 
         # Create and Open must be handled specially.
         if item in {'create', 'open'}:
@@ -78,7 +77,7 @@ class CommandWalletCreate(CommandBase):
     def execute(self, arguments):
         if PromptData.Wallet:
             PromptData.close_wallet()
-        path = get_arg(arguments, 0)
+        path = PromptUtils.get_arg(arguments, 0)
 
         if not path:
             print("Please specify a path")
@@ -131,7 +130,7 @@ class CommandWalletOpen(CommandBase):
         if PromptData.Wallet:
             PromptData.close_wallet()
 
-        path = get_arg(arguments, 0)
+        path = PromptUtils.get_arg(arguments, 0)
 
         if not path:
             print("Please specify a path")
@@ -189,7 +188,7 @@ class CommandWalletCreateAddress(CommandBase):
         super().__init__()
 
     def execute(self, arguments):
-        addresses_to_create = get_arg(arguments, 0)
+        addresses_to_create = PromptUtils.get_arg(arguments, 0)
 
         if not addresses_to_create:
             print("Please specify a number of addresses to create.")
@@ -207,7 +206,7 @@ class CommandWalletDeleteAddress(CommandBase):
         super().__init__()
 
     def execute(self, arguments):
-        addr_to_delete = get_arg(arguments, 0)
+        addr_to_delete = PromptUtils.get_arg(arguments, 0)
 
         if not addr_to_delete:
             print("Please specify an address to delete.")
@@ -230,7 +229,7 @@ class CommandWalletClaimGas(CommandBase):
 
         args = arguments
         if args:
-            args, from_addr_str = get_from_addr(args)
+            args, from_addr_str = PromptUtils.get_from_addr(args)
 
         return ClaimGas(PromptData.Wallet, True, from_addr_str)
 
@@ -247,7 +246,7 @@ class CommandWalletRebuild(CommandBase):
     def execute(self, arguments):
         PromptData.Prompt.stop_wallet_loop()
 
-        start_block = get_arg(arguments, 0, convert_to_int=True)
+        start_block = PromptUtils.get_arg(arguments, 0, convert_to_int=True)
         if not start_block or start_block < 0:
             start_block = 0
         print(f"Restarting at block {start_block}")
@@ -360,7 +359,7 @@ def ImportToken(wallet, contract_hash):
 
     if contract:
         hex_script = binascii.hexlify(contract.Code.Script)
-        token = NEP5Token(script=hex_script)
+        token = NEP5Token.NEP5Token(script=hex_script)
 
         result = token.Query()
 
@@ -481,7 +480,7 @@ def ShowUnspentCoins(wallet, args):
             if len(item) == 34:
                 addr = wallet.ToScriptHash(item)
             elif len(item) > 1:
-                asset_type = get_asset_id(wallet, item)
+                asset_type = PromptUtils.get_asset_id(wallet, item)
             if item == '--watch':
                 watch_only = 64
             elif item == '--count':
@@ -520,7 +519,7 @@ def SplitUnspentCoin(wallet, args, prompt_passwd=True):
 
     try:
         addr = wallet.ToScriptHash(args[0])
-        asset = get_asset_id(wallet, args[1])
+        asset = PromptUtils.get_asset_id(wallet, args[1])
         index = int(args[2])
         divisions = int(args[3])
 

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -291,7 +291,7 @@ class CommandWalletImport(CommandBase):
         return CommandDesc('import', 'import wallet items')
 
     def execute(self, arguments):
-        item = get_arg(arguments)
+        item = PromptUtils.get_arg(arguments)
 
         if not item:
             print(f"Please specify an action. See help for available actions")

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -10,6 +10,11 @@ from neocore.Cryptography.ECCurve import ECDSA
 from decimal import Decimal
 from prompt_toolkit.shortcuts import PromptSession
 from neo.logging import log_manager
+from neo.Wallets import NEP5Token
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from neo.Wallets.Wallet import Wallet
 
 logger = log_manager.getLogger()
 
@@ -334,3 +339,33 @@ def gather_param(index, param_type, do_continue=True):
             return gather_param(index, param_type, do_continue)
 
     return None, True
+
+
+def get_token(wallet: 'Wallet', token_str: str) -> 'NEP5Token.NEP5Token':
+    """
+    Try to get a NEP-5 token based on the symbol or script_hash
+
+    Args:
+        wallet: wallet instance
+        token_str: symbol or script_hash (accepts script hash with or without 0x prefix)
+    Raises:
+        ValueError: if token is not found
+
+    Returns:
+        NEP5Token instance if found.
+    """
+    if token_str.startswith('0x'):
+        token_str = token_str[2:]
+
+    token = None
+    for t in wallet.GetTokens().values():
+        if token_str == t.symbol:
+            token = t
+            break
+        elif token_str == t.ScriptHash.ToString():
+            token = t
+            break
+
+    if not isinstance(token, NEP5Token.NEP5Token):
+        raise ValueError("The given token argument does not represent a known NEP5 token")
+    return token

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -359,10 +359,7 @@ def get_token(wallet: 'Wallet', token_str: str) -> 'NEP5Token.NEP5Token':
 
     token = None
     for t in wallet.GetTokens().values():
-        if token_str == t.symbol:
-            token = t
-            break
-        elif token_str == t.ScriptHash.ToString():
+        if token_str in [t.symbol, t.ScriptHash.ToString()]:
             token = t
             break
 

--- a/neo/Wallets/NEP5Token.py
+++ b/neo/Wallets/NEP5Token.py
@@ -5,7 +5,7 @@ from neo.Core.VerificationCode import VerificationCode
 from neocore.Cryptography.Crypto import Crypto
 from neocore.Fixed8 import Fixed8
 from neo.Prompt.Commands.Invoke import TestInvokeContract, test_invoke
-from neo.Prompt.Utils import parse_param
+from neo.Prompt import Utils as PromptUtils
 from neocore.UInt160 import UInt160
 from neo.VM.ScriptBuilder import ScriptBuilder
 from neo.SmartContract.ApplicationEngine import ApplicationEngine
@@ -127,7 +127,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
         Returns:
             int/str: token balance value as int (default), token balanace as string if `as_string` is set to True. 0 if balance retrieval failed.
         """
-        addr = parse_param(address, wallet)
+        addr = PromptUtils.parse_param(address, wallet)
         if isinstance(addr, UInt160):
             addr = addr.Data
         sb = ScriptBuilder()
@@ -172,8 +172,8 @@ class NEP5Token(VerificationCode, SerializableMixin):
 
         sb = ScriptBuilder()
         sb.EmitAppCallWithOperationAndArgs(self.ScriptHash, 'transfer',
-                                           [parse_param(from_addr, wallet), parse_param(to_addr, wallet),
-                                            parse_param(amount)])
+                                           [PromptUtils.parse_param(from_addr, wallet), PromptUtils.parse_param(to_addr, wallet),
+                                            PromptUtils.parse_param(amount)])
 
         tx, fee, results, num_ops = test_invoke(sb.ToArray(), wallet, [], from_addr=from_addr, invoke_attrs=tx_attributes)
 
@@ -197,7 +197,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
                 list: the neo VM evaluation stack results.
         """
         invoke_args = [self.ScriptHash.ToString(), 'transferFrom',
-                       [parse_param(from_addr, wallet), parse_param(to_addr, wallet), parse_param(amount)]]
+                       [PromptUtils.parse_param(from_addr, wallet), PromptUtils.parse_param(to_addr, wallet), PromptUtils.parse_param(amount)]]
 
         tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True)
 
@@ -219,7 +219,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
                 list: the neo VM evaluation stack results.
         """
         invoke_args = [self.ScriptHash.ToString(), 'allowance',
-                       [parse_param(owner_addr, wallet), parse_param(requestor_addr, wallet)]]
+                       [PromptUtils.parse_param(owner_addr, wallet), PromptUtils.parse_param(requestor_addr, wallet)]]
 
         tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True)
 
@@ -242,7 +242,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
                 list: the neo VM evaluation stack results.
         """
         invoke_args = [self.ScriptHash.ToString(), 'approve',
-                       [parse_param(owner_addr, wallet), parse_param(requestor_addr, wallet), parse_param(amount)]]
+                       [PromptUtils.parse_param(owner_addr, wallet), PromptUtils.parse_param(requestor_addr, wallet), PromptUtils.parse_param(amount)]]
 
         tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True)
 
@@ -286,7 +286,7 @@ class NEP5Token(VerificationCode, SerializableMixin):
                 list: the neo VM evaluation stack results.
         """
         invoke_args = [self.ScriptHash.ToString(), 'crowdsale_register',
-                       [parse_param(p, wallet) for p in register_addresses]]
+                       [PromptUtils.parse_param(p, wallet) for p in register_addresses]]
 
         tx, fee, results, num_ops = TestInvokeContract(wallet, invoke_args, None, True, from_addr)
 

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -22,7 +22,7 @@ from neocore.Cryptography.Crypto import Crypto
 from neo.Wallets.AddressState import AddressState
 from neo.Wallets.Coin import Coin
 from neocore.KeyPair import KeyPair
-from neo.Wallets.NEP5Token import NEP5Token
+from neo.Wallets import NEP5Token
 from neo.Settings import settings
 from neocore.Fixed8 import Fixed8
 from neocore.UInt160 import UInt160
@@ -593,7 +593,7 @@ class Wallet:
         """
         total = Fixed8(0)
 
-        if type(asset_id) is NEP5Token:
+        if type(asset_id) is NEP5Token.NEP5Token:
             return self.GetTokenBalance(asset_id, watch_only)
 
         for coin in self.GetCoins():
@@ -1231,7 +1231,7 @@ class Wallet:
                 bc_asset = Blockchain.Default().GetAssetState(asset.ToBytes())
                 total = self.GetBalance(asset).value / Fixed8.D
                 balances.append((bc_asset.GetName(), total))
-            elif type(asset) is NEP5Token:
+            elif type(asset) is NEP5Token.NEP5Token:
                 balances.append((asset.symbol, self.GetBalance(asset)))
         return balances
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
move #623 forward by adding `token history`

**How did you solve this problem?**
port to new command

**How did you make sure your solution works?**
make test

**Are there any special changes in the code that we should be aware of?**
Yes. When I added the `get_token` utility function in `neo.Prompt.Utils` I was facing circular import errors. To get around them I changed some import statements to not import functions directly, but import the module and call from there. 

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
