### PR TITLE
[refactor-prompt] fix prompt printer for lists types

### DIFF
--- a/neo/Prompt/PromptPrinter.py
+++ b/neo/Prompt/PromptPrinter.py
@@ -25,7 +25,7 @@ class PromptPrinter():
             if isinstance(a, FormattedText):
                 frags.append(a)
             else:
-                frags.append(FormattedText([("class:command", a)]))
+                frags.append(FormattedText([("class:command", str(a))]))
 
         print_formatted_text(*frags, **kwargs)
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
we proxy/wrap `print` data to `prompt_toolkits`'s `print_formatted_text`. The latter asserts the inputs and we didn't handle lists (and possible other objects) in the way it expects. 

**How did you solve this problem?**
Ensure all data are strings

**How did you make sure your solution works?**
manual test the error case reported in DM on slack.

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
