### PR TITLE
Resolve Peewee deprecation warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ All notable changes to this project are documented in this file.
 - Refactor CLI to be more user friendly and support better future extensibility `#805 <https://github.com/CityOfZion/neo-python/pull/805>`_
 - Update TestNet seeds
 - Add ``--to-addr`` option when claiming gas `#755 <https://github.com/CityOfZion/neo-python/issues/755>`_
+- Resolve peewee DeprecationWarning
 
 [0.8.2] 2018-10-31
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,7 @@ All notable changes to this project are documented in this file.
 - Refactor CLI to be more user friendly and support better future extensibility `#805 <https://github.com/CityOfZion/neo-python/pull/805>`_
 - Update TestNet seeds
 - Add ``--to-addr`` option when claiming gas `#755 <https://github.com/CityOfZion/neo-python/issues/755>`_
-- Resolve peewee DeprecationWarning
+- Resolve peewee DeprecationWarning `#810 <https://github.com/CityOfZion/neo-python/pull/810>`_
 
 [0.8.2] 2018-10-31
 -------------------

--- a/neo/Implementations/Wallets/peewee/Models.py
+++ b/neo/Implementations/Wallets/peewee/Models.py
@@ -1,5 +1,4 @@
-
-from peewee import Model, PrimaryKeyField, CharField, BooleanField, ForeignKeyField, IntegerField, DateTimeField, BlobField
+from peewee import Model, CharField, BooleanField, ForeignKeyField, IntegerField, DateTimeField, BlobField, AutoField
 from .PWDatabase import PWDatabase
 from neocore.Cryptography.Crypto import Crypto
 from neocore.UInt256 import UInt256
@@ -15,13 +14,13 @@ class ModelBase(Model):
 
 
 class Account(ModelBase):
-    Id = PrimaryKeyField()
+    Id = AutoField()
     PrivateKeyEncrypted = BlobField(unique=True)
     PublicKeyHash = CharField()
 
 
 class Address(ModelBase):
-    Id = PrimaryKeyField()
+    Id = AutoField()
     ScriptHash = BlobField(unique=True)
     IsWatchOnly = BooleanField(default=False)
 
@@ -30,7 +29,7 @@ class Address(ModelBase):
 
 
 class NamedAddress(ModelBase):
-    Id = PrimaryKeyField()
+    Id = AutoField()
     ScriptHash = BlobField(unique=True)
     Title = CharField()
 
@@ -42,7 +41,7 @@ class NamedAddress(ModelBase):
 
 
 class Coin(ModelBase):
-    Id = PrimaryKeyField()
+    Id = AutoField()
     TxId = BlobField()
     Index = IntegerField()
     AssetId = BlobField()
@@ -53,7 +52,7 @@ class Coin(ModelBase):
 
 
 class Contract(ModelBase):
-    Id = PrimaryKeyField()
+    Id = AutoField()
     RawData = CharField()
     ScriptHash = BlobField()
     PublicKeyHash = CharField()
@@ -62,7 +61,7 @@ class Contract(ModelBase):
 
 
 class Key(ModelBase):
-    Id = PrimaryKeyField()
+    Id = AutoField()
     Name = CharField(unique=True)
     Value = BlobField()
 
@@ -75,7 +74,7 @@ class NEP5Token(ModelBase):
 
 
 class Transaction(ModelBase):
-    Id = PrimaryKeyField()
+    Id = AutoField()
     Hash = CharField(unique=True)
     TransactionType = IntegerField()
     RawData = CharField()
@@ -84,14 +83,14 @@ class Transaction(ModelBase):
 
 
 class TransactionInfo(ModelBase):
-    Id = PrimaryKeyField()
+    Id = AutoField()
     CoreTransaction = ForeignKeyField(Transaction)
     Height = IntegerField()
     DateTime = DateTimeField()
 
 
 class VINHold(ModelBase):
-    Id = PrimaryKeyField()
+    Id = AutoField()
     Index = IntegerField()
     Hash = CharField()
     FromAddress = CharField()


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
peewee prints
```
neo-python/venv/lib/python3.6/site-packages/peewee.py:235: DeprecationWarning: "PrimaryKeyField" has been renamed to "AutoField". Please update your code accordingly as this will be completely removed in a subsequent release.
  warnings.warn(s, DeprecationWarning)
```

**How did you solve this problem?**
follow suggestion of peewee

**How did you make sure your solution works?**
make test, manually open old wallet.

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
