### PR TITLE
cleanup show nodes output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ All notable changes to this project are documented in this file.
 - Add VM SafeReadBytes `#812 <https://github.com/CityOfZion/neo-python/pull/812>`_
 - Add gettransactionheight RPC method `#813 <https://github.com/CityOfZion/neo-python/pull/813>`_
 - Update ``ApplicationEngine`` methods ``CheckStackSize`` and ``GetPrice`` `#814 <https://github.com/CityOfZion/neo-python/pull/814/>`_
+- Cleanup ``show nodes`` output `#815 <https://github.com/CityOfZion/neo-python/pull/815>`_
 
 
 [0.8.2] 2018-10-31

--- a/neo/Network/NeoNode.py
+++ b/neo/Network/NeoNode.py
@@ -89,7 +89,9 @@ class NeoNode(Protocol):
         Returns:
             str:
         """
-        return self.transport.getPeer()
+        if self.Version:
+            name = self.Version.UserAgent
+        return name
 
     def GetNetworkAddressWithTime(self):
         """
@@ -113,7 +115,7 @@ class NeoNode(Protocol):
         biM = self.bytes_in / 1000000  # megabyes
         boM = self.bytes_out / 1000000
 
-        return "%s MB in / %s MB out" % (biM, boM)
+        return f"{biM:>10} MB in / {boM:>10} MB out"
 
     def connectionMade(self):
         """Callback handler from twisted when establishing a new connection."""
@@ -351,7 +353,8 @@ class NeoNode(Protocol):
 
             hashstart += 1
 
-        self.Log("asked for more blocks ... %s thru %s (%s blocks) stale count %s BCRLen: %s " % (first, hashstart, len(hashes), BC.Default().BlockSearchTries, len(BC.Default().BlockRequests)))
+        self.Log("asked for more blocks ... %s thru %s (%s blocks) stale count %s BCRLen: %s " % (
+            first, hashstart, len(hashes), BC.Default().BlockSearchTries, len(BC.Default().BlockRequests)))
 
         if len(hashes) > 0:
             message = Message("getdata", InvPayload(InventoryType.Block, hashes))

--- a/neo/Prompt/Commands/Show.py
+++ b/neo/Prompt/Commands/Show.py
@@ -163,8 +163,8 @@ class CommandShowNodes(CommandBase):
     def execute(self, arguments=None):
         if len(NodeLeader.Instance().Peers) > 0:
             out = "Total Connected: %s\n" % len(NodeLeader.Instance().Peers)
-            for peer in NodeLeader.Instance().Peers:
-                out += "Peer %s - IO: %s\n" % (peer.Name(), peer.IOStats())
+            for i, peer in enumerate(NodeLeader.Instance().Peers):
+                out += f"Peer {i} {peer.Name():>12} - {peer.Address:>21} - IO {peer.IOStats()}\n"
             print(out)
             return out
         else:

--- a/neo/Prompt/Commands/tests/test_show_commands.py
+++ b/neo/Prompt/Commands/tests/test_show_commands.py
@@ -156,14 +156,14 @@ class CommandShowTestCase(BlockchainFixtureTestCase):
             res = CommandShow().execute(args)
             self.assertTrue(res)
             self.assertIn('Total Connected: 1', res)
-            self.assertIn('Peer test name - IO: 0.0 MB in / 0.0 MB out', res)
+            self.assertIn('Peer 0', res)
 
             # now use "node"
             args = ['node']
             res = CommandShow().execute(args)
             self.assertTrue(res)
             self.assertIn('Total Connected: 1', res)
-            self.assertIn('Peer test name - IO: 0.0 MB in / 0.0 MB out', res)
+            self.assertIn('Peer 0', res)
 
         # restore whatever state the instance was in
         NodeLeader._LEAD = old_leader


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
The current output of show nodes is a bit messy. It's not aligned, has some irrelevant info and missing relevant info. This is a little improvement to clean that up (ported from the `network_improv` branch)

old
```
neo> show node
Total Connected: 3
Peer IPv4Address(type='TCP', host='127.0.0.1', port=20333) - IO: 0.000322 MB in / 0.000211 MB out
Peer IPv4Address(type='TCP', host='127.0.0.1', port=20334) - IO: 0.000347 MB in / 0.000211 MB out
Peer IPv4Address(type='TCP', host='127.0.0.1', port=20334) - IO: 8.7e-05 MB in / 0.000211 MB out
```

new
```
neo> show node
Total Connected: 3
Peer 0  /NEO:2.8.0/ -       127.0.0.1:20333 - IO   0.000346 MB in /   0.000211 MB out
Peer 1  /NEO:2.8.0/ -       127.0.0.1:20334 - IO   0.000347 MB in /   0.000211 MB out
Peer 2  /NEO:2.8.0/ -       127.0.0.1:20334 - IO   0.000377 MB in /   0.000211 MB out
```

**How did you solve this problem?**

**How did you make sure your solution works?**

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
