### PR TITLE
Fix sysfee maketx / block height display

### DIFF
--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -1025,7 +1025,7 @@ class Wallet:
         if not tx.inputs:
             tx.inputs = []
 
-        fee = fee + (tx.SystemFee() * Fixed8.FD())
+        fee = fee + tx.SystemFee()
 
         #        pdb.set_trace()
 

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -97,8 +97,8 @@ class PromptInterface:
         out = []
         try:
             return "[%s] Progress: %s/%s" % (settings.net_name,
-                                             str(Blockchain.Default().Height + 1),
-                                             str(Blockchain.Default().HeaderHeight + 1))
+                                             str(Blockchain.Default().Height),
+                                             str(Blockchain.Default().HeaderHeight))
         except Exception as e:
             pass
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
1) #751 introduced a bug for deploying smart contracts. The fee calculated in `MakeTransaction` was off due to the change and could cause an "insufficient funds" error. This resolves that.
2) the prompt showed a block and header height that was consistently 1 ahead of the reality. I discovered this while being connected to a local `neo-cli` node. This would also give a bad user experience as people would try to query the latest block and get a "block not found" (which is true as it didn't exist yet).

**How did you solve this problem?**
1) remove sysfee multiplication. Also doesn't exist in the neo-cli reference code
2) remove the `+1` in the prompt toolbar (not sure why that was ever there)

**How did you make sure your solution works?**
make test, 
manually deploy contract, 
manually send some assets,
verify that #749 is still fixed
  
**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
