### PR TITLE
[refactor-prompt] Migrate command: wallet import token

### DIFF
--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -283,7 +283,7 @@ class CommandWalletUnspent(CommandBase):
         if from_addr_str:
             if not isValidPublicAddress(from_addr_str):
                 print("Invalid address specified")
-                return None
+                return
 
             from_addr = wallet.ToScriptHash(from_addr_str)
 
@@ -628,7 +628,7 @@ class CommandWalletImportToken(CommandBase):
     def execute(self, arguments):
         if len(arguments) != 1:
             print("Please specify the required parameter")
-            return None
+            return
 
         contract_hash = arguments[0]
         return ImportToken(PromptData.Wallet, contract_hash)
@@ -647,15 +647,15 @@ def CreateAddress(wallet, args):
         int_args = int(args)
     except (ValueError, TypeError) as error:  # for non integer args or Nonetype
         print(error)
-        return None
+        return
 
     if wallet is None:
         print("Please open a wallet.")
-        return None
+        return
 
     if int_args <= 0:
         print('Enter a number greater than 0.')
-        return None
+        return
 
     address_list = []
     for _ in range(int_args):
@@ -687,7 +687,7 @@ def DeleteAddress(wallet, addr):
 def ImportToken(wallet, contract_hash):
     if wallet is None:
         print("please open a wallet")
-        return None
+        return
 
     contract = Blockchain.Default().GetContract(contract_hash)
 
@@ -705,8 +705,6 @@ def ImportToken(wallet, contract_hash):
             print("Could not import token")
     else:
         print("Could not find the contract hash")
-
-    return None
 
 
 def AddAlias(wallet, addr, title):
@@ -826,7 +824,7 @@ def ShowUnspentCoins(wallet, asset_id=None, from_addr=None, watch_only=False, do
 
     if wallet is None:
         print("Please open a wallet.")
-        return None
+        return
 
     watch_only_flag = 64 if watch_only else 0
     if asset_id:
@@ -871,13 +869,13 @@ def SplitUnspentCoin(wallet, args, prompt_passwd=True):
 
     except Exception as e:
         logger.info("Invalid arguments specified: %s " % e)
-        return None
+        return
 
     try:
         unspentItem = wallet.FindUnspentCoinsByAsset(asset, from_addr=addr)[index]
     except Exception as e:
         logger.info("Could not find unspent item for asset with index %s %s :  %s" % (asset, index, e))
-        return None
+        return
 
     outputs = split_to_vouts(asset, addr, unspentItem.Output.Value, divisions)
 
@@ -897,7 +895,7 @@ def SplitUnspentCoin(wallet, args, prompt_passwd=True):
         passwd = prompt("[Password]> ", is_password=True)
         if not wallet.ValidatePassword(passwd):
             print("incorrect password")
-            return None
+            return
 
     if ctx.Completed:
 
@@ -911,8 +909,6 @@ def SplitUnspentCoin(wallet, args, prompt_passwd=True):
             return contract_tx
         else:
             print("Could not relay tx %s " % contract_tx.Hash.ToString())
-
-    return None
 
 
 def split_to_vouts(asset, addr, input_val, divisions):

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -699,7 +699,12 @@ class CommandWalletImportToken(CommandBase):
             print("Please specify the required parameter")
             return
 
-        contract_hash = arguments[0]
+        try:
+            contract_hash = UInt160.ParseString(arguments[0]).ToBytes()
+        except Exception:
+            print(f"Invalid contract hash: {arguments[0]}")
+            return
+
         return ImportToken(PromptData.Wallet, contract_hash)
 
     def command_desc(self):

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -355,6 +355,7 @@ class CommandWalletImport(CommandBase):
         self.register_sub_command(CommandWalletImportNEP2())
         self.register_sub_command(CommandWalletImportWatchAddr())
         self.register_sub_command(CommandWalletImportMultisigAddr())
+        self.register_sub_command(CommandWalletImportToken())
 
     def command_desc(self):
         return CommandDesc('import', 'import wallet items')
@@ -620,6 +621,23 @@ class CommandWalletImportMultisigAddr(CommandBase):
         return CommandDesc('multisig_addr', 'import a multi-signature address', [p1, p2, p3])
 
 
+class CommandWalletImportToken(CommandBase):
+    def __init__(self):
+        super().__init__()
+
+    def execute(self, arguments):
+        if len(arguments) != 1:
+            print("Please specify the required parameter")
+            return None
+
+        contract_hash = arguments[0]
+        return ImportToken(PromptData.Wallet, contract_hash)
+
+    def command_desc(self):
+        p1 = ParameterDesc('contract_hash', 'the token contract hash')
+        return CommandDesc('token', 'import a token', [p1])
+
+
 #########################################################################
 #########################################################################
 
@@ -669,7 +687,7 @@ def DeleteAddress(wallet, addr):
 def ImportToken(wallet, contract_hash):
     if wallet is None:
         print("please open a wallet")
-        return False
+        return None
 
     contract = Blockchain.Default().GetContract(contract_hash)
 
@@ -682,8 +700,13 @@ def ImportToken(wallet, contract_hash):
         if result:
             wallet.AddNEP5Token(token)
             print("added token %s " % json.dumps(token.ToJson(), indent=4))
+            return token
         else:
             print("Could not import token")
+    else:
+        print("Could not find the contract hash")
+
+    return None
 
 
 def AddAlias(wallet, addr, title):

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -797,9 +797,16 @@ class UserWalletTestCase(UserWalletTestCaseBase):
             self.assertIsNone(res)
             self.assertIn("specify the required parameter", mock_print.getvalue())
 
-        # test with unknown contract hash
+        # test with invalid contract hash
         with patch('sys.stdout', new=StringIO()) as mock_print:
             args = ['import', 'token', 'does_not_exist']
+            res = CommandWallet().execute(args)
+            self.assertIsNone(res)
+            self.assertIn("Invalid contract hash", mock_print.getvalue())
+
+        # test with valid but unknown contract hash
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['import', 'token', '31730cc9a1844891a3bafd1aa929a41000000000']
             res = CommandWallet().execute(args)
             self.assertIsNone(res)
             self.assertIn("Could not find the contract hash", mock_print.getvalue())

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -854,11 +854,13 @@ class UserWalletTestCase(UserWalletTestCaseBase):
         addr = wallet.ToScriptHash('AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3')
 
         # bad inputs
+        tx = SplitUnspentCoin(None, self.NEO, addr, 0, 2)
+        self.assertEqual(tx, None)
+
         tx = SplitUnspentCoin(wallet, self.NEO, addr, 3, 2)
         self.assertEqual(tx, None)
 
-        # bad inputs
-        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'neo', 3, 2])
+        tx = SplitUnspentCoin(wallet, 'bla', addr, 0, 2)
         self.assertEqual(tx, None)
 
         # should be ok

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -467,101 +467,6 @@ class UserWalletTestCase(WalletFixtureTestCase):
         self.assertTrue(res)
         self.assertIn('mine', [n.Title for n in PromptData.Wallet.NamedAddr])
 
