### PR TITLE
[refactor-prompt] cleanup 2

### DIFF
--- a/neo/Prompt/Commands/Config.py
+++ b/neo/Prompt/Commands/Config.py
@@ -27,7 +27,7 @@ class CommandConfig(CommandBase):
         item = get_arg(arguments)
 
         if not item:
-            print("run `%s help` to see supported queries" % self.command_desc().command)
+            print(f"run `{self.command_desc().command} help` to see supported queries")
             return
 
         try:
@@ -101,7 +101,7 @@ class CommandConfigDebugNotify(CommandBase):
 
     def command_desc(self):
         p1 = ParameterDesc('attribute', 'either "on"|"off" or 1|0')
-        return CommandDesc('sc-debug-notify', 'toggle printing Notify events on execution failure', [p1])
+        return CommandDesc('sc-debug-notify', 'toggle printing smart contract Notify events on execution failure', [p1])
 
 
 class CommandConfigVMLog(CommandBase):

--- a/neo/Prompt/Commands/Config.py
+++ b/neo/Prompt/Commands/Config.py
@@ -69,7 +69,7 @@ class CommandConfigSCEvents(CommandBase):
             return True
         else:
             print("Smart contract event logging is now disabled")
-            return False
+            return True
 
     def command_desc(self):
         p1 = ParameterDesc('attribute', 'either "on"|"off" or 1|0')

--- a/neo/Prompt/Commands/Config.py
+++ b/neo/Prompt/Commands/Config.py
@@ -53,23 +53,23 @@ class CommandConfigSCEvents(CommandBase):
         super().__init__()
 
     def execute(self, arguments):
-        c1 = get_arg(arguments)
-        if c1 is not None:
-            c1 = c1.lower()
-            if c1 == 'on' or c1 == '1':
-                settings.set_log_smart_contract_events(True)
-                print("Smart contract event logging is now enabled")
-                return c1
-            elif c1 == 'off' or c1 == '0':
-                settings.set_log_smart_contract_events(False)
-                print("Smart contract event logging is now disabled")
-                return c1
-            else:
-                print("Cannot configure log. Please specify on|off or 1|0")
-                return
+        if len(arguments) == 0:
+            print("Please specify the required parameter")
+            return False
+
+        try:
+            flag = bool(util.strtobool(arguments[0]))
+            settings.set_log_smart_contract_events(flag)
+        except ValueError:
+            print("Invalid option")
+            return False
+
+        if flag:
+            print("Smart contract event logging is now enabled")
+            return True
         else:
-            print("Cannot configure log. Please specify on|off or 1|0")
-            return
+            print("Smart contract event logging is now disabled")
+            return False
 
     def command_desc(self):
         p1 = ParameterDesc('attribute', 'either "on"|"off" or 1|0')
@@ -81,23 +81,23 @@ class CommandConfigDebugNotify(CommandBase):
         super().__init__()
 
     def execute(self, arguments):
-        c1 = get_arg(arguments)
-        if c1 is not None:
-            c1 = c1.lower()
-            if c1 == 'on' or c1 == '1':
-                settings.set_emit_notify_events_on_sc_execution_error(True)
-                print("Smart contract emit Notify events on execution failure is now enabled")
-                return c1
-            elif c1 == 'off' or c1 == '0':
-                settings.set_emit_notify_events_on_sc_execution_error(False)
-                print("Smart contract emit Notify events on execution failure is now disabled")
-                return c1
-            else:
-                print("Cannot configure log. Please specify on|off or 1|0")
-                return
+        if len(arguments) == 0:
+            print("Please specify the required parameter")
+            return False
+
+        try:
+            flag = bool(util.strtobool(arguments[0]))
+            settings.set_emit_notify_events_on_sc_execution_error(flag)
+        except ValueError:
+            print("Invalid option")
+            return False
+
+        if flag:
+            print("Smart contract emit Notify events on execution failure is now enabled")
+            return True
         else:
-            print("Cannot configure log. Please specify on|off or 1|0")
-            return
+            print("Smart contract emit Notify events on execution failure is now disabled")
+            return True
 
     def command_desc(self):
         p1 = ParameterDesc('attribute', 'either "on"|"off" or 1|0')
