### PR TITLE
Fix change value calculation when using alternating asset inputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ All notable changes to this project are documented in this file.
 - Add fix to ensure tx is saved to wallet when sent using RPC
 - Add bad peers to the ``getpeers`` RPC method `#715 <https://github.com/CityOfZion/neo-python/pull/715>`
 - Allow a raw tx to be build without an active blockchain db in the environment
+- Fix calculation of asset change value when using multiple alternating asset inputs
 
 
 [0.8.2] 2018-10-31

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -1032,7 +1032,8 @@ class Wallet:
                 sum = Fixed8(0)
                 for item in group:
                     sum = sum + item.Value
-                paytotal[key] = sum
+                cur_val = paytotal.get(key, Fixed8.Zero())
+                paytotal[key] = cur_val + sum
         else:
             paytotal = {}
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
fix #801 

**How did you solve this problem?**
correctly calculate the total paid that gets subtracted from the `vin` to form the change amount.

**How did you make sure your solution works?**
manual testing

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