-    ##########################################################
-    ##########################################################
-
-    def test_3_import_token(self):
-        wallet = self.GetWallet1(recreate=True)
-
-        self.assertEqual(len(wallet.GetTokens()), 1)
-
-        token_hash = '31730cc9a1844891a3bafd1aa929a4142860d8d3'
-
-        ImportToken(wallet, token_hash)
-
-        token = list(wallet.GetTokens().values())[0]
-
-        self.assertEqual(token.name, 'NEX Template V4')
-        self.assertEqual(token.symbol, 'NXT4')
-        self.assertEqual(token.decimals, 8)
-        self.assertEqual(token.Address, 'Ab61S1rk2VtCVd3NtGNphmBckWk4cfBdmB')
-
-    def test_4_get_synced_balances(self):
-        wallet = self.GetWallet1(recreate=True)
-        synced_balances = wallet.GetSyncedBalances()
-        self.assertEqual(len(synced_balances), 2)
-
-    def test_5_show_unspent(self):
-        wallet = self.GetWallet1(recreate=True)
-        unspents = ShowUnspentCoins(wallet)
-        self.assertEqual(len(unspents), 2)
-
-        unspents = ShowUnspentCoins(wallet, asset_id=self.NEO)
-        self.assertEqual(len(unspents), 1)
-
-        unspents = ShowUnspentCoins(wallet, asset_id=self.GAS)
-        self.assertEqual(len(unspents), 1)
-
-        unspents = ShowUnspentCoins(wallet, from_addr=wallet.ToScriptHash('AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3'))
-        self.assertEqual(len(unspents), 2)
-
-        unspents = ShowUnspentCoins(wallet, from_addr=wallet.ToScriptHash('AYhE3Svuqdfh1RtzvE8hUhNR7HSpaSDFQg'))
-        self.assertEqual(len(unspents), 0)
-
-        unspents = ShowUnspentCoins(wallet, watch_only=True)
-        self.assertEqual(len(unspents), 0)
-
-    def test_6_split_unspent(self):
-        wallet = self.GetWallet1(recreate=True)
-
-        # test bad
-        tx = SplitUnspentCoin(wallet, [])
-        self.assertEqual(tx, None)
-
-        # bad inputs
-        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'neo', 3, 2])
-        self.assertEqual(tx, None)
-
-        # should be ok
-        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'neo', 0, 2], prompt_passwd=False)
-        self.assertIsNotNone(tx)
-
-        # rebuild wallet and try with non-even amount of neo, should be split into integer values of NEO
-        wallet = self.GetWallet1(True)
-        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'neo', 0, 3], prompt_passwd=False)
-        self.assertIsNotNone(tx)
-
-        self.assertEqual([Fixed8.FromDecimal(17), Fixed8.FromDecimal(17), Fixed8.FromDecimal(16)], [item.Value for item in tx.outputs])
-
-        # try with gas
-        wallet = self.GetWallet1(True)
-        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'gas', 0, 3], prompt_passwd=False)
-        self.assertIsNotNone(tx)
-
-    def test_7_create_address(self):
-        # no wallet
-        res = CreateAddress(None, 1)
-        self.assertFalse(res)
-
-        wallet = self.GetWallet1(recreate=True)
-
-        # not specifying a number of addresses
-        res = CreateAddress(wallet, None)
-        self.assertFalse(res)
-
-        # bad args
-        res = CreateAddress(wallet, "blah")
-        self.assertFalse(res)
-
-        # negative value
-        res = CreateAddress(wallet, -1)
-        self.assertFalse(res)
-
-        # should pass
-        res = CreateAddress(wallet, 2)
-        self.assertTrue(res)
-        self.assertEqual(len(wallet.Addresses), 3)
-
     def test_wallet_export_baseclass(self):
         self.OpenWallet1()
 
