### PR TITLE
[refactor-prompt] polish and clarify insufficient funds reason

### DIFF
--- a/neo/Implementations/Wallets/peewee/test_user_wallet.py
+++ b/neo/Implementations/Wallets/peewee/test_user_wallet.py
@@ -193,7 +193,10 @@ class UserWalletTestCase(WalletFixtureTestCase):
         tx = ContractTransaction()
         tx.outputs = [TransactionOutput(Blockchain.SystemShare().Hash, Fixed8.FromDecimal(10.0), self.import_watch_addr)]
 
-        tx = wallet.MakeTransaction(tx)
+        try:
+            tx = wallet.MakeTransaction(tx)
+        except ValueError:
+            pass
 
         cpc = ContractParametersContext(tx)
         wallet.Sign(cpc)

--- a/neo/Network/test_node_leader.py
+++ b/neo/Network/test_node_leader.py
@@ -179,7 +179,10 @@ class LeaderTestCase(WalletFixtureTestCase):
         output = TransactionOutput(AssetId=Blockchain.SystemShare().Hash, Value=amount,
                                    script_hash=LeaderTestCase.wallet_1_script_hash)
         contract_tx = ContractTransaction(outputs=[output])
-        wallet.MakeTransaction(contract_tx)
+        try:
+            wallet.MakeTransaction(contract_tx)
+        except ValueError:
+            pass
         ctx = ContractParametersContext(contract_tx)
         wallet.Sign(ctx)
         contract_tx.scripts = ctx.GetScripts()

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -48,7 +48,11 @@ def InvokeContract(wallet, tx, fee=Fixed8.Zero(), from_addr=None, owners=None):
     if from_addr is not None:
         from_addr = PromptUtils.lookup_addr_str(wallet, from_addr)
 
-    wallet_tx = wallet.MakeTransaction(tx=tx, fee=fee, use_standard=True, from_addr=from_addr)
+    try:
+        wallet_tx = wallet.MakeTransaction(tx=tx, fee=fee, use_standard=True, from_addr=from_addr)
+    except ValueError:
+        print("Insufficient funds")
+        return False
 
     if wallet_tx:
 
@@ -92,7 +96,11 @@ def InvokeContract(wallet, tx, fee=Fixed8.Zero(), from_addr=None, owners=None):
 
 
 def InvokeWithTokenVerificationScript(wallet, tx, token, fee=Fixed8.Zero(), invoke_attrs=None):
-    wallet_tx = wallet.MakeTransaction(tx=tx, fee=fee, use_standard=True)
+    try:
+        wallet_tx = wallet.MakeTransaction(tx=tx, fee=fee, use_standard=True)
+    except ValueError:
+        print("Insufficient funds")
+        return False
 
     if wallet_tx:
 
@@ -299,7 +307,10 @@ def test_invoke(script, wallet, outputs, withdrawal_tx=None,
     if withdrawal_tx is not None:
         wallet_tx = tx
     else:
-        wallet_tx = wallet.MakeTransaction(tx=tx, from_addr=from_addr)
+        try:
+            wallet_tx = wallet.MakeTransaction(tx=tx, from_addr=from_addr)
+        except ValueError:
+            pass
 
     context = ContractParametersContext(wallet_tx)
     wallet.Sign(context)
@@ -407,7 +418,11 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet,
     if from_addr is not None:
         from_addr = PromptUtils.lookup_addr_str(wallet, from_addr)
 
-    dtx = wallet.MakeTransaction(tx=dtx, from_addr=from_addr)
+    try:
+        dtx = wallet.MakeTransaction(tx=dtx, from_addr=from_addr)
+    except ValueError:
+        pass
+
     context = ContractParametersContext(dtx)
     wallet.Sign(context)
     dtx.scripts = context.GetScripts()
@@ -526,7 +541,10 @@ def test_deploy_and_invoke(deploy_script, invoke_args, wallet,
                                                        data=contract.ScriptHash))
             itx.Attributes = make_unique_script_attr(itx.Attributes)
 
-        itx = wallet.MakeTransaction(tx=itx, from_addr=from_addr)
+        try:
+            itx = wallet.MakeTransaction(tx=itx, from_addr=from_addr)
+        except ValueError:
+            pass
 
         context = ContractParametersContext(itx)
         wallet.Sign(context)

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -228,11 +228,17 @@ def process_transaction(wallet, contract_tx, scripthash_from=None, scripthash_ch
                                     change_address=scripthash_change,
                                     fee=fee,
                                     from_addr=scripthash_from)
+    except ValueError:
+        print("Insufficient funds. No unspent outputs available for building the transaction.\n"
+              "If you are trying to sent multiple transactions in 1 block, then make sure you have enough 'vouts'\n."
+              "Use `wallet unspent` and `wallet address split`, or wait until the first transaction is processed before sending another.")
+        return None
 