@@ -109,23 +109,23 @@ class CommandConfigVMLog(CommandBase):
         super().__init__()
 
     def execute(self, arguments):
-        c1 = get_arg(arguments)
-        if c1 is not None:
-            c1 = c1.lower()
-            if c1 == 'on' or c1 == '1':
-                settings.set_log_vm_instruction(True)
-                print("VM instruction execution logging is now enabled")
-                return c1
-            elif c1 == 'off' or c1 == '0':
-                settings.set_log_vm_instruction(False)
-                print("VM instruction execution logging is now disabled")
-                return c1
-            else:
-                print("Cannot configure VM instruction logging. Please specify on|off or 1|0")
-                return
+        if len(arguments) == 0:
+            print("Please specify the required parameter")
+            return False
+
+        try:
+            flag = bool(util.strtobool(arguments[0]))
+            settings.set_log_vm_instruction(flag)
+        except ValueError:
+            print("Invalid option")
+            return False
+
+        if flag:
+            print("VM instruction execution logging is now enabled")
+            return True
         else:
-            print("Cannot configure VM instruction logging. Please specify on|off or 1|0")
-            return
+            print("VM instruction execution logging is now disabled")
+            return True
 
     def command_desc(self):
         p1 = ParameterDesc('attribute', 'either "on"|"off" or 1|0')
@@ -142,12 +142,12 @@ class CommandConfigNodeRequests(CommandBase):
                 try:
                     return NodeLeader.Instance().setBlockReqSizeAndMax(int(arguments[0]), int(arguments[1]))
                 except ValueError:
-                    print("invalid values. Please specify a block request part and max size for each node, like 30 and 1000")
+                    print("Invalid values. Please specify a block request part and max size for each node, like 30 and 1000")
                     return False
             elif len(arguments) == 1:
                 return NodeLeader.Instance().setBlockReqSizeByName(arguments[0])
         else:
-            print("Invalid number of arguments")
+            print("Please specify the required parameter")
             return False
 
     def command_desc(self):

--- a/neo/Prompt/Commands/Search.py
+++ b/neo/Prompt/Commands/Search.py
@@ -5,7 +5,6 @@ from neo.Core.Blockchain import Blockchain
 from neo.logging import log_manager
 import json
 
-
 logger = log_manager.getLogger()
 
 
@@ -23,7 +22,7 @@ class CommandSearch(CommandBase):
         item = get_arg(arguments)
 
         if not item:
-            print("run `%s help` to see supported queries" % self.command_desc().command)
+            print(f"run `{self.command_desc().command} help` to see supported queries")
             return
 
         try:

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -78,6 +78,10 @@ class CommandWalletSign(CommandBase):
 
     def execute(self, arguments):
         jsn = get_arg(arguments)
+        if not jsn:
+            print("Please specify the required parameter")
+            return False
+
         return parse_and_sign(PromptData.Wallet, jsn)
 
     def command_desc(self):
@@ -88,7 +92,7 @@ class CommandWalletSign(CommandBase):
 
 def construct_send_basic(wallet, arguments):
     if len(arguments) < 3:
-        print("Not enough arguments")
+        print("Please specify the requred parameters")
         return None
 
     arguments, from_address = get_from_addr(arguments)

--- a/neo/Prompt/Commands/Show.py
+++ b/neo/Prompt/Commands/Show.py
@@ -75,7 +75,7 @@ class CommandShowBlock(CommandBase):
                 print("Could not locate block %s" % item)
                 return
         else:
-            print("please specify a supported block attribute: index or scripthash")
+            print("Please specify the required parameter")
             return
 
     def command_desc(self):
@@ -99,7 +99,7 @@ class CommandShowHeader(CommandBase):
                 print("Could not locate header %s\n" % item)
                 return
         else:
-            print("Please specify a supported header attribute: index or scripthash")
+            print("Please specify the required parameter")
             return
 
     def command_desc(self):
@@ -130,7 +130,7 @@ class CommandShowTx(CommandBase):
                 print("Could not find transaction from args: %s" % arguments)
                 return
         else:
-            print("Please specify a TX hash")
+            print("Please specify the required parameter")
             return
 
     def command_desc(self):
