### PR TITLE
[refactor-prompt] restore theming support

### DIFF
--- a/neo/Prompt/CommandBase.py
+++ b/neo/Prompt/CommandBase.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from neo.Prompt.Utils import get_arg
 from typing import List
+from neo.Prompt.PromptPrinter import prompt_print as print
 
 
 class ParameterDesc():

--- a/neo/Prompt/Commands/BuildNRun.py
+++ b/neo/Prompt/Commands/BuildNRun.py
@@ -13,6 +13,7 @@ import traceback
 from neocore.BigInteger import BigInteger
 from neo.Settings import settings
 from neo.logging import log_manager
+from neo.Prompt.PromptPrinter import prompt_print as print
 
 logger = log_manager.getLogger()
 
@@ -77,7 +78,6 @@ def BuildAndRun(arguments, wallet, verbose=True, min_fee=DEFAULT_MIN_FEE, invoca
 def DoRun(contract_script, arguments, wallet, path, verbose=True,
           from_addr=None, min_fee=DEFAULT_MIN_FEE, invocation_test_mode=True,
           debug_map=None, invoke_attrs=None, owners=None):
-
     if not wallet:
         print("Please open a wallet to test build contract")
         return None, None, None, None

--- a/neo/Prompt/Commands/Config.py
+++ b/neo/Prompt/Commands/Config.py
@@ -4,6 +4,7 @@ from neo.Prompt.CommandBase import CommandBase, CommandDesc, ParameterDesc
 from neo.Prompt.Utils import get_arg
 from neo.Settings import settings
 from neo.Network.NodeLeader import NodeLeader
+from neo.Prompt.PromptPrinter import prompt_print as print
 from distutils import util
 import logging
 

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -34,6 +34,7 @@ from neo.EventHub import events
 from prompt_toolkit import prompt
 from copy import deepcopy
 from neo.logging import log_manager
+from neo.Prompt.PromptPrinter import prompt_print as print
 
 logger = log_manager.getLogger()
 

--- a/neo/Prompt/Commands/LoadSmartContract.py
+++ b/neo/Prompt/Commands/LoadSmartContract.py
@@ -9,6 +9,7 @@ from neo.VM.ScriptBuilder import ScriptBuilder
 from neo.Core.Blockchain import Blockchain
 from neo.SmartContract.Contract import Contract
 from neocore.BigInteger import BigInteger
+from neo.Prompt.PromptPrinter import prompt_print as print
 
 
 def ImportContractAddr(wallet, contract_hash, pubkey_script_hash):

--- a/neo/Prompt/Commands/SC.py
+++ b/neo/Prompt/Commands/SC.py
@@ -13,7 +13,7 @@ from neocore.Fixed8 import Fixed8
 from neo.Implementations.Blockchains.LevelDB.DebugStorage import DebugStorage
 from distutils import util
 from neo.Settings import settings
-
+from neo.Prompt.PromptPrinter import prompt_print as print
 from neo.logging import log_manager
 
 logger = log_manager.getLogger()

--- a/neo/Prompt/Commands/Search.py
+++ b/neo/Prompt/Commands/Search.py
@@ -3,6 +3,7 @@ from neo.Prompt.PromptData import PromptData
 from neo.Prompt.Utils import get_arg
 from neo.Core.Blockchain import Blockchain
 from neo.logging import log_manager
+from neo.Prompt.PromptPrinter import prompt_print as print
 import json
 
 logger = log_manager.getLogger()

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -14,6 +14,7 @@ import traceback
 from neo.Prompt.PromptData import PromptData
 from neo.Prompt.CommandBase import CommandBase, CommandDesc, ParameterDesc
 from logzero import logger
+from neo.Prompt.PromptPrinter import prompt_print as print
 
 
 class CommandWalletSend(CommandBase):

--- a/neo/Prompt/Commands/Show.py
+++ b/neo/Prompt/Commands/Show.py
@@ -11,6 +11,7 @@ from neo.IO.MemoryStream import StreamManager
 from neo.Network.NodeLeader import NodeLeader
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
 from neo.logging import log_manager
+from neo.Prompt.PromptPrinter import prompt_print as print
 import json
 
 logger = log_manager.getLogger()

--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -16,7 +16,7 @@ from neocore.Utils import isValidPublicAddress
 from distutils.util import strtobool
 import peewee
 import traceback
-
+from neo.Prompt.PromptPrinter import prompt_print as print
 from neo.logging import log_manager
 
 logger = log_manager.getLogger()

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -21,6 +21,7 @@ from neo.Prompt.Commands.WalletImport import CommandWalletImport
 from neo.Prompt.Commands.WalletExport import CommandWalletExport
 from neo.logging import log_manager
 from neocore.Utils import isValidPublicAddress
+from neo.Prompt.PromptPrinter import prompt_print as print
 
 logger = log_manager.getLogger()
 

--- a/neo/Prompt/Commands/WalletAddress.py
+++ b/neo/Prompt/Commands/WalletAddress.py
@@ -11,6 +11,7 @@ from prompt_toolkit import prompt
 from neo.Core.Blockchain import Blockchain
 from neo.Core.TX.Transaction import ContractTransaction
 from neo.Core.TX.Transaction import TransactionOutput
+from neo.Prompt.PromptPrinter import prompt_print as print
 
 
 class CommandWalletAddress(CommandBase):

--- a/neo/Prompt/Commands/WalletExport.py
+++ b/neo/Prompt/Commands/WalletExport.py
@@ -2,6 +2,7 @@ from neo.Prompt.CommandBase import CommandBase, CommandDesc, ParameterDesc
 from neo.Prompt import Utils as PromptUtils
 from neo.Prompt.PromptData import PromptData
 from prompt_toolkit import prompt
+from neo.Prompt.PromptPrinter import prompt_print as print
 
 
 class CommandWalletExport(CommandBase):

--- a/neo/Prompt/Commands/WalletImport.py
+++ b/neo/Prompt/Commands/WalletImport.py
@@ -12,6 +12,7 @@ from neocore.Cryptography.Crypto import Crypto
 from neo.SmartContract.Contract import Contract
 from neo.Core.Blockchain import Blockchain
 from neo.Wallets import NEP5Token
+from neo.Prompt.PromptPrinter import prompt_print as print
 
 
 class CommandWalletImport(CommandBase):

--- a/neo/Prompt/Commands/tests/test_claim_command.py
+++ b/neo/Prompt/Commands/tests/test_claim_command.py
@@ -6,6 +6,7 @@ from neocore.UInt160 import UInt160
 from neo.Prompt.Commands.Wallet import ClaimGas
 from neocore.Fixed8 import Fixed8
 from neo.Core.TX.ClaimTransaction import ClaimTransaction
+from neo.Prompt.PromptPrinter import pp
 import shutil
 
 
@@ -27,6 +28,17 @@ class UserWalletTestCase(WalletFixtureTestCase):
     _wallet2 = None
 
     _wallet3 = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # replace the prompt_toolkit formatted print function with the default such that we can test easily
+        pp.printer = print
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        pp.reset_printer()
 
     @property
     def GAS(self):

--- a/neo/Prompt/Commands/tests/test_config_commands.py
+++ b/neo/Prompt/Commands/tests/test_config_commands.py
@@ -36,7 +36,7 @@ class CommandConfigTestCase(BlockchainFixtureTestCase):
         self.assertFalse(res)
 
     def test_config_output(self):
-        # importing because it setups `peewee` logging, which is checked at the test below
+        # importing because it sets up `peewee` logging, which is checked at the test below
         from neo.Implementations.Wallets.peewee.UserWallet import UserWallet
 
         args = ['output']

--- a/neo/Prompt/Commands/tests/test_config_commands.py
+++ b/neo/Prompt/Commands/tests/test_config_commands.py
@@ -6,9 +6,20 @@ from copy import deepcopy
 from neo.Network.NodeLeader import NodeLeader
 from mock import patch
 from io import StringIO
+from neo.Prompt.PromptPrinter import pp
 
 
 class CommandConfigTestCase(BlockchainFixtureTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # replace the prompt_toolkit formatted print function with the default such that we can test easily
+        pp.printer = print
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        pp.reset_printer()
 
     @classmethod
     def leveldb_testpath(self):
@@ -25,6 +36,9 @@ class CommandConfigTestCase(BlockchainFixtureTestCase):
         self.assertFalse(res)
 
     def test_config_output(self):
+        # importing because it setups `peewee` logging, which is checked at the test below
+        from neo.Implementations.Wallets.peewee.UserWallet import UserWallet
+
         args = ['output']
         with patch('neo.Prompt.Commands.Config.prompt', side_effect=[1, 1, 1, "\n", "\n"]):  # tests changing the level and keeping the current level
             res = CommandConfig().execute(args)

--- a/neo/Prompt/Commands/tests/test_output_config.py
+++ b/neo/Prompt/Commands/tests/test_output_config.py
@@ -2,11 +2,22 @@ from neo.logging import log_manager
 from neo.Prompt.Commands.Config import start_output_config
 from mock import patch
 from neo.Utils.NeoTestCase import NeoTestCase
+from neo.Prompt.PromptPrinter import pp
 import logging
 import io
 
 
 class TestOutputConfig(NeoTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # replace the prompt_toolkit formatted print function with the default such that we can test easily by patching sys.stdout
+        pp.printer = print
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        pp.reset_printer()
 
     @patch('sys.stdout', new_callable=io.StringIO)
     @patch('neo.Prompt.Commands.Config.log_manager.config_stdio')

--- a/neo/Prompt/Commands/tests/test_sc_commands.py
+++ b/neo/Prompt/Commands/tests/test_sc_commands.py
@@ -11,6 +11,7 @@ from mock import patch
 from io import StringIO
 from boa.compiler import Compiler
 from neo.Settings import settings
+from neo.Prompt.PromptPrinter import pp
 
 
 class CommandSCTestCase(WalletFixtureTestCase):
@@ -22,6 +23,17 @@ class CommandSCTestCase(WalletFixtureTestCase):
     watch_addr_str = 'AGYaEi3W6ndHPUmW7T12FFfsbQ6DWymkEm'
     _wallet1 = None
     _wallet3 = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # replace the prompt_toolkit formatted print function with the default such that we can test easily
+        pp.printer = print
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        pp.reset_printer()
 
     @classmethod
     def GetWallet1(cls, recreate=False):

--- a/neo/Prompt/Commands/tests/test_search_commands.py
+++ b/neo/Prompt/Commands/tests/test_search_commands.py
@@ -4,9 +4,21 @@ from neo.Utils.BlockchainFixtureTestCase import BlockchainFixtureTestCase
 from neo.Prompt.Commands.Search import CommandSearch
 from mock import patch
 from io import StringIO
+from neo.Prompt.PromptPrinter import pp
 
 
 class CommandShowTestCase(BlockchainFixtureTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # replace the prompt_toolkit formatted print function with the default such that we can test easily
+        pp.printer = print
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        pp.reset_printer()
 
     @classmethod
     def leveldb_testpath(self):

--- a/neo/Prompt/Commands/tests/test_send_command.py
+++ b/neo/Prompt/Commands/tests/test_send_command.py
@@ -11,6 +11,7 @@ import shutil
 from mock import patch
 import json
 from io import StringIO
+from neo.Prompt.PromptPrinter import pp
 
 
 class UserWalletTestCase(WalletFixtureTestCase):
@@ -41,6 +42,17 @@ class UserWalletTestCase(WalletFixtureTestCase):
     @classmethod
     def tearDown(cls):
         PromptData.Wallet = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # replace the prompt_toolkit formatted print function with the default such that we can test easily
+        pp.printer = print
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        pp.reset_printer()
 
     def test_send_neo(self):
         with patch('neo.Prompt.Commands.Send.prompt', side_effect=[UserWalletTestCase.wallet_1_pass()]):

--- a/neo/Prompt/Commands/tests/test_show_commands.py
+++ b/neo/Prompt/Commands/tests/test_show_commands.py
@@ -4,6 +4,7 @@ from neo.Utils.BlockchainFixtureTestCase import BlockchainFixtureTestCase
 from neo.Prompt.Commands.Show import CommandShow
 from neo.Prompt.Commands.Wallet import CommandWallet
 from neo.Prompt.PromptData import PromptData
+from neo.Prompt.PromptPrinter import pp
 from neo.bin.prompt import PromptInterface
 from copy import deepcopy
 from neo.Network.NodeLeader import NodeLeader, NeoNode
@@ -13,6 +14,16 @@ from mock import patch
 
 
 class CommandShowTestCase(BlockchainFixtureTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # replace the prompt_toolkit formatted print function with the default such that we can test easily
+        pp.printer = print
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        pp.reset_printer()
 
     @classmethod
     def leveldb_testpath(self):

--- a/neo/Prompt/Commands/tests/test_token_commands.py
+++ b/neo/Prompt/Commands/tests/test_token_commands.py
@@ -15,6 +15,7 @@ from neo.Prompt.PromptData import PromptData
 from contextlib import contextmanager
 from io import StringIO
 from neo.VM.InteropService import StackItem
+from neo.Prompt.PromptPrinter import pp
 
 
 class UserWalletTestCase(WalletFixtureTestCase):
@@ -33,6 +34,17 @@ class UserWalletTestCase(WalletFixtureTestCase):
     _wallet3 = None
 
     token_hash_str = '31730cc9a1844891a3bafd1aa929a4142860d8d3'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # replace the prompt_toolkit formatted print function with the default such that we can test easily
+        pp.printer = print
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        pp.reset_printer()
 
     @property
     def GAS(self):
@@ -783,6 +795,17 @@ class TokenSendFromTestCase(WalletFixtureTestCase):
     """
     watch_addr_str = 'AGYaEi3W6ndHPUmW7T12FFfsbQ6DWymkEm'
     wallet_1_addr = 'AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3'
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # replace the prompt_toolkit formatted print function with the default such that we can test easily
+        pp.printer = print
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        pp.reset_printer()
 
     @contextmanager
     def OpenWallet1(self):

--- a/neo/Prompt/Commands/tests/test_wallet_commands.py
+++ b/neo/Prompt/Commands/tests/test_wallet_commands.py
@@ -7,6 +7,7 @@ from neo.Core.TX.ClaimTransaction import ClaimTransaction
 from neo.Prompt.Commands.Wallet import CommandWallet
 from neo.Prompt.Commands.Wallet import ShowUnspentCoins
 from neo.Prompt.PromptData import PromptData
+from neo.Prompt.PromptPrinter import pp
 import os
 import shutil
 from mock import patch
@@ -61,9 +62,19 @@ class UserWalletTestCaseBase(WalletFixtureTestCase):
     def tearDown(cls):
         PromptData.Wallet = None
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # replace the prompt_toolkit formatted print function with the default such that we can test easily
+        pp.printer = print
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+        pp.reset_printer()
+
 
 class UserWalletTestCase(UserWalletTestCaseBase):
-
     # Beginning with refactored tests
     def test_wallet(self):
         # without wallet opened

--- a/neo/Prompt/PromptPrinter.py
+++ b/neo/Prompt/PromptPrinter.py
@@ -1,0 +1,40 @@
+from prompt_toolkit import print_formatted_text
+from prompt_toolkit.formatted_text import FormattedText
+from prompt_toolkit.styles import Style
+from neo.UserPreferences import preferences
+
+token_style = Style.from_dict({
+    "command": preferences.token_style['Command'],
+    "neo": preferences.token_style['Neo'],
+    "default": preferences.token_style['Default'],
+    "number": preferences.token_style['Number'],
+})
+
+
+class PromptPrinter():
+    def __init__(self):
+        self.printer = self._internal_prompt_print
+
+    def reset_printer(self):
+        self.printer = self._internal_prompt_print
+
+    def _internal_prompt_print(self, *args, **kwargs):
+        kwargs['style'] = token_style
+        frags = []
+        for a in args:
+            if isinstance(a, FormattedText):
+                frags.append(a)
+            else:
+                frags.append(FormattedText([("class:command", a)]))
+
+        print_formatted_text(*frags, **kwargs)
+
+    def print(self, *args, **kwargs):
+        self.printer(*args, **kwargs)
+
+
+pp = PromptPrinter()
+
+
+def prompt_print(*args, **kwargs):
+    pp.print(*args, **kwargs)

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -11,8 +11,8 @@ from decimal import Decimal
 from prompt_toolkit.shortcuts import PromptSession
 from neo.logging import log_manager
 from neo.Wallets import NEP5Token
-from typing import TYPE_CHECKING
 from neocore.Cryptography.Crypto import Crypto
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from neo.Wallets.Wallet import Wallet

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -8,7 +8,6 @@ from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.shortcuts import print_formatted_text, PromptSession
 from prompt_toolkit.formatted_text import FormattedText
-from prompt_toolkit.styles import Style
 from twisted.internet import reactor, task
 from neo import __version__
 from neo.Core.Blockchain import Blockchain
@@ -25,6 +24,7 @@ from neo.Prompt.InputParser import InputParser
 from neo.Settings import settings, PrivnetConnectionError
 from neo.UserPreferences import preferences
 from neo.logging import log_manager
+from neo.Prompt.PromptPrinter import prompt_print, token_style
 
 logger = log_manager.getLogger()
 
@@ -81,7 +81,6 @@ class PromptInterface:
 
     commands = {command.command_desc().command: command for command in _commands}
 
-    token_style = None
     start_height = None
     start_dt = None
 
@@ -93,13 +92,6 @@ class PromptInterface:
         self.input_parser = InputParser()
         self.start_height = Blockchain.Default().Height
         self.start_dt = datetime.datetime.utcnow()
-
-        self.token_style = Style.from_dict({
-            "command": preferences.token_style['Command'],
-            "neo": preferences.token_style['Neo'],
-            "default": preferences.token_style['Default'],
-            "number": preferences.token_style['Number'],
-        })
 
     def get_bottom_toolbar(self, cli=None):
         out = []
@@ -140,11 +132,11 @@ class PromptInterface:
         reactor.stop()
 
     def help(self):
-        print(f"\nCommands:")
+        prompt_print(f"\nCommands:")
         for command_group in sorted(self.commands.keys()):
             command = self.commands[command_group]
-            print(f"   {command_group:<15} - {command.command_desc().short_help}")
-        print(f"\nRun 'COMMAND help' for more information on a command.")
+            prompt_print(f"   {command_group:<15} - {command.command_desc().short_help}")
+        prompt_print(f"\nRun 'COMMAND help' for more information on a command.")
 
     def start_wallet_loop(self):
         if self.wallet_loop_deferred:
@@ -170,7 +162,7 @@ class PromptInterface:
         tokens = [("class:neo", 'NEO'), ("class:default", ' cli. Type '),
                   ("class:command", '\'help\' '), ("class:default", 'to get started')]
 
-        print_formatted_text(FormattedText(tokens), style=self.token_style)
+        print_formatted_text(FormattedText(tokens), style=token_style)
 
         print('\n')
 
@@ -180,7 +172,7 @@ class PromptInterface:
                                     completer=self.get_completer(),
                                     history=self.history,
                                     bottom_toolbar=self.get_bottom_toolbar,
-                                    style=self.token_style,
+                                    style=token_style,
                                     refresh_interval=3,
                                     )
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
resolve the following todo of #623 
> after the previous item, make sure console themes still work. This requires "Format Tokens" from the prompt_toolkit package, but it should only be applied when used in the CLI. Meaning; the business logic should not be coupled to a PromptInterface() instance because that's the one who creates the theme tokens. solution idea: supply print function as param.

**How did you solve this problem?**
replace built-in print with `prompt_print` in the classes below `Commands` as follows:
```
from neo.Prompt.PromptPrinter import prompt_print as print
```
This was the most straight forward way to replace all `print` calls in command code. One advantage is that we can easily swap out the `print` call for something custom. One place we do this is for testing where we swap out the `prompt_toolkit.print_formatted_text` with the buildint `print` such that all our `patch('sys.stdout')` in test-cases still work.

In the old prompt some part of the command execution would be themed (e.g. red coloured) whereas others not because they used regular prints. Now everything related to a command response is printed themed.

**How did you make sure your solution works?**
make test and some manual testing

**Are there any special changes in the code that we should be aware of?**
see the "how solved" section. 

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
