### PR TITLE
properly reset NodeLeader for test cases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ All notable changes to this project are documented in this file.
 - Refactor CLI to be more user friendly and support better future extensibility `#805 <https://github.com/CityOfZion/neo-python/pull/805>`_
 - Update TestNet seeds
 - Add ``--to-addr`` option when claiming gas `#755 <https://github.com/CityOfZion/neo-python/issues/755>`_
+- Add Reset logic to NodeLeader such that Blockchain fixture testcases reset properly `#809 <https://github.com/CityOfZion/neo-python/pull/809>`_
 
 [0.8.2] 2018-10-31
 -------------------

--- a/neo/Network/NodeLeader.py
+++ b/neo/Network/NodeLeader.py
@@ -410,3 +410,44 @@ class NodeLeader:
             res = self.RemoveTransaction(tx)
             if res:
                 logger.debug("found tx 0x%s on the blockchain ...removed from mempool" % tx.Hash)
+
+    @staticmethod
+    def Reset():
+        NodeLeader._LEAD = None
+
+        NodeLeader.Peers = []
+
+        NodeLeader.KNOWN_ADDRS = []
+        NodeLeader.DEAD_ADDRS = []
+
+        NodeLeader.NodeId = None
+
+        NodeLeader._MissedBlocks = []
+
+        NodeLeader.BREQPART = 100
+        NodeLeader.BREQMAX = 10000
+
+        NodeLeader.KnownHashes = []
+        NodeLeader.MissionsGlobal = []
+        NodeLeader.MemPool = {}
+        NodeLeader.RelayCache = {}
+
+        NodeLeader.NodeCount = 0
+
+        NodeLeader.CurrentBlockheight = 0
+
+        NodeLeader.ServiceEnabled = False
+
+        NodeLeader.peer_check_loop = None
+        NodeLeader.peer_check_loop_deferred = None
+
+        NodeLeader.check_bcr_loop = None
+        NodeLeader.check_bcr_loop_deferred = None
+
+        NodeLeader.memcheck_loop = None
+        NodeLeader.memcheck_loop_deferred = None
+
+        NodeLeader.blockheight_loop = None
+        NodeLeader.blockheight_loop_deferred = None
+
+        NodeLeader.task_handles = {}

--- a/neo/Utils/BlockchainFixtureTestCase.py
+++ b/neo/Utils/BlockchainFixtureTestCase.py
@@ -37,6 +37,7 @@ class BlockchainFixtureTestCase(NeoTestCase):
 
         super(BlockchainFixtureTestCase, cls).setUpClass()
 
+        NodeLeader.Instance().Reset()
         NodeLeader.Instance().Setup()
 
         # setup Blockchain DB
@@ -57,7 +58,8 @@ class BlockchainFixtureTestCase(NeoTestCase):
             tar.extractall(path=settings.DATA_DIR_PATH)
             tar.close()
         except Exception as e:
-            raise Exception("Could not extract tar file - %s. You may want need to remove the fixtures file %s manually to fix this." % (e, cls.FIXTURE_FILENAME))
+            raise Exception(
+                "Could not extract tar file - %s. You may want need to remove the fixtures file %s manually to fix this." % (e, cls.FIXTURE_FILENAME))
 
         if not os.path.exists(cls.leveldb_testpath()):
             raise Exception("Error downloading fixtures at %s" % cls.leveldb_testpath())
@@ -85,7 +87,8 @@ class BlockchainFixtureTestCase(NeoTestCase):
             tar.close()
 
         except Exception as e:
-            raise Exception("Could not extract tar file - %s. You may want need to remove the fixtures file %s manually to fix this." % (e, cls.N_FIXTURE_FILENAME))
+            raise Exception(
+                "Could not extract tar file - %s. You may want need to remove the fixtures file %s manually to fix this." % (e, cls.N_FIXTURE_FILENAME))
         if not os.path.exists(cls.N_NOTIFICATION_DB_NAME):
             raise Exception("Error downloading fixtures at %s" % cls.N_NOTIFICATION_DB_NAME)
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
A common root cause for tests failing to relay is because NodeLeader isn't reset properly. Other tests could have created a similar TX which is now stored in the `KnownHashes` and therefore `Relay` fails.

**How did you solve this problem?**
add reset logic

**How did you make sure your solution works?**
make test and faced this issue again when merging `development` into #723 

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