@@ -222,8 +222,6 @@ class CommandShowNotifications(CommandBase):
             if item[0:2] == "0x":
                 item = item[2:]
 
-            events = []
-
             if len(item) == 34 and item[0] == 'A':
                 events = NotificationDB.instance().get_by_addr(item)
 
@@ -249,7 +247,7 @@ class CommandShowNotifications(CommandBase):
                 print("No events found for %s" % item)
                 return
         else:
-            print("Please specify a supported attribute: a block index, an address, or contract scripthash")
+            print("Please specify the required parameter")
             return
 
     def command_desc(self):
@@ -273,7 +271,7 @@ class CommandShowAccount(CommandBase):
                 print("Account %s not found" % item)
                 return
         else:
-            print("Please specify an account address")
+            print("Please specify the required parameter")
             return
 
     def command_desc(self):
@@ -318,14 +316,15 @@ class CommandShowAsset(CommandBase):
                 print("Asset %s not found" % item)
                 return
         else:
-            print('Please specify a supported attribute: asset name, assetId, or "all" shows all assets')
+            print('Please specify the required parameter')
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('attribute', 'the asset name, assetId, or "all" shows all assets\n\n'
-        f"{' ':>17} Example:\n"
-        f"{' ':>20} 'neo' or 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'\n"
-        f"{' ':>20} 'gas' or '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'\n")
+        p1 = ParameterDesc('attribute',
+                           'the asset name, assetId, or "all" shows all assets\n\n'
+                           f"{' ':>17} Example:\n"
+                           f"{' ':>20} 'neo' or 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'\n"
+                           f"{' ':>20} 'gas' or '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'\n")
         return CommandDesc('asset', 'show a specified asset', [p1])
 
 
@@ -362,7 +361,7 @@ class CommandShowContract(CommandBase):
                 print("Contract %s not found" % item)
                 return
         else:
-            print('Please specify a supported attribute: contract scripthash or "all"')
+            print('Please specify the required parameter')
             return
 
     def command_desc(self):

--- a/neo/Prompt/Commands/Show.py
+++ b/neo/Prompt/Commands/Show.py
@@ -13,7 +13,6 @@ from neo.Implementations.Notifications.LevelDB.NotificationDB import Notificatio
 from neo.logging import log_manager
 import json
 
-
 logger = log_manager.getLogger()
 
 
@@ -39,7 +38,7 @@ class CommandShow(CommandBase):
         item = get_arg(arguments)
 
         if not item:
-            print("run `%s help` to see supported queries" % self.command_desc().command)
+            print(f"run `{self.command_desc().command} help` to see supported queries")
             return
 
         try:
@@ -324,9 +323,9 @@ class CommandShowAsset(CommandBase):
 
     def command_desc(self):
         p1 = ParameterDesc('attribute', 'the asset name, assetId, or "all" shows all assets\n\n'
-                           f"{' ':>17} Example:\n"
-                           f"{' ':>20} 'neo' or 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'\n"
-                           f"{' ':>20} 'gas' or '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'\n")
+        f"{' ':>17} Example:\n"
+        f"{' ':>20} 'neo' or 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'\n"
+        f"{' ':>20} 'gas' or '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'\n")
         return CommandDesc('asset', 'show a specified asset', [p1])
 
 

--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -41,7 +41,7 @@ class CommandWalletToken(CommandBase):
         item = PromptUtils.get_arg(arguments)
 
         if not item:
-            print(f"Please specify an action. See help for available actions")
+            print(f"run `{self.command_desc().command} help` to see supported queries")
             return False
 
         try:

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -76,8 +76,6 @@ class CommandWalletCreate(CommandBase):
         super().__init__()
 
     def execute(self, arguments):
-        if PromptData.Wallet:
-            PromptData.close_wallet()
         path = PromptUtils.get_arg(arguments, 0)
 
         if not path:
@@ -87,6 +85,9 @@ class CommandWalletCreate(CommandBase):
         if os.path.exists(path):
             print("File already exists")
             return