-        if tx is None:
-            logger.debug("insufficient funds")
-            return None
+    if tx is None:
+        logger.debug("insufficient funds")
+        return None
 
+    try:
         # password prompt
         passwd = prompt("[Password]> ", is_password=True)
         if not wallet.ValidatePassword(passwd):

--- a/neo/Prompt/Commands/tests/test_send_command.py
+++ b/neo/Prompt/Commands/tests/test_send_command.py
@@ -304,13 +304,13 @@ class UserWalletTestCase(WalletFixtureTestCase):
     def test_could_not_send(self):
         # mocking traceback module to avoid stacktrace printing during test run
         with patch('neo.Prompt.Commands.Send.traceback'):
-            PromptData.Wallet = self.GetWallet1(recreate=True)
-            args = ['send', 'gas', self.watch_addr_str, '2']
+            with patch('neo.Prompt.Commands.Send.prompt', side_effect=[UserWalletTestCase.wallet_1_pass()]):
+                with patch('neo.Wallets.Wallet.Wallet.GetStandardAddress', side_effect=[Exception]):
+                    PromptData.Wallet = self.GetWallet1(recreate=True)
+                    args = ['send', 'gas', self.watch_addr_str, '2']
+                    res = Wallet.CommandWallet().execute(args)
 
-            with patch('neo.Wallets.Wallet.Wallet.MakeTransaction', side_effect=[Exception]):
-                res = Wallet.CommandWallet().execute(args)
-
-                self.assertFalse(res)
+                    self.assertFalse(res)
 
     def test_sendmany_good_simple(self):
         with patch('neo.Prompt.Commands.Send.prompt',

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -1068,8 +1068,7 @@ class Wallet:
                     return None
 
                 else:
-                    logger.error("insufficient funds for asset id: %s " % key)
-                    return None
+                    raise ValueError(f"insufficient funds for asset id: {key}")
 
         input_sums = {}
 
@@ -1183,7 +1182,8 @@ class Wallet:
 
             contract = self.GetContract(hash)
             if contract is None:
-                logger.info(f"Cannot find key belonging to script_hash {hash}. Make sure the source address you're trying to sign the transaction for is imported in the wallet.")
+                logger.info(
+                    f"Cannot find key belonging to script_hash {hash}. Make sure the source address you're trying to sign the transaction for is imported in the wallet.")
                 continue
 
             key = self.GetKeyByScriptHash(hash)

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -545,11 +545,17 @@ class JsonRpcApi:
         standard_contract = self.wallet.GetStandardAddress()
         signer_contract = self.wallet.GetContract(standard_contract)
 
-        tx = self.wallet.MakeTransaction(tx=contract_tx,
-                                         change_address=change_addr,
-                                         fee=fee,
-                                         from_addr=address_from)
+        try:
+            tx = self.wallet.MakeTransaction(tx=contract_tx,
+                                             change_address=change_addr,
+                                             fee=fee,
+                                             from_addr=address_from)
+        except ValueError:
+            # if not enough unspents while fully synced
+            raise JsonRpcError(-300, "Insufficient funds")
+
         if tx is None:
+            # if not enough unspents while not being fully synced
             raise JsonRpcError(-300, "Insufficient funds")
         data = standard_contract.Data
         tx.Attributes = [


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Currently whenever you try to send assets with insufficient funds you get the following output
```
neo> wallet send NEO AG4Z3kNtdQxDvdCPYyht1Mq8ntdi7uHuvy 25
[E 190105 12:16:44 Wallet:1071] insufficient funds for asset id: c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b
[D 190105 12:16:44 Send:233] insufficient funds
neo>
```
A double error message, and also one that doesn't always clearly identify the real reason. The above account had more than enough funds, but not enough `vouts`
 
**How did you solve this problem?**
Changed the error handling of `MakeTransaction` such that we can differentiate the root cause. The above scenario now shows
```
neo> wallet send NEO AG4Z3kNtdQxDvdCPYyht1Mq8ntdi7uHuvy 25
[Password]> **********
[I 190105 13:32:00 Transaction:619] Verifying transaction: b'73d8a0106e8c2b9f2a4d6a7733fe57a534ec5968ba3d6ba67dffb253cb21a66e'
Relayed Tx: 73d8a0106e8c2b9f2a4d6a7733fe57a534ec5968ba3d6ba67dffb253cb21a66e
neo> wallet send NEO AG4Z3kNtdQxDvdCPYyht1Mq8ntdi7uHuvy 25
Insufficient funds. No unspent outputs available for building the transaction.
If you are trying to sent multiple transactions in 1 block, then make sure you have enough 'vouts'.
Use `wallet unspent` and `wallet address split`, or wait until the first transaction is processed before sending another.
neo>
```

**How did you make sure your solution works?**
manual testing

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
