### PR TITLE
[refactor-prompt] enforce pw prompt send

### DIFF
--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -13,7 +13,6 @@ from neo.Implementations.Wallets.peewee.Models import NEP5Token as ModelNEP5Toke
 from neo.Implementations.Notifications.LevelDB.NotificationDB import NotificationDB
 from neo.Core.TX.TransactionAttribute import TransactionAttributeUsage
 from neocore.Utils import isValidPublicAddress
-from distutils.util import strtobool
 import peewee
 import traceback
 

--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -154,13 +154,8 @@ class CommandTokenSendFrom(CommandBase):
     def execute(self, arguments):
         wallet = PromptData.Wallet
 
-        if len(arguments) < 4:
+        if len(arguments) != 4:
             print("Please specify the required parameters")
-            return False
-
-        if len(arguments) > 5:
-            # the 5th argument is prompting for a password before sending,
-            print("Too many parameters supplied. Please check your command")
             return False
 
         token_str = arguments[0]
@@ -172,14 +167,6 @@ class CommandTokenSendFrom(CommandBase):
         except ValueError:
             print(f"{arguments[3]} is not a valid amount")
             return False
-
-        prompt_passwd = True
-        if len(arguments) == 5:
-            try:
-                prompt_passwd = bool(strtobool(arguments[4]))
-            except ValueError:
-                print("Invalid value for showing prompt parameter. Must be True or False if supplied")
-                return False
 
         try:
             token, tx, fee, results = test_token_send_from(wallet, token_str, from_addr, to_addr, amount)
@@ -202,12 +189,10 @@ class CommandTokenSendFrom(CommandBase):
                 print("Transfer fee: %s " % (fee.value / Fixed8.D))
                 print("-------------------------------------------------------------\n")
 
-                if prompt_passwd:
-                    passwd = prompt("[Password]> ", is_password=True)
-
-                    if not wallet.ValidatePassword(passwd):
-                        print("incorrect password")
-                        return False
+                passwd = prompt("[Password]> ", is_password=True)
+                if not wallet.ValidatePassword(passwd):
+                    print("incorrect password")
+                    return False
 
                 return InvokeContract(wallet, tx, fee)
 
@@ -222,9 +207,8 @@ class CommandTokenSendFrom(CommandBase):
         p2 = ParameterDesc('from_addr', 'address to send token from')
         p3 = ParameterDesc('to_addr', 'address to send token to')
         p4 = ParameterDesc('amount', 'number of tokens to send')
-        p5 = ParameterDesc('ask_for_passw', 'prompt for a password before sending to the actual network. Default is True', optional=True)
 
-        return CommandDesc('sendfrom', 'send a token on behalf of another account (requires approval)', [p1, p2, p3, p4, p5])
+        return CommandDesc('sendfrom', 'send a token on behalf of another account (requires approval)', [p1, p2, p3, p4])
 
 
 class CommandTokenHistory(CommandBase):
@@ -275,7 +259,7 @@ class CommandTokenApprove(CommandBase):
     def execute(self, arguments):
         wallet = PromptData.Wallet
 
-        if not len(arguments) in [4, 5]:
+        if len(arguments) != 4:
             print("Please specify the required parameters")
             return False
 
@@ -283,14 +267,6 @@ class CommandTokenApprove(CommandBase):
         from_addr = arguments[1]
         to_addr = arguments[2]
         amount = arguments[3]
-
-        prompt_passwd = True
-        if len(arguments) == 5:
-            try:
-                prompt_passwd = bool(strtobool(arguments[4]))
-            except ValueError:
-                print("Invalid value for showing prompt parameter. Must be True or False if supplied")
-                return False
 
         try:
             token = _validate_nep5_args(wallet, token_str, from_addr, to_addr, amount)
@@ -309,12 +285,11 @@ class CommandTokenApprove(CommandBase):
                 print(f"Transfer fee: {fee.value / Fixed8.D}")
                 print("-------------------------------------------------------------\n")
 
-                if prompt_passwd:
-                    passwd = prompt("[Password]> ", is_password=True)
+                passwd = prompt("[Password]> ", is_password=True)
 
-                    if not wallet.ValidatePassword(passwd):
-                        print("incorrect password")
-                        return False
+                if not wallet.ValidatePassword(passwd):
+                    print("incorrect password")
+                    return False
 
                 return InvokeContract(wallet, tx, fee)
 
@@ -326,9 +301,8 @@ class CommandTokenApprove(CommandBase):
         p2 = ParameterDesc('from_addr', 'address to send token from')
         p3 = ParameterDesc('to_addr', 'address to send token to')
         p4 = ParameterDesc('amount', 'number of tokens to send')
-        p5 = ParameterDesc('ask_for_passw', 'prompt for a password before sending to the actual network. Default is True', optional=True)
 
-        return CommandDesc('approve', 'approve an allowance', [p1, p2, p3, p4, p5])
+        return CommandDesc('approve', 'approve an allowance', [p1, p2, p3, p4])
 
     def handle_help(self, arguments):
         super().handle_help(arguments)
@@ -404,7 +378,6 @@ class CommandTokenMint(CommandBase):
 
         remaining_args = arguments[2:]
         asset_attachments = []
-        prompt_passwd = True
         for optional in remaining_args:
             _, neo_to_attach, gas_to_attach = PromptUtils.get_asset_attachments([optional])
 
@@ -422,12 +395,6 @@ class CommandTokenMint(CommandBase):
                 else:
                     asset_attachments.append(optional)
 
-            # finally assume optional is "prompt pw"
-            try:
-                prompt_passwd = bool(strtobool(optional))
-            except ValueError:
-                pass
-
         tx, fee, results = token.Mint(wallet, to_addr, asset_attachments)
 
         if tx and results:
@@ -437,12 +404,11 @@ class CommandTokenMint(CommandBase):
                 print(f"Fee: {fee.value / Fixed8.D}")
                 print("-------------------------------------------------------------\n")
 
-                if prompt_passwd:
-                    passwd = prompt("[Password]> ", is_password=True)
+                passwd = prompt("[Password]> ", is_password=True)
 
-                    if not wallet.ValidatePassword(passwd):
-                        print("incorrect password")
-                        return False
+                if not wallet.ValidatePassword(passwd):
+                    print("incorrect password")
+                    return False
 
                 return InvokeWithTokenVerificationScript(wallet, tx, token, fee)
 
@@ -454,8 +420,7 @@ class CommandTokenMint(CommandBase):
         p2 = ParameterDesc('to_addr', 'address to mint tokens to')
         p3 = ParameterDesc('--attach-neo', 'amount of neo to attach to the transaction', optional=True)
         p4 = ParameterDesc('--attach-gas', 'amount of gas to attach to the transaction', optional=True)
-        p5 = ParameterDesc('ask_for_passw', 'prompt for a password before sending to the actual network. Default is True', optional=True)
-        return CommandDesc('mint', 'mint tokens from a contract', [p1, p2, p3, p4, p5])
+        return CommandDesc('mint', 'mint tokens from a contract', [p1, p2, p3, p4])
 
 
 class CommandTokenRegister(CommandBase):


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
In #780 (and another PR) we discussed if we should be prompted for the wallet password before we can send funds. The question has been posted on slack and after some thought I think that at least from the cli it should be asked for. 

Previously we could bypass it using a `--ask_for_pw` type of flag. While the logic remains in some parts of the code (so people can programmatically choose), from the CLI it is no longer possible to bypass for security reasons.

**How did you solve this problem?**
remove optional arg to bypass

**How did you make sure your solution works?**
make test

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
