### PR TITLE
[refactor-prompt] cleanup parameter descriptions

### DIFF
--- a/neo/Prompt/Commands/Config.py
+++ b/neo/Prompt/Commands/Config.py
@@ -151,8 +151,8 @@ class CommandConfigNodeRequests(CommandBase):
             return False
 
     def command_desc(self):
-        p1 = ParameterDesc('block-size', 'a preset of "slow"/"normal"/"fast", or a specific block request size (max. 500) e.g. 250 ')
-        p2 = ParameterDesc('queue-size', 'the maximum number of outstanding block requests')
+        p1 = ParameterDesc('block-size', 'preset of "slow"/"normal"/"fast", or a specific block request size (max. 500) e.g. 250 ')
+        p2 = ParameterDesc('queue-size', 'maximum number of outstanding block requests')
         return CommandDesc('node-requests', 'configure block request settings', [p1, p2])
 
     def handle_help(self, arguments):

--- a/neo/Prompt/Commands/SC.py
+++ b/neo/Prompt/Commands/SC.py
@@ -1,10 +1,9 @@
 from neo.Prompt.CommandBase import CommandBase, CommandDesc, ParameterDesc
 from neo.Prompt.PromptData import PromptData
 from neo.Prompt.Commands.LoadSmartContract import LoadContract, GatherContractDetails
-from neo.Prompt.Commands.Invoke import test_invoke, InvokeContract
 from neo.Prompt import Utils as PromptUtils
 from neo.Prompt.Commands.BuildNRun import Build, BuildAndRun, LoadAndRun
-from neo.Prompt.Commands.Invoke import TestInvokeContract, InvokeContract
+from neo.Prompt.Commands.Invoke import TestInvokeContract, InvokeContract, test_invoke
 from neo.Core.Blockchain import Blockchain
 from neocore.UInt160 import UInt160
 from neo.SmartContract.ContractParameter import ContractParameter
@@ -62,7 +61,7 @@ class CommandSCBuild(CommandBase):
         return contract_script
 
     def command_desc(self):
-        p1 = ParameterDesc('path', 'the path to the desired Python (.py) file')
+        p1 = ParameterDesc('path', 'path to the desired Python (.py) file')
         return CommandDesc('build', 'compile a specified Python (.py) script into a smart contract (.avm) file', [p1])
 
 
@@ -86,16 +85,16 @@ class CommandSCBuildRun(CommandBase):
         return tx, result, total_ops, engine
 
     def command_desc(self):
-        p1 = ParameterDesc('path', 'the path to the desired Python (.py) file')
+        p1 = ParameterDesc('path', 'path to the desired Python (.py) file')
         p2 = ParameterDesc('storage', 'boolean input to determine if smart contract requires storage')
         p3 = ParameterDesc('dynamic_invoke', 'boolean input to determine if smart contract requires dynamic invoke')
         p4 = ParameterDesc('payable', 'boolean input to determine if smart contract is payable')
-        p5 = ParameterDesc('params', 'the input parameter types of the smart contract')
-        p6 = ParameterDesc('returntype', 'the returntype of the smart contract output')
-        p7 = ParameterDesc('inputs', 'the test parameters fed to the smart contract, or use "--i" for prompted parameter input')
-        p8 = ParameterDesc('--no-parse-addr', 'a flag to turn off address parsing when input into the smart contract', optional=True)
+        p5 = ParameterDesc('params', 'input parameter types of the smart contract')
+        p6 = ParameterDesc('returntype', 'return type of the smart contract output')
+        p7 = ParameterDesc('inputs', 'test parameters fed to the smart contract, or use "--i" for prompted parameter input')
+        p8 = ParameterDesc('--no-parse-addr', 'flag to turn off address parsing when input into the smart contract', optional=True)
         p9 = ParameterDesc('--from-addr', 'source address to take fee funds from (if not specified, take first address in wallet)', optional=True)