+
+        if PromptData.Wallet:
+            PromptData.close_wallet()
 
         passwd1 = prompt("[password]> ", is_password=True)
         passwd2 = prompt("[password again]> ", is_password=True)

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -135,7 +135,7 @@ class CommandWalletOpen(CommandBase):
         path = PromptUtils.get_arg(arguments, 0)
 
         if not path:
-            print("Please specify a path")
+            print("Please specify the required parameter")
             return
 
         if not os.path.exists(path):

--- a/neo/Prompt/Commands/WalletAddress.py
+++ b/neo/Prompt/Commands/WalletAddress.py
@@ -47,7 +47,7 @@ class CommandWalletCreateAddress(CommandBase):
         addresses_to_create = PromptUtils.get_arg(arguments, 0)
 
         if not addresses_to_create:
-            print("Please specify a number of addresses to create.")
+            print("Please specify the required parameter")
             return
 
         return CreateAddress(PromptData.Wallet, addresses_to_create)
@@ -65,7 +65,7 @@ class CommandWalletDeleteAddress(CommandBase):
         addr_to_delete = PromptUtils.get_arg(arguments, 0)
 
         if not addr_to_delete:
-            print("Please specify an address to delete.")
+            print("Please specify the required parameter")
             return False
 
         return DeleteAddress(PromptData.Wallet, addr_to_delete)
@@ -148,7 +148,7 @@ class CommandWalletAlias(CommandBase):
 
     def execute(self, arguments):
         if len(arguments) < 2:
-            print("Please supply an address and an alias")
+            print("Please specify the required parameters")
             return False
 
         return AddAlias(PromptData.Wallet, arguments[0], arguments[1])

--- a/neo/Prompt/Commands/WalletExport.py
+++ b/neo/Prompt/Commands/WalletExport.py
@@ -62,7 +62,7 @@ class CommandWalletExportNEP2(CommandBase):
         wallet = PromptData.Wallet
 
         if len(arguments) != 1:
-            print("Please specify the required parameters")
+            print("Please specify the required parameter")
             return False
 
         address = arguments[0]

--- a/neo/Prompt/Commands/WalletExport.py
+++ b/neo/Prompt/Commands/WalletExport.py
@@ -18,7 +18,7 @@ class CommandWalletExport(CommandBase):
         item = PromptUtils.get_arg(arguments)
 
         if not item:
-            print(f"Please specify an action. See help for available actions")
+            print(f"run `{self.command_desc().command} help` to see supported queries")
             return False
 
         try:

--- a/neo/Prompt/Commands/WalletImport.py
+++ b/neo/Prompt/Commands/WalletImport.py
@@ -87,7 +87,7 @@ class CommandWalletImportNEP2(CommandBase):
         wallet = PromptData.Wallet
 
         if len(arguments) != 1:
-            print("Please specify the required parameters")
+            print("Please specify the required parameter")
             return False
 
         nep2_key = arguments[0]
@@ -124,7 +124,7 @@ class CommandWalletImportWatchAddr(CommandBase):
         wallet = PromptData.Wallet
 
         if len(arguments) != 1:
-            print("Please specify the required parameters")
+            print("Please specify the required parameter")
             return False
 
         addr = arguments[0]

--- a/neo/Prompt/Commands/WalletImport.py
+++ b/neo/Prompt/Commands/WalletImport.py
@@ -32,7 +32,7 @@ class CommandWalletImport(CommandBase):
         item = PromptUtils.get_arg(arguments)
 
         if not item:
-            print(f"Please specify an action. See help for available actions")
+            print(f"run `{self.command_desc().command} help` to see supported queries")
             return False
 
         try:

--- a/neo/Prompt/Commands/tests/test_config_commands.py
+++ b/neo/Prompt/Commands/tests/test_config_commands.py
@@ -49,7 +49,7 @@ class CommandConfigTestCase(BlockchainFixtureTestCase):
         # test turning them off
         args = ['sc-events', '0']
         res = CommandConfig().execute(args)
-        self.assertTrue(res)
+        self.assertFalse(settings.log_smart_contract_events)
 
         # test bad input
         args = ['sc-events', 'blah']

--- a/neo/Prompt/Commands/tests/test_config_commands.py
+++ b/neo/Prompt/Commands/tests/test_config_commands.py
@@ -45,10 +45,12 @@ class CommandConfigTestCase(BlockchainFixtureTestCase):
         args = ['sc-events', 'on']
         res = CommandConfig().execute(args)
         self.assertTrue(res)