@@ -875,3 +780,98 @@ class UserWalletTestCase(WalletFixtureTestCase):
             res = CommandWallet().execute(args)
             self.assertTrue(res)
             self.assertIn("Added multi-sig contract address", mock_print.getvalue())
+
+    ##########################################################
+    ##########################################################
+
+    def test_3_import_token(self):
+        wallet = self.GetWallet1(recreate=True)
+
+        self.assertEqual(len(wallet.GetTokens()), 1)
+
+        token_hash = '31730cc9a1844891a3bafd1aa929a4142860d8d3'
+
+        ImportToken(wallet, token_hash)
+
+        token = list(wallet.GetTokens().values())[0]
+
+        self.assertEqual(token.name, 'NEX Template V4')
+        self.assertEqual(token.symbol, 'NXT4')
+        self.assertEqual(token.decimals, 8)
+        self.assertEqual(token.Address, 'Ab61S1rk2VtCVd3NtGNphmBckWk4cfBdmB')
+
+    def test_4_get_synced_balances(self):
+        wallet = self.GetWallet1(recreate=True)
+        synced_balances = wallet.GetSyncedBalances()
+        self.assertEqual(len(synced_balances), 2)
+
+    def test_5_show_unspent(self):
+        wallet = self.GetWallet1(recreate=True)
+        unspents = ShowUnspentCoins(wallet)
+        self.assertEqual(len(unspents), 2)
+
+        unspents = ShowUnspentCoins(wallet, asset_id=self.NEO)
+        self.assertEqual(len(unspents), 1)
+
+        unspents = ShowUnspentCoins(wallet, asset_id=self.GAS)
+        self.assertEqual(len(unspents), 1)
+
+        unspents = ShowUnspentCoins(wallet, from_addr=wallet.ToScriptHash('AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3'))
+        self.assertEqual(len(unspents), 2)
+
+        unspents = ShowUnspentCoins(wallet, from_addr=wallet.ToScriptHash('AYhE3Svuqdfh1RtzvE8hUhNR7HSpaSDFQg'))
+        self.assertEqual(len(unspents), 0)
+
+        unspents = ShowUnspentCoins(wallet, watch_only=True)
+        self.assertEqual(len(unspents), 0)
+
+    def test_6_split_unspent(self):
+        wallet = self.GetWallet1(recreate=True)
+
+        # test bad
+        tx = SplitUnspentCoin(wallet, [])
+        self.assertEqual(tx, None)
+
+        # bad inputs
+        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'neo', 3, 2])
+        self.assertEqual(tx, None)
+
+        # should be ok
+        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'neo', 0, 2], prompt_passwd=False)
+        self.assertIsNotNone(tx)
+
+        # rebuild wallet and try with non-even amount of neo, should be split into integer values of NEO
+        wallet = self.GetWallet1(True)
+        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'neo', 0, 3], prompt_passwd=False)
+        self.assertIsNotNone(tx)
+
+        self.assertEqual([Fixed8.FromDecimal(17), Fixed8.FromDecimal(17), Fixed8.FromDecimal(16)], [item.Value for item in tx.outputs])
+
+        # try with gas
+        wallet = self.GetWallet1(True)
+        tx = SplitUnspentCoin(wallet, ['AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3', 'gas', 0, 3], prompt_passwd=False)
+        self.assertIsNotNone(tx)
+
+    def test_7_create_address(self):
+        # no wallet
+        res = CreateAddress(None, 1)
+        self.assertFalse(res)
+
+        wallet = self.GetWallet1(recreate=True)
+
+        # not specifying a number of addresses
+        res = CreateAddress(wallet, None)
+        self.assertFalse(res)
+
+        # bad args
+        res = CreateAddress(wallet, "blah")
+        self.assertFalse(res)
+
+        # negative value
+        res = CreateAddress(wallet, -1)
+        self.assertFalse(res)
+
+        # should pass
+        res = CreateAddress(wallet, 2)
+        self.assertTrue(res)
+        self.assertEqual(len(wallet.Addresses), 3)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
#623 
Migrate the command `wallet import token` to the new `Command` system.

**How did you solve this problem?**
Implementation of `CommandWalletImportToken`

**How did you make sure your solution works?**
unit tests & manual testing

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
