### PR TITLE
[refactor-prompt] update wallet usage help

### DIFF
--- a/neo/Prompt/CommandBase.py
+++ b/neo/Prompt/CommandBase.py
@@ -124,12 +124,15 @@ class CommandBase(ABC):
             s = self.__parent_command.__command_with_parents() + " " + s
         return s
 
+    def _usage_str(self):
+        return f"Usage: {self.__command_with_parents()} COMMAND"
+
     def handle_help(self, arguments):
         item = get_arg(arguments)
         if item == 'help':
             if len(self.__sub_commands) > 0:
                 # show overview of subcommands and their purpose
-                print(f"\nUsage: {self.__command_with_parents()} COMMAND\n")
+                print(f"\n{self._usage_str()}\n")
                 print(f"{self.command_desc().short_help.capitalize()}\n")
                 print("Commands:")
 

--- a/neo/Prompt/Commands/Wallet.py
+++ b/neo/Prompt/Commands/Wallet.py
@@ -69,6 +69,10 @@ class CommandWallet(CommandBase):
             print(f"{item} is an invalid parameter")
             return
 
+    def _usage_str(self):
+        base = super()._usage_str()
+        return base + " (or \"wallet\" to show the wallet contents)"
+
 
 class CommandWalletCreate(CommandBase):
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
@jseagrave21 pointed out an issue with `wallet help` here: https://github.com/CityOfZion/neo-python/pull/788#pullrequestreview-189586838

**How did you solve this problem?**
LysanderGG gave alternative solutions to resolve it, here: https://github.com/CityOfZion/neo-python/pull/788#issuecomment-451644553
option 1 was implemented for the time being because as pointed out by LysanderGG, only 1 command currently needs it. When we encounter multiple use-cases we can get a better feel of the requirements and adjust accordingly.

**How did you make sure your solution works?**
manual testing. it now shows
```
neo> wallet help

Usage: wallet COMMAND (or "wallet" to show the wallet contents)

Manage wallets

```
**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