-        p10 = ParameterDesc('--owners', 'a list of NEO addresses indicating the transaction owners e.g. --owners=[address1,address2]', optional=True)
+        p10 = ParameterDesc('--owners', 'list of NEO addresses indicating the transaction owners e.g. --owners=[address1,address2]', optional=True)
         p11 = ParameterDesc('--tx-attr',
                             'a list of transaction attributes to attach to the transaction\n\n'
                             f"{' ':>17} See: http://docs.neo.org/en-us/network/network-protocol.html section 4 for a description of possible attributes\n\n"
@@ -131,14 +130,14 @@ class CommandSCLoadRun(CommandBase):
         return tx, result, total_ops, engine
 
     def command_desc(self):
-        p1 = ParameterDesc('path', 'the path to the desired smart contract (.avm) file')
+        p1 = ParameterDesc('path', 'path to the desired smart contract (.avm) file')
         p2 = ParameterDesc('storage', 'boolean input to determine if smart contract requires storage')
         p3 = ParameterDesc('dynamic_invoke', 'boolean input to determine if smart contract requires dynamic invoke')
         p4 = ParameterDesc('payable', 'boolean input to determine if smart contract is payable')
-        p5 = ParameterDesc('params', 'the input parameter types of the smart contract')
-        p6 = ParameterDesc('returntype', 'the returntype of the smart contract output')
-        p7 = ParameterDesc('inputs', 'the test parameters fed to the smart contract, or use "--i" for prompted parameter input')
-        p8 = ParameterDesc('--no-parse-addr', 'a flag to turn off address parsing when input into the smart contract', optional=True)
+        p5 = ParameterDesc('params', 'input parameter types of the smart contract')
+        p6 = ParameterDesc('returntype', 'the return type of the smart contract output')
+        p7 = ParameterDesc('inputs', 'test parameters fed to the smart contract, or use "--i" for prompted parameter input')
+        p8 = ParameterDesc('--no-parse-addr', 'flag to turn off address parsing when input into the smart contract', optional=True)
         p9 = ParameterDesc('--from-addr',
                            'source address to take fee funds from (if not specified, take first address in wallet)\n\n'
                            f"{' ':>17} Usage Examples:\n"
@@ -204,19 +203,22 @@ class CommandSCTestInvoke(CommandBase):
             return False
 
     def command_desc(self):
-        p1 = ParameterDesc('contract', 'token contract hash (script_hash)')
-        p2 = ParameterDesc('inputs', 'the test parameters fed to the smart contract, or use "--i" for prompted parameter input')
+        p1 = ParameterDesc('contract', 'token contract hash (script hash)')
+        p2 = ParameterDesc('inputs', 'test parameters fed to the smart contract, or use "--i" for prompted parameter input')
         p3 = ParameterDesc('--attach-neo', 'amount of neo to attach to the transaction. Required if --attach-gas is not specified', optional=True)
         p4 = ParameterDesc('--attach-gas', 'amount of gas to attach to the transaction. Required if --attach-neo is not specified', optional=True)
-        p5 = ParameterDesc('--no-parse-addr', 'a flag to turn off address parsing when input into the smart contract', optional=True)
+        p5 = ParameterDesc('--no-parse-addr', 'flag to turn off address parsing when input into the smart contract', optional=True)
         p6 = ParameterDesc('--from-addr', 'source address to take fee funds from (if not specified, take first address in wallet)', optional=True)
-        p7 = ParameterDesc('--owners', 'a list of NEO addresses indicating the transaction owners e.g. --owners=[address1,address2]', optional=True)
+        p7 = ParameterDesc('--owners', 'list of NEO addresses indicating the transaction owners e.g. --owners=[address1,address2]', optional=True)
         p8 = ParameterDesc('--tx-attr',
                            'a list of transaction attributes to attach to the transaction\n\n'
                            f"{' ':>17} See: http://docs.neo.org/en-us/network/network-protocol.html section 4 for a description of possible attributes\n\n"
                            f"{' ':>17} Example\n"
                            f"{' ':>20} --tx-attr=[{{\"usage\": <value>,\"data\":\"<remark>\"}}, ...]\n"
-                           f"{' ':>20} --tx-attr=[{{\"usage\": 0x90,\"data\":\"my brief description\"}}]\n\n", optional=True)
+                           f"{' ':>20} --tx-attr=[{{\"usage\": 0x90,\"data\":\"my brief description\"}}]\n\n"
+                           f"{' ':>17} For more information about parameter types see\n"
+                           f"{' ':>17} https://neo-python.readthedocs.io/en/latest/data-types.html#contractparametertypes\n", optional=True)
+
         params = [p1, p2, p3, p4, p5, p6, p7, p8]
         return CommandDesc('invoke', 'Call functions on the smart contract. Will prompt before sending to the network', params=params)
 
@@ -288,12 +290,15 @@ class CommandSCDeploy(CommandBase):
             return False
 
     def command_desc(self):
-        p1 = ParameterDesc('path', 'the path to the desired Python (.py) file')
+        p1 = ParameterDesc('path', 'path to the desired Python (.py) file')
         p2 = ParameterDesc('storage', 'boolean input to determine if smart contract requires storage')
         p3 = ParameterDesc('dynamic_invoke', 'boolean input to determine if smart contract requires dynamic invoke')
         p4 = ParameterDesc('payable', 'boolean input to determine if smart contract is payable')
-        p5 = ParameterDesc('params', 'the input parameter types of the smart contract')
-        p6 = ParameterDesc('returntype', 'the returntype of the smart contract output')
+        p5 = ParameterDesc('params', 'input parameter types of the smart contract')
+        p6 = ParameterDesc('returntype',
+                           f"the return type of the smart contract output\n\n"
+                           f"{' ':>17} For more information about parameter types see\n"
+                           f"{' ':>17} https://neo-python.readthedocs.io/en/latest/data-types.html#contractparametertypes\n", optional=True)
 
         params = [p1, p2, p3, p4, p5, p6]
         return CommandDesc('deploy', 'Deploy a smart contract (.avm) file to the blockchain', params=params)

--- a/neo/Prompt/Commands/Search.py
+++ b/neo/Prompt/Commands/Search.py
@@ -49,7 +49,7 @@ class CommandSearchAsset(CommandBase):
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('query', 'supports name, issuer, or admin searches')
+        p1 = ParameterDesc('query', 'name, issuer, or admin')
         return CommandDesc('asset', 'perform an asset search', [p1])
 
 
@@ -70,5 +70,5 @@ class CommandSearchContract(CommandBase):
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('query', 'supports name, author, description, or email searches')
+        p1 = ParameterDesc('query', 'name, author, description, or email')
         return CommandDesc('contract', 'perform a contract search', [p1])

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -29,17 +29,18 @@ class CommandWalletSend(CommandBase):
         return framework
 
     def command_desc(self):
-        p1 = ParameterDesc('assetId or name', 'the asset (NEO/GAS) to send')
-        p2 = ParameterDesc('address', 'the destination address')
-        p3 = ParameterDesc('amount', 'the amount of the asset to send')
+        p1 = ParameterDesc('asset', 'assetId or name (NEO/GAS) to send')
+        p2 = ParameterDesc('address', 'destination address')
+        p3 = ParameterDesc('amount', 'amount of the asset to send')
         p4 = ParameterDesc('--from-addr', 'source address to take funds from (if not specified, take first address in wallet)', optional=True)
-        p5 = ParameterDesc('--fee', 'a fee to give your transaction priority (> 0.001) e.g. --fee=0.01', optional=True)
-        p6 = ParameterDesc('--owners', 'a list of NEO addresses indicating the transaction owners e.g. --owners=[address1,address2]', optional=True)
-        p7 = ParameterDesc('--tx-attr', f'a list of transaction attributes to attach to the transaction\n\n'
-        f"{' ':>17} See: http://docs.neo.org/en-us/network/network-protocol.html section 4 for a description of possible attributes\n\n"  # noqa: E128 ignore indentation
-        f"{' ':>17} Example:\n"
-        f"{' ':>20} --tx-attr=[{{\"usage\": <value>,\"data\":\"<remark>\"}}, ...]\n"
-        f"{' ':>20} --tx-attr=[{{\"usage\": 0x90,\"data\":\"my brief description\"}}]\n", optional=True)
+        p5 = ParameterDesc('--fee', 'fee to give your transaction priority (> 0.001) e.g. --fee=0.01', optional=True)
+        p6 = ParameterDesc('--owners', 'list of NEO addresses indicating the transaction owners e.g. --owners=[address1,address2]', optional=True)
+        p7 = ParameterDesc('--tx-attr',
+                           f"list of transaction attributes to attach to the transaction\n\n"
+                           f"{' ':>17} See: http://docs.neo.org/en-us/network/network-protocol.html section 4 for a description of possible attributes\n\n"
+                           f"{' ':>17} Example:\n"
+                           f"{' ':>20} --tx-attr=[{{\"usage\": <value>,\"data\":\"<remark>\"}}, ...]\n"
+                           f"{' ':>20} --tx-attr=[{{\"usage\": 0x90,\"data\":\"my brief description\"}}]\n", optional=True)
         params = [p1, p2, p3, p4, p5, p6, p7]
         return CommandDesc('send', 'send an asset (NEO/GAS)', params=params)
 
@@ -57,16 +58,17 @@ class CommandWalletSendMany(CommandBase):
         return framework
 
     def command_desc(self):
-        p1 = ParameterDesc('tx_count', 'the number of transactions to send')
-        p2 = ParameterDesc('--change-addr', 'an address to send remaining funds to', optional=True)
+        p1 = ParameterDesc('tx_count', 'number of transactions to send')
+        p2 = ParameterDesc('--change-addr', 'address to send remaining funds to', optional=True)
         p3 = ParameterDesc('--from-addr', 'source address to take funds from (if not specified, take first address in wallet)', optional=True)
-        p4 = ParameterDesc('--fee', 'a fee to give your transaction priority (> 0.001) e.g. --fee=0.01', optional=True)
-        p5 = ParameterDesc('--owners', 'a list of NEO addresses indicating the transaction owners e.g. --owners=[address1,address2]', optional=True)
-        p6 = ParameterDesc('--tx-attr', f'a list of transaction attributes to attach to the transaction\n\n'
-        f"{' ':>17} See: http://docs.neo.org/en-us/network/network-protocol.html section 4 for a description of possible attributes\n\n"  # noqa: E128 ignore indentation
-        f"{' ':>17} Example:\n"
-        f"{' ':>20} --tx-attr=[{{\"usage\": <value>,\"data\":\"<remark>\"}}, ...]\n"
-        f"{' ':>20} --tx-attr=[{{\"usage\": 0x90,\"data\":\"my brief description\"}}]\n", optional=True)
+        p4 = ParameterDesc('--fee', 'fee to give your transaction priority (> 0.001) e.g. --fee=0.01', optional=True)
+        p5 = ParameterDesc('--owners', 'list of NEO addresses indicating the transaction owners e.g. --owners=[address1,address2]', optional=True)
+        p6 = ParameterDesc('--tx-attr',
+                           f"a list of transaction attributes to attach to the transaction\n\n"
+                           f"{' ':>17} See: http://docs.neo.org/en-us/network/network-protocol.html section 4 for a description of possible attributes\n\n"
+                           f"{' ':>17} Example:\n"
+                           f"{' ':>20} --tx-attr=[{{\"usage\": <value>,\"data\":\"<remark>\"}}, ...]\n"
+                           f"{' ':>20} --tx-attr=[{{\"usage\": 0x90,\"data\":\"my brief description\"}}]\n", optional=True)
         params = [p1, p2, p3, p4, p5, p6]
         return CommandDesc('sendmany', 'send multiple NEO/GAS transactions', params=params)
 
@@ -92,7 +94,7 @@ class CommandWalletSign(CommandBase):
 
 def construct_send_basic(wallet, arguments):
     if len(arguments) < 3:
-        print("Please specify the requred parameters")
+        print("Please specify the required parameters")
         return None
 
     arguments, from_address = get_from_addr(arguments)

--- a/neo/Prompt/Commands/Show.py
+++ b/neo/Prompt/Commands/Show.py
@@ -32,7 +32,7 @@ class CommandShow(CommandBase):
         self.register_sub_command(CommandShowContract())
 
     def command_desc(self):
-        return CommandDesc('show', 'show useful data')
+        return CommandDesc('show', 'show various node and blockchain data')
 
     def execute(self, arguments):
         item = get_arg(arguments)
@@ -79,8 +79,8 @@ class CommandShowBlock(CommandBase):
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('attribute', 'the block index or scripthash')
-        p2 = ParameterDesc('tx', 'arg to only show block transactions', optional=True)
+        p1 = ParameterDesc('attribute', 'block index or script hash')
+        p2 = ParameterDesc('tx', 'flag to only show block transactions', optional=True)
         return CommandDesc('block', 'show a specified block', [p1, p2])
 
 
@@ -103,7 +103,7 @@ class CommandShowHeader(CommandBase):
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('attribute', 'the header index or scripthash')
+        p1 = ParameterDesc('attribute', 'header index or script hash')
         return CommandDesc('header', 'show the header of a specified block', [p1])
 
 
@@ -134,7 +134,7 @@ class CommandShowTx(CommandBase):
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('hash', 'the scripthash of the transaction')
+        p1 = ParameterDesc('hash', 'transaction script hash')
         return CommandDesc('tx', 'show a specified transaction', [p1])
 
 
@@ -251,7 +251,7 @@ class CommandShowNotifications(CommandBase):
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('attribute', 'the block index, an address, or contract scripthash to show notifications for')
+        p1 = ParameterDesc('attribute', 'block index, an address, or contract script hash to show notifications for')
         return CommandDesc('notifications', 'show specified contract execution notifications', [p1])
 
 
@@ -275,7 +275,7 @@ class CommandShowAccount(CommandBase):
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('address', 'the address to show')
+        p1 = ParameterDesc('address', 'public NEO address')
         return CommandDesc('account', 'show the assets (NEO/GAS) held by a specified address', [p1])
 
 
@@ -321,7 +321,7 @@ class CommandShowAsset(CommandBase):
 
     def command_desc(self):
         p1 = ParameterDesc('attribute',
-                           'the asset name, assetId, or "all" shows all assets\n\n'
+                           'asset name, assetId, or "all"\n\n'
                            f"{' ':>17} Example:\n"
                            f"{' ':>20} 'neo' or 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'\n"
                            f"{' ':>20} 'gas' or '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'\n")
@@ -365,5 +365,5 @@ class CommandShowContract(CommandBase):
             return
 
     def command_desc(self):
-        p1 = ParameterDesc('attribute', 'the contract scripthash, or "all" shows all contracts')
+        p1 = ParameterDesc('attribute', 'contract script hash, or "all"')
         return CommandDesc('contract', 'show a specified smart contract', [p1])

--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -88,7 +88,7 @@ class CommandTokenDelete(CommandBase):
         return success
 
     def command_desc(self):
-        p1 = ParameterDesc('contract', 'token contract hash (script_hash)')
+        p1 = ParameterDesc('contract', 'token contract hash (script hash)')
         return CommandDesc('delete', 'remove a token from the wallet', [p1])
 
 
@@ -130,7 +130,7 @@ class CommandTokenSend(CommandBase):
         return success
 
     def command_desc(self):
-        p1 = ParameterDesc('token', 'token symbol name or script_hash')
+        p1 = ParameterDesc('token', 'token symbol or script hash')
         p2 = ParameterDesc('from_addr', 'address to send token from')
         p3 = ParameterDesc('to_addr', 'address to send token to')
         p4 = ParameterDesc('amount', 'number of tokens to send')
@@ -218,7 +218,7 @@ class CommandTokenSendFrom(CommandBase):
         return False
 
     def command_desc(self):
-        p1 = ParameterDesc('token', 'token symbol name or script_hash')
+        p1 = ParameterDesc('token', 'token symbol or script hash')
         p2 = ParameterDesc('from_addr', 'address to send token from')
         p3 = ParameterDesc('to_addr', 'address to send token to')
         p4 = ParameterDesc('amount', 'number of tokens to send')
@@ -263,7 +263,7 @@ class CommandTokenHistory(CommandBase):
         return True
 
     def command_desc(self):
-        p1 = ParameterDesc('symbol', 'token symbol')
+        p1 = ParameterDesc('symbol', 'token symbol or script hash')
         return CommandDesc('history', 'show transaction history', [p1])
 
 
@@ -322,7 +322,7 @@ class CommandTokenApprove(CommandBase):
         return False
 
     def command_desc(self):
-        p1 = ParameterDesc('symbol', 'token symbol')
+        p1 = ParameterDesc('symbol', 'token symbol or script hash')
         p2 = ParameterDesc('from_addr', 'address to send token from')
         p3 = ParameterDesc('to_addr', 'address to send token to')
         p4 = ParameterDesc('amount', 'number of tokens to send')
@@ -367,7 +367,7 @@ class CommandTokenAllowance(CommandBase):
             return False
 
     def command_desc(self):
-        p1 = ParameterDesc('symbol', 'token symbol')
+        p1 = ParameterDesc('symbol', 'token symbol or script hash')
         p2 = ParameterDesc('from_addr', 'address to send token from')
         p3 = ParameterDesc('to_addr', 'address to send token to')
 
@@ -450,7 +450,7 @@ class CommandTokenMint(CommandBase):
         return False
 
     def command_desc(self):
-        p1 = ParameterDesc('symbol', 'token symbol')
+        p1 = ParameterDesc('symbol', 'token symbol or script hash')
         p2 = ParameterDesc('to_addr', 'address to mint tokens to')
         p3 = ParameterDesc('--attach-neo', 'amount of neo to attach to the transaction', optional=True)
         p4 = ParameterDesc('--attach-gas', 'amount of gas to attach to the transaction', optional=True)
@@ -500,9 +500,9 @@ class CommandTokenRegister(CommandBase):
         return False
 
     def command_desc(self):
-        p1 = ParameterDesc('symbol', 'token symbol')
-        p2 = ParameterDesc('addresses', 'space seperated list of addresses')
-        return CommandDesc('register', 'register for a crowdsale', [p1, p2])
+        p1 = ParameterDesc('symbol', 'token symbol  or script hash')
+        p2 = ParameterDesc('addresses', 'space separated list of NEO addresses')
+        return CommandDesc('register', 'register for a crowd sale', [p1, p2])
 
 
 def _validate_nep5_args(wallet, token_str, from_addr, to_addr, amount):
@@ -522,16 +522,10 @@ def _validate_nep5_args(wallet, token_str, from_addr, to_addr, amount):
     Returns:
         token (NEP5Token): instance
     """
-    token = None
-    for t in wallet.GetTokens().values():
-        if token_str == t.symbol:
-            token = t
-            break
-        elif token_str == t.ScriptHash.ToString():
-            token = t
-
-    if not isinstance(token, NEP5Token):
-        raise ValueError("The given token argument does not represent a known NEP5 token")
+    try:
+        token = PromptUtils.get_token(wallet, token_str)
+    except ValueError:
+        raise
 
     if not isValidPublicAddress(from_addr):
         raise ValueError("send_from is not a valid address")

--- a/neo/Prompt/Commands/WalletAddress.py
+++ b/neo/Prompt/Commands/WalletAddress.py
@@ -53,7 +53,7 @@ class CommandWalletCreateAddress(CommandBase):
         return CreateAddress(PromptData.Wallet, addresses_to_create)
 
     def command_desc(self):
-        p1 = ParameterDesc('number of addresses', 'number of addresses to create')
+        p1 = ParameterDesc('count', 'number of addresses to create')
         return CommandDesc('create', 'add an address to the wallet', params=[p1])
 
 
@@ -137,8 +137,8 @@ class CommandWalletSplit(CommandBase):
         p1 = ParameterDesc('address', 'address to split from')
         p2 = ParameterDesc('asset', 'type of asset to split (NEO/GAS)')
         p3 = ParameterDesc('unspent_index', 'index of the vin to split')
-        p4 = ParameterDesc('divisions', 'divide into number of vouts')
-        p5 = ParameterDesc('fee', 'optional fee', optional=True)
+        p4 = ParameterDesc('divisions', 'number of vouts to divide into ')
+        p5 = ParameterDesc('fee', 'fee to give your transaction priority (> 0.001) e.g. --fee=0.01', optional=True)
         return CommandDesc('split', 'split an asset unspent output into N outputs', params=[p1, p2, p3, p4, p5])
 
 
@@ -155,7 +155,7 @@ class CommandWalletAlias(CommandBase):
 
     def command_desc(self):
         p1 = ParameterDesc('address', 'address to create an alias for')
-        p2 = ParameterDesc('alias', 'alias to associate with the address')
+        p2 = ParameterDesc('alias', 'custom name to associate with the address')
         return CommandDesc('alias', 'create an alias for an address', params=[p1, p2])
 
 

--- a/neo/Prompt/Commands/WalletExport.py
+++ b/neo/Prompt/Commands/WalletExport.py
@@ -70,7 +70,7 @@ class CommandWalletExportNEP2(CommandBase):
         passphrase = prompt("[key password] ", is_password=True)
         len_pass = len(passphrase)
         if len_pass < 10:
-            print(f"Passphrase is too short, length: {len_pass}. Mininum length is 10")
+            print(f"Passphrase is too short, length: {len_pass}. Minimum length is 10")
             return False
 
         passphrase_confirm = prompt("[key password again] ", is_password=True)

--- a/neo/Prompt/Commands/WalletImport.py
+++ b/neo/Prompt/Commands/WalletImport.py
@@ -112,7 +112,7 @@ class CommandWalletImportNEP2(CommandBase):
             return False
 
     def command_desc(self):
-        p1 = ParameterDesc('private key', 'a NEP-2 protected private key')
+        p1 = ParameterDesc('private key', 'NEP-2 protected private key')
         return CommandDesc('nep2', 'import a passphrase protected private key record (NEP-2 format)', [p1])
 
 
@@ -143,7 +143,7 @@ class CommandWalletImportWatchAddr(CommandBase):
         return True
 
     def command_desc(self):
-        p1 = ParameterDesc('address', 'a public NEO address to watch')
+        p1 = ParameterDesc('address', 'public NEO address to watch')
         return CommandDesc('watch_addr', 'import a public address as watch only', [p1])
 
 
@@ -208,7 +208,7 @@ class CommandWalletImportMultisigAddr(CommandBase):
 
     def command_desc(self):
         p1 = ParameterDesc('own pub key', 'public key in your own wallet (use `wallet` to find the information)')
-        p2 = ParameterDesc('sign_cnt', 'the minimum number of signatures required for using the address (min is: 1)')
+        p2 = ParameterDesc('sign_cnt', 'minimum number of signatures required for using the address (min is: 1)')
         p3 = ParameterDesc('signing key n', 'all remaining signing public keys')
         return CommandDesc('multisig_addr', 'import a multi-signature address', [p1, p2, p3])
 
@@ -231,7 +231,7 @@ class CommandWalletImportToken(CommandBase):
         return ImportToken(PromptData.Wallet, contract_hash)
 
     def command_desc(self):
-        p1 = ParameterDesc('contract_hash', 'the token contract hash')
+        p1 = ParameterDesc('contract_hash', 'token script hash')
         return CommandDesc('token', 'import a token', [p1])
 
 
@@ -262,7 +262,7 @@ class CommandWalletImportContractAddr(CommandBase):
         return ImportContractAddr(wallet, contract_hash, pubkey_script_hash)
 
     def command_desc(self):
-        p1 = ParameterDesc('contract_hash', 'hash of the contract')
+        p1 = ParameterDesc('contract_hash', 'contract script hash')
         p2 = ParameterDesc('pubkey', 'pubkey of the contract')
         return CommandDesc('contract_addr', 'import a contract address', [p1, p2])
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- some parameter help descriptions used the form of `the <something>` and `a <something>` whereas others just stated `<something>`
- some descriptions had typo's, unnecessary long names, vague descriptions or inconsistent descriptions

**How did you solve this problem?**
streamline all the above to use the same format

**How did you make sure your solution works?**
n/a

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
