### PR TITLE
[refactor-prompt] update export cmds with password checking

### DIFF
--- a/neo/Prompt/Commands/WalletExport.py
+++ b/neo/Prompt/Commands/WalletExport.py
@@ -43,6 +43,10 @@ class CommandWalletExportWIF(CommandBase):
         keys = wallet.GetKeys()
         for key in keys:
             if key.GetAddress() == address:
+                passwd = prompt("[wallet password]> ", is_password=True)
+                if not wallet.ValidatePassword(passwd):
+                    return print("Incorrect password")
+
                 print(f"WIF: {key.Export()}")
                 return True
         else:
@@ -82,6 +86,10 @@ class CommandWalletExportNEP2(CommandBase):
         keys = wallet.GetKeys()
         for key in keys:
             if key.GetAddress() == address:
+                passwd = prompt("[wallet password]> ", is_password=True)
+                if not wallet.ValidatePassword(passwd):
+                    return print("Incorrect password")
+
                 print(f"NEP2: {key.ExportNEP2(passphrase)}")
                 return True
         else:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
In https://github.com/CityOfZion/neo-python/pull/780 (and another PR) we discussed if we should be prompted for the wallet password before we can send funds. The question has been posted on slack and after some thought I think that at least from the cli it should be asked for. Currently for exporting keys this is not asked

**How did you solve this problem?**
This PR introduces wallet password checking before exporting the key 

**How did you make sure your solution works?**
tests

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