+        self.assertTrue(settings.log_smart_contract_events)
 
         # test turning them off
         args = ['sc-events', '0']
         res = CommandConfig().execute(args)
+        self.assertTrue(res)
         self.assertFalse(settings.log_smart_contract_events)
 
         # test bad input
@@ -66,11 +68,13 @@ class CommandConfigTestCase(BlockchainFixtureTestCase):
         args = ['sc-debug-notify', 'on']
         res = CommandConfig().execute(args)
         self.assertTrue(res)
+        self.assertTrue(settings.emit_notify_events_on_sc_execution_error)
 
         # test turning them off
         args = ['sc-debug-notify', '0']
         res = CommandConfig().execute(args)
         self.assertTrue(res)
+        self.assertFalse(settings.emit_notify_events_on_sc_execution_error)
 
         # test bad input
         args = ['sc-debug-notify', 'blah']
@@ -87,11 +91,13 @@ class CommandConfigTestCase(BlockchainFixtureTestCase):
         args = ['vm-log', 'on']
         res = CommandConfig().execute(args)
         self.assertTrue(res)
+        self.assertTrue(settings.log_vm_instructions)
 
         # test turning them off
         args = ['vm-log', '0']
         res = CommandConfig().execute(args)
         self.assertTrue(res)
+        self.assertFalse(settings.log_vm_instructions)
 
         # test bad input
         args = ['vm-log', 'blah']

--- a/neo/Prompt/Commands/tests/test_token_commands.py
+++ b/neo/Prompt/Commands/tests/test_token_commands.py
@@ -347,13 +347,13 @@ class UserWalletTestCase(WalletFixtureTestCase):
                 args = ['token']
                 res = CommandWallet().execute(args)
                 self.assertFalse(res)
-                self.assertIn("Please specify an action", mock_print.getvalue())
+                self.assertIn("run `token help` to see supported queries", mock_print.getvalue())
 
             with patch('sys.stdout', new=StringIO()) as mock_print:
                 args = ['token', None]
                 res = CommandWallet().execute(args)
                 self.assertFalse(res)
-                self.assertIn("Please specify an action", mock_print.getvalue())
+                self.assertIn("run `token help` to see supported queries", mock_print.getvalue())
 
             # test token with invalid subcommands
             with patch('sys.stdout', new=StringIO()) as mock_print:

--- a/neo/Prompt/Commands/tests/test_wallet_export_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_export_commands.py
@@ -13,7 +13,7 @@ class UserWalletTestCase(UserWalletTestCaseBase):
             args = ['export']
             res = CommandWallet().execute(args)
             self.assertFalse(res)
-            self.assertIn("Please specify an action", mock_print.getvalue())
+            self.assertIn("run `export help` to see supported queries", mock_print.getvalue())
 
         # test with an invalid action
         with patch('sys.stdout', new=StringIO()) as mock_print:

--- a/neo/Prompt/Commands/tests/test_wallet_import_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_import_commands.py
@@ -17,7 +17,7 @@ class UserWalletTestCase(UserWalletTestCaseBase):
             args = ['import']
             res = CommandWallet().execute(args)
             self.assertFalse(res)
-            self.assertIn("Please specify an action", mock_print.getvalue())
+            self.assertIn("run `import help` to see supported queries", mock_print.getvalue())
 
         # test with an invalid action
         with patch('sys.stdout', new=StringIO()) as mock_print:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
1) some group commands had the error message 
```
Please specify an action. See help for available actions
```
the other half
```
run `<cmd name> help`   to see supported queries
```

2) A good part of the commands used
```
Please specify the required parameters
```
others use slightly more specific

```
Please specify the <missing argument name>
```
and then some had completely different responses like

```
invalid number of   arguments
Not enough   arguments
etc
```

3) some commands that toggle settings accepted either `1` or `on`, others accepted more boolean values like `t`, `true` etc.

**How did you solve this problem?**
streamline responses amongst commands for certain actions. see commits

**How did you make sure your solution works?**
make test

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
