### PR TITLE
[refactor-prompt] add wallet export commands

### DIFF
--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -316,7 +316,7 @@ class CommandWalletExportWIF(CommandBase):
             return False
 
         address = arguments[0]
-        keys = PromptData.Wallet.GetKeys()
+        keys = wallet.GetKeys()
         for key in keys:
             if key.GetAddress() == address:
                 print(f"WIF: {key.Export()}")
@@ -355,7 +355,7 @@ class CommandWalletExportNEP2(CommandBase):
             print("Please provide matching passwords")
             return False
 
-        keys = PromptData.Wallet.GetKeys()
+        keys = wallet.GetKeys()
         for key in keys:
             if key.GetAddress() == address:
                 print(f"NEP2: {key.ExportNEP2(passphrase)}")

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -337,16 +337,22 @@ class CommandWalletExportNEP2(CommandBase):
     def execute(self, arguments):
         wallet = PromptData.Wallet
 
-        if len(arguments) != 2:
+        if len(arguments) != 1:
             print("Please specify the required parameters")
             return False
 
         address = arguments[0]
-        passphrase = arguments[1]
 
+        passphrase = prompt("[key password] ", is_password=True)
         len_pass = len(passphrase)
         if len_pass < 10:
             print(f"Passphrase is too short, length: {len_pass}. Mininum length is 10")
+            return False
+
+        passphrase_confirm = prompt("[key password again] ", is_password=True)
+
+        if passphrase != passphrase_confirm:
+            print("Please provide matching passwords")
             return False
 
         keys = PromptData.Wallet.GetKeys()
@@ -360,8 +366,7 @@ class CommandWalletExportNEP2(CommandBase):
 
     def command_desc(self):
         p1 = ParameterDesc('address', 'public address in the wallet')
-        p2 = ParameterDesc('passphrase', 'secret to encrypt the private key with (min len: 10)')
-        return CommandDesc('nep2', 'export a passphrase protected private key record of an address (NEP-2 format)', [p1, p2])
+        return CommandDesc('nep2', 'export a passphrase protected private key record of an address (NEP-2 format)', [p1])
 
 
 #########################################################################


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
move #623 forward by implementing `wallet export nep2` and `wallet export wif` commands.

**How did you solve this problem?**
write code

**How did you make sure your solution works?**
make test

**Are there any special changes in the code that we should be aware of?**
Yes the old prompt required you to enter your wallet password multiple times before you could export. This was mostly a protection on the cli level but didn't really unlock anything as the wallet is already open with the keys useable. Now the prompt instantly exports without asking for input. 

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
