### PR TITLE
[refactor-prompt] Migrate command: wallet split

### DIFF
--- a/neo/Core/Helper.py
+++ b/neo/Core/Helper.py
@@ -155,7 +155,7 @@ class Helper:
         Get a hash of the provided raw bytes using the ripemd160 algorithm.
 
         Args:
-            raw (bytes): byte array of raw bytes. i.e. b'\xAA\xBB\xCC'
+            raw (bytes): byte array of raw bytes. e.g. b'\xAA\xBB\xCC'
 
         Returns:
             UInt160:

--- a/neo/Core/State/AssetState.py
+++ b/neo/Core/State/AssetState.py
@@ -42,8 +42,8 @@ class AssetState(StateBase):
             amount (Fixed8):
             available (Fixed8):
             precision (int): number of decimals the asset has.
-            fee_mode (Fixed8):
-            fee (int):
+            fee_mode (int):
+            fee (Fixed8):
             fee_addr (UInt160): where the fee will be send to.
             owner (EllipticCurve.ECPoint):
             admin (UInt160): the administrator of the asset.

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -495,7 +495,7 @@ class LevelDBBlockchain(Blockchain):
             height(int): height of the block to retrieve hash from.
 
         Returns:
-            bytes: a non-raw block hash (i.e. b'6dd83ed8a3fc02e322f91f30431bf3662a8c8e8ebe976c3565f0d21c70620991', but not b'\x6d\xd8...etc'
+            bytes: a non-raw block hash (e.g. b'6dd83ed8a3fc02e322f91f30431bf3662a8c8e8ebe976c3565f0d21c70620991', but not b'\x6d\xd8...etc'
         """
         if self._current_block_height < height:
             return

--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -85,7 +85,7 @@ class UserWallet(Wallet):
         Create a new user wallet.
 
         Args:
-            path (str): A path indicating where to create or open the wallet i.e. "/Wallets/mywallet".
+            path (str): A path indicating where to create or open the wallet e.g. "/Wallets/mywallet".
             password (str): a 10 characters minimum password to secure the wallet with.
 
         Returns:

--- a/neo/Network/Message.py
+++ b/neo/Network/Message.py
@@ -32,7 +32,7 @@ class Message(SerializableMixin):
         Create an instance.
 
         Args:
-            command (str): payload command i.e. "inv", "getdata". See NeoNode.MessageReceived() for more commands.
+            command (str): payload command e.g. "inv", "getdata". See NeoNode.MessageReceived() for more commands.
             payload (bytes): raw bytes of the payload.
             print_payload: UNUSED
         """

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -33,7 +33,7 @@ class CommandWalletSend(CommandBase):
         p2 = ParameterDesc('address', 'the destination address')
         p3 = ParameterDesc('amount', 'the amount of the asset to send')
         p4 = ParameterDesc('--from-addr', 'source address to take funds from (if not specified, take first address in wallet)', optional=True)
-        p5 = ParameterDesc('--fee', 'a fee to give your transaction priority (> 0.001) i.e. --fee=0.01', optional=True)
+        p5 = ParameterDesc('--fee', 'a fee to give your transaction priority (> 0.001) e.g. --fee=0.01', optional=True)
         p6 = ParameterDesc('--owners', 'a list of NEO addresses indicating the transaction owners e.g. --owners=[address1,address2]', optional=True)
         p7 = ParameterDesc('--tx-attr', f'a list of transaction attributes to attach to the transaction\n\n'
         f"{' ':>17} See: http://docs.neo.org/en-us/network/network-protocol.html section 4 for a description of possible attributes\n\n"  # noqa: E128 ignore indentation
@@ -60,7 +60,7 @@ class CommandWalletSendMany(CommandBase):
         p1 = ParameterDesc('tx_count', 'the number of transactions to send')
         p2 = ParameterDesc('--change-addr', 'an address to send remaining funds to', optional=True)
         p3 = ParameterDesc('--from-addr', 'source address to take funds from (if not specified, take first address in wallet)', optional=True)
-        p4 = ParameterDesc('--fee', 'a fee to give your transaction priority (> 0.001) i.e. --fee=0.01', optional=True)
+        p4 = ParameterDesc('--fee', 'a fee to give your transaction priority (> 0.001) e.g. --fee=0.01', optional=True)
         p5 = ParameterDesc('--owners', 'a list of NEO addresses indicating the transaction owners e.g. --owners=[address1,address2]', optional=True)
         p6 = ParameterDesc('--tx-attr', f'a list of transaction attributes to attach to the transaction\n\n'
         f"{' ':>17} See: http://docs.neo.org/en-us/network/network-protocol.html section 4 for a description of possible attributes\n\n"  # noqa: E128 ignore indentation

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -340,7 +340,7 @@ class CommandWalletSplit(CommandBase):
         try:
             divisions = int(arguments[3])
         except ValueError:
-            print(f"Invalid unspent index value: {arguments[3]}")
+            print(f"Invalid divisions value: {arguments[3]}")
             return None
 
         if divisions < 1:
@@ -358,12 +358,12 @@ class CommandWalletSplit(CommandBase):
         return SplitUnspentCoin(wallet, asset_id, from_addr, index, divisions, fee)
 
     def command_desc(self):
-        p1 = ParameterDesc('address', '')
-        p2 = ParameterDesc('asset', 'type of asset to query (NEO/GAS)')
-        p3 = ParameterDesc('unspent_index', '')
-        p4 = ParameterDesc('nb_vins', 'divide into number of vins')
+        p1 = ParameterDesc('address', 'address to split from')
+        p2 = ParameterDesc('asset', 'type of asset to split (NEO/GAS)')
+        p3 = ParameterDesc('unspent_index', 'index of the vin to split')
+        p4 = ParameterDesc('divisions', 'divide into number of vouts')
         p5 = ParameterDesc('fee', 'optional fee', optional=True)
-        return CommandDesc('split', 'show unspent assets', params=[p1, p2, p3, p4, p5])
+        return CommandDesc('split', 'split an asset unspent output into N outputs', params=[p1, p2, p3, p4, p5])
 
 
 class CommandWalletAlias(CommandBase):
@@ -903,7 +903,6 @@ def SplitUnspentCoin(wallet, asset_id, from_addr, index, divisions, fee=Fixed8.Z
     Returns:
         neo.Core.TX.Transaction.ContractTransaction: contract transaction created
     """
-    print(wallet, asset_id, from_addr, index, divisions, fee)
 
     if wallet is None:
         print("Please open a wallet.")
@@ -914,17 +913,13 @@ def SplitUnspentCoin(wallet, asset_id, from_addr, index, divisions, fee=Fixed8.Z
         print(f"No unspent assets matching the arguments.")
         return None
 
-    print("len(unspent_items): ", len(unspent_items))
-
     if index < len(unspent_items):
         unspent_item = unspent_items[index]
     else:
         print(f"Could not find unspent item for asset {asset_id} with index {index}")
         return None
 
-    print(unspent_item.ToJson())
     outputs = split_to_vouts(asset_id, from_addr, unspent_item.Output.Value, divisions)
-    print(outputs[0].ToJson(0))
 
     # subtract a fee from the first vout
     if outputs[0].Value > fee:

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -907,14 +907,14 @@ class UserWalletSplitTestCase(UserWalletTestCaseBase):
             args = ['split', '123', 'neo', '0', '2']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
-            self.assertIn("Not correct Address, wrong length", mock_print.getvalue())
+            self.assertIn("Invalid address specified", mock_print.getvalue())
 
         # test wallet split with unknown asset
         with patch('sys.stdout', new=StringIO()) as mock_print:
             args = ['split', self.wallet_1_addr, 'unknownasset', '0', '2']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
-            self.assertIn("No unspent assets matching the arguments", mock_print.getvalue())
+            self.assertIn("Unknown asset id", mock_print.getvalue())
 
         # test wallet split with invalid index
         with patch('sys.stdout', new=StringIO()) as mock_print:
@@ -935,11 +935,18 @@ class UserWalletSplitTestCase(UserWalletTestCaseBase):
             args = ['split', self.wallet_1_addr, 'neo', '0', '-3']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
-            self.assertIn("Divisions cannot be lower than 1", mock_print.getvalue())
+            self.assertIn("Divisions cannot be lower than 2", mock_print.getvalue())
 
         # test wallet split with invalid fee
         with patch('sys.stdout', new=StringIO()) as mock_print:
             args = ['split', self.wallet_1_addr, 'neo', '0', '2', 'abc']
+            res = CommandWallet().execute(args)
+            self.assertIsNone(res)
+            self.assertIn("Invalid fee value", mock_print.getvalue())
+
+        # test wallet split with negative fee
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['split', self.wallet_1_addr, 'neo', '0', '2', '-0.01']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
             self.assertIn("Invalid fee value", mock_print.getvalue())

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -897,49 +897,49 @@ class UserWalletSplitTestCase(UserWalletTestCaseBase):
 
         # test wallet split with too much arguments
         with patch('sys.stdout', new=StringIO()) as mock_print:
-            args = ['split', self.wallet_1_addr, 'neo', 0, 2, 'too', 'much']
+            args = ['split', self.wallet_1_addr, 'neo', '0', '2', 'too', 'much']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
             self.assertIn("Too many parameters supplied", mock_print.getvalue())
 
         # test wallet split with invalid address
         with patch('sys.stdout', new=StringIO()) as mock_print:
-            args = ['split', '123', 'neo', 0, 2]
+            args = ['split', '123', 'neo', '0', '2']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
             self.assertIn("Not correct Address, wrong length", mock_print.getvalue())
 
         # test wallet split with unknown asset
         with patch('sys.stdout', new=StringIO()) as mock_print:
-            args = ['split', self.wallet_1_addr, 'unknownasset', 0, 2]
+            args = ['split', self.wallet_1_addr, 'unknownasset', '0', '2']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
             self.assertIn("No unspent assets matching the arguments", mock_print.getvalue())
 
         # test wallet split with invalid index
         with patch('sys.stdout', new=StringIO()) as mock_print:
-            args = ['split', self.wallet_1_addr, 'neo', 'abc', 2]
+            args = ['split', self.wallet_1_addr, 'neo', 'abc', '2']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
             self.assertIn("Invalid unspent index value", mock_print.getvalue())
 
         # test wallet split with invalid divisions
         with patch('sys.stdout', new=StringIO()) as mock_print:
-            args = ['split', self.wallet_1_addr, 'neo', 0, 'abc']
+            args = ['split', self.wallet_1_addr, 'neo', '0', 'abc']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
             self.assertIn("Invalid divisions value", mock_print.getvalue())
 
         # test wallet split with invalid divisions (negative)
         with patch('sys.stdout', new=StringIO()) as mock_print:
-            args = ['split', self.wallet_1_addr, 'neo', 0, -3]
+            args = ['split', self.wallet_1_addr, 'neo', '0', '-3']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
             self.assertIn("Divisions cannot be lower than 1", mock_print.getvalue())
 
         # test wallet split with invalid fee
         with patch('sys.stdout', new=StringIO()) as mock_print:
-            args = ['split', self.wallet_1_addr, 'neo', 0, 2, 'abc']
+            args = ['split', self.wallet_1_addr, 'neo', '0', '2', 'abc']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
             self.assertIn("Invalid fee value", mock_print.getvalue())
@@ -947,7 +947,7 @@ class UserWalletSplitTestCase(UserWalletTestCaseBase):
         # test wallet split with wrong password
         with patch('neo.Prompt.Commands.Wallet.prompt', side_effect=["wrong_password"]):
             with patch('sys.stdout', new=StringIO()) as mock_print:
-                args = ['split', self.wallet_1_addr, 'neo', 0, 2]
+                args = ['split', self.wallet_1_addr, 'neo', '0', '2']
                 res = CommandWallet().execute(args)
                 self.assertIsNone(res)
                 self.assertIn("incorrect password", mock_print.getvalue())
@@ -955,7 +955,7 @@ class UserWalletSplitTestCase(UserWalletTestCaseBase):
         # test wallet split with fee bigger than the outputs
         with patch('neo.Prompt.Commands.Wallet.prompt', side_effect=[self.wallet_1_pass()]):
             with patch('sys.stdout', new=StringIO()) as mock_print:
-                args = ['split', self.wallet_1_addr, 'neo', 0, 2, 100]
+                args = ['split', self.wallet_1_addr, 'neo', '0', '2', '100']
                 res = CommandWallet().execute(args)
                 self.assertIsNone(res)
                 self.assertIn("Fee could not be subtracted from outputs", mock_print.getvalue())
@@ -964,14 +964,14 @@ class UserWalletSplitTestCase(UserWalletTestCaseBase):
         with patch('neo.Prompt.Commands.Wallet.prompt', side_effect=[self.wallet_1_pass()]):
             with patch('neo.Network.NodeLeader.NodeLeader.Relay', side_effect=[None]):
                 with patch('sys.stdout', new=StringIO()) as mock_print:
-                    args = ['split', self.wallet_1_addr, 'neo', 0, 2]
+                    args = ['split', self.wallet_1_addr, 'neo', '0', '2']
                     res = CommandWallet().execute(args)
                     self.assertIsNone(res)
                     self.assertIn("Could not relay tx", mock_print.getvalue())
 
         # test wallet split neo successful
         with patch('neo.Prompt.Commands.Wallet.prompt', side_effect=[self.wallet_1_pass()]):
-            args = ['split', self.wallet_1_addr, 'neo', 0, 2]
+            args = ['split', self.wallet_1_addr, 'neo', '0', '2']
             tx = CommandWallet().execute(args)
             self.assertTrue(tx)
             self.assertIsInstance(tx, ContractTransaction)
@@ -979,7 +979,7 @@ class UserWalletSplitTestCase(UserWalletTestCaseBase):
 
         # test wallet split gas successful
         with patch('neo.Prompt.Commands.Wallet.prompt', side_effect=[self.wallet_1_pass()]):
-            args = ['split', self.wallet_1_addr, 'gas', 0, 3]
+            args = ['split', self.wallet_1_addr, 'gas', '0', '3']
             tx = CommandWallet().execute(args)
             self.assertTrue(tx)
             self.assertIsInstance(tx, ContractTransaction)

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -513,29 +513,25 @@ class UserWalletTestCase(WalletFixtureTestCase):
 
     def test_6_split_unspent(self):
         wallet = self.GetWallet1(recreate=True)
-
-        # test bad
-        tx = SplitUnspentCoin(wallet, [])
-        self.assertEqual(tx, None)
+        addr = wallet.ToScriptHash('AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3')
 
         # bad inputs
-        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'neo', 3, 2])
+        tx = SplitUnspentCoin(wallet, self.NEO, addr, 3, 2)
         self.assertEqual(tx, None)
 
         # should be ok
-        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'neo', 0, 2], prompt_passwd=False)
+        tx = SplitUnspentCoin(wallet, self.NEO, addr, 0, 2, prompt_passwd=False)
         self.assertIsNotNone(tx)
 
         # rebuild wallet and try with non-even amount of neo, should be split into integer values of NEO
         wallet = self.GetWallet1(True)
-        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'neo', 0, 3], prompt_passwd=False)
+        tx = SplitUnspentCoin(wallet, self.NEO, addr, 0, 3, prompt_passwd=False)
         self.assertIsNotNone(tx)
-
         self.assertEqual([Fixed8.FromDecimal(17), Fixed8.FromDecimal(17), Fixed8.FromDecimal(16)], [item.Value for item in tx.outputs])
 
         # try with gas
         wallet = self.GetWallet1(True)
-        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'gas', 0, 3], prompt_passwd=False)
+        tx = SplitUnspentCoin(wallet, self.GAS, addr, 0, 3, prompt_passwd=False)
         self.assertIsNotNone(tx)
 
     def test_7_create_address(self):

--- a/neo/SmartContract/Contract.py
+++ b/neo/SmartContract/Contract.py
@@ -126,7 +126,7 @@ class Contract(SerializableMixin, VerificationCode):
         Create a signature contract.
 
         Args:
-            publicKey (edcsa.Curve.point): i.e. KeyPair.PublicKey.
+            publicKey (edcsa.Curve.point): e.g. KeyPair.PublicKey.
 
         Returns:
             neo.SmartContract.Contract: a Contract instance.

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -220,7 +220,7 @@ class Wallet:
         Test if the wallet contains the supplied public key.
 
         Args:
-            public_key (edcsa.Curve.point): a public key to test for its existance. i.e. KeyPair.PublicKey
+            public_key (edcsa.Curve.point): a public key to test for its existance. e.g. KeyPair.PublicKey
 
         Returns:
             bool: True if exists, False otherwise.

--- a/neo/logging.py
+++ b/neo/logging.py
@@ -12,7 +12,7 @@
 
 
     By default getting a logger `log_manager.getLogger()` will give you a `logging.Logger` class of name `neo-python.generic`.
-    When specifying a component name i.e. `getLogger('db')` you'll get `neo-python.db`. This allows you to integrate neo-python and process
+    When specifying a component name e.g. `getLogger('db')` you'll get `neo-python.db`. This allows you to integrate neo-python and process
     its logs via the parent id `neo-python`.
 
 
@@ -111,7 +111,7 @@ class LogManager(object):
         Get the logger instance matching ``component_name`` or create a new one if non-existent.
 
         Args:
-            component_name: a neo-python component name. i.e. network, vm, db
+            component_name: a neo-python component name. e.g. network, vm, db
 
         Returns:
             a logger for the specified component.


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
#623 
Migrate the command `wallet split` to the new `Command` system.

**How did you solve this problem?**
Implementation of `CommandWalletUnspent`

**How did you make sure your solution works?**
manual testing
Add unit tests 

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
