### PR TITLE
Add wallet height to bottom toolbar

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.8.5-dev] in progress
 -----------------------
+- Add current wallet height to bottom toolbar
 - Change class attributes of ``Transaction`` into instance attributes and fix constructor
 - Improve testing of "getbalance" RPC method
 - Support cancelling actions with ``KeyboardInterrupt``

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -650,14 +650,14 @@ class Wallet:
         self._lock.acquire()
         try:
             blockcount = 0
-            while self._current_height <= Blockchain.Default().Height and (block_limit == 0 or blockcount < block_limit):
+            while self._current_height < Blockchain.Default().Height and (block_limit == 0 or blockcount < block_limit):
 
                 block = Blockchain.Default().GetBlockByHeight(self._current_height)
 
                 if block is not None:
                     self.ProcessNewBlock(block)
                 else:
-                    self._current_height += 1
+                    break
 
                 blockcount += 1
 

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -96,7 +96,12 @@ class PromptInterface:
     def get_bottom_toolbar(self, cli=None):
         out = []
         try:
-            return "[%s] Progress: %s/%s" % (settings.net_name,
+            if PromptData.Wallet is None:
+                return "[%s] Progress: 0/%s/%s" % (settings.net_name,
+                                             str(Blockchain.Default().Height),
+                                             str(Blockchain.Default().HeaderHeight))
+            else:
+                return "[%s] Progress: %s/%s/%s" % (settings.net_name, str(PromptData.Wallet._current_height),
                                              str(Blockchain.Default().Height),
                                              str(Blockchain.Default().HeaderHeight))
         except Exception as e:

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -98,12 +98,12 @@ class PromptInterface:
         try:
             if PromptData.Wallet is None:
                 return "[%s] Progress: 0/%s/%s" % (settings.net_name,
-                                             str(Blockchain.Default().Height),
-                                             str(Blockchain.Default().HeaderHeight))
+                                                   str(Blockchain.Default().Height),
+                                                   str(Blockchain.Default().HeaderHeight))
             else:
                 return "[%s] Progress: %s/%s/%s" % (settings.net_name, str(PromptData.Wallet._current_height),
-                                             str(Blockchain.Default().Height),
-                                             str(Blockchain.Default().HeaderHeight))
+                                                    str(Blockchain.Default().Height),
+                                                    str(Blockchain.Default().HeaderHeight))
         except Exception as e:
             pass
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Monitoring wallet height requires getting all the wallet info which can be slow depending on how many address/tokens/contracts exist in the wallet

**How did you solve this problem?**
Added the current wallet height to the bottom toolbar in the same format neo-cli uses (wallet height/db height/blockchain height)

**How did you make sure your solution works?**
Manual testing

**Are there any special changes in the code that we should be aware of?**
No
**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
