### PR TITLE
[refactor-prompt] fix exception in specific help case 

### DIFF
--- a/neo/Prompt/CommandBase.py
+++ b/neo/Prompt/CommandBase.py
@@ -112,10 +112,11 @@ class CommandBase(ABC):
             params += f"{p.formatted_name()} "
         print(f"\nUsage: {self.__command_with_parents()} {params}\n")
 
-        min_indent = 15
-        longest_param_name = max(min_indent, max(len(p.name) for p in self.command_desc().params))
-        for p in self.command_desc().params:
-            print(p.to_str(longest_param_name))
+        if len(self.command_desc().params) > 0:
+            min_indent = 15
+            longest_param_name = max(min_indent, max(len(p.name) for p in self.command_desc().params))
+            for p in self.command_desc().params:
+                print(p.to_str(longest_param_name))
 
     def __command_with_parents(self):
         s = self.command_desc().command


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
@jseagrave21 pointed out a problem with `show state help` here: https://github.com/CityOfZion/neo-python/pull/788#pullrequestreview-189586441

**How did you solve this problem?**
Test for available params before attempting to print them (where a `max()` received an empty input)

**How did you make sure your solution works?**
manual testing on the console

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
