### PR TITLE
Fix testnet seeds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ All notable changes to this project are documented in this file.
 - Fix ``getcontractstate`` JSON output to match neo-cli 2.9.2 `#746 <https://github.com/CityOfZion/neo-python/issues/746>`_
 - Fix ``getrawtransaction`` JSON output to match neo-cli 2.9.2 `#751 <https://github.com/CityOfZion/neo-python/pull/751>`_
 - Refactor CLI to be more user friendly and support better future extensibility `#805 <https://github.com/CityOfZion/neo-python/pull/805`_
-
+- Update TestNet seeds
 
 [0.8.2] 2018-10-31
 -------------------

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -9,6 +9,7 @@ from neo.Settings import settings
 from twisted.internet.protocol import ReconnectingClientFactory
 from twisted.internet import reactor, task
 from neo.logging import log_manager
+from neo.Network.utils import is_ip_address, hostname_to_ip
 
 logger = log_manager.getLogger('network')
 
@@ -124,6 +125,8 @@ class NodeLeader:
         start_delay = 0
         for bootstrap in settings.SEED_LIST:
             host, port = bootstrap.split(":")
+            if not is_ip_address(host):
+                host = hostname_to_ip(host)
             setupConnDeferred = task.deferLater(reactor, start_delay, self.SetupConnection, host, port)
             setupConnDeferred.addErrback(self.onSetupConnectionErr)
             start_delay += 1

--- a/neo/Network/utils.py
+++ b/neo/Network/utils.py
@@ -1,0 +1,15 @@
+import socket
+import ipaddress
+
+
+def hostname_to_ip(hostname):
+    return socket.gethostbyname(hostname)
+
+
+def is_ip_address(hostname):
+    host = hostname.split(':')[0]
+    try:
+        ip = ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        return False

--- a/neo/data/protocol.testnet.json
+++ b/neo/data/protocol.testnet.json
@@ -22,11 +22,21 @@
     "AddressVersion": 23,
     "Magic": 1953787457,
     "SeedList": [
-      "13.58.169.218:20333",
-      "13.58.33.157:20333",
-      "18.222.161.128:20333",
-      "18.191.171.240:20333",
-      "18.222.168.189:20333"
+      "seed1.ngd.network:20333",
+      "seed2.ngd.network:20333",
+      "seed3.ngd.network:20333",
+      "seed4.ngd.network:20333",
+      "seed5.ngd.network:20333",
+      "seed6.ngd.network:20333",
+      "seed7.ngd.network:20333",
+      "seed8.ngd.network:20333",
+      "seed9.ngd.network:20333",
+      "seed10.ngd.network:20333",
+      "seed1.neo.org:20333",
+      "seed2.neo.org:20333",
+      "seed3.neo.org:20333",
+      "seed4.neo.org:20333",
+      "seed5.neo.org:20333"
     ],
     "RPCList": [
       "http://18.221.221.195:8880",


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
the current testnet seeds in `protocol.testnet.json` are not working anymore.

**How did you solve this problem?**
re-introduce named seeds and a bit of code to translate the hostname to ip addresses in nodeleader.

**How did you make sure your solution works?**
test

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
