### PR TITLE
add --return-type to override test invoke return parameter type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.8.5-dev] in progress
 -----------------------
+- Allow override of test invocation return type
 - Add current wallet height to bottom toolbar
 - Change class attributes of ``Transaction`` into instance attributes and fix constructor
 - Improve testing of "getbalance" RPC method

--- a/neo/Prompt/Commands/SC.py
+++ b/neo/Prompt/Commands/SC.py
@@ -189,7 +189,11 @@ class CommandSCTestInvoke(CommandBase):
         if tx and results:
 
             if return_type is not None:
-                parameterized_results = [ContractParameter.AsParameterType(ContractParameterType.FromString(return_type), item).ToJson() for item in results]
+                try:
+                    parameterized_results = [ContractParameter.AsParameterType(ContractParameterType.FromString(return_type), item).ToJson() for item in results]
+                except:
+                    logger.debug("invalid return type")
+                    return False
             else:
                 parameterized_results = [ContractParameter.ToParameter(item).ToJson() for item in results]
 

--- a/neo/Prompt/Commands/SC.py
+++ b/neo/Prompt/Commands/SC.py
@@ -7,6 +7,7 @@ from neo.Prompt.Commands.Invoke import TestInvokeContract, InvokeContract, test_
 from neo.Core.Blockchain import Blockchain
 from neocore.UInt160 import UInt160
 from neo.SmartContract.ContractParameter import ContractParameter
+from neo.SmartContract.ContractParameterType import ContractParameterType
 from prompt_toolkit import prompt
 from neocore.Fixed8 import Fixed8
 from neo.Implementations.Blockchains.LevelDB.DebugStorage import DebugStorage
@@ -163,6 +164,7 @@ class CommandSCTestInvoke(CommandBase):
         arguments, priority_fee = PromptUtils.get_fee(arguments)
         arguments, invoke_attrs = PromptUtils.get_tx_attr_from_args(arguments)
         arguments, owners = PromptUtils.get_owners_from_params(arguments)
+        arguments, return_type = PromptUtils.get_return_type_from_args(arguments)
 
         if len(arguments) < 1:
             print("Please specify the required parameters")
@@ -186,7 +188,10 @@ class CommandSCTestInvoke(CommandBase):
         tx, fee, results, num_ops, engine_success = TestInvokeContract(wallet, arguments, from_addr=from_addr, invoke_attrs=invoke_attrs, owners=owners)
         if tx and results:
 
-            parameterized_results = [ContractParameter.ToParameter(item).ToJson() for item in results]
+            if return_type is not None:
+                parameterized_results = [ContractParameter.AsParameterType(ContractParameterType.FromString(return_type), item).ToJson() for item in results]
+            else:
+                parameterized_results = [ContractParameter.ToParameter(item).ToJson() for item in results]
 
             print(
                 "\n-------------------------------------------------------------------------------------------------------------------------------------")
@@ -226,16 +231,17 @@ class CommandSCTestInvoke(CommandBase):
         p6 = ParameterDesc('--from-addr', 'source address to take fee funds from (if not specified, take first address in wallet)', optional=True)
         p7 = ParameterDesc('--fee', 'Attach GAS amount to give your transaction priority (> 0.001) e.g. --fee=0.01', optional=True)
         p8 = ParameterDesc('--owners', 'list of NEO addresses indicating the transaction owners e.g. --owners=[address1,address2]', optional=True)
-        p9 = ParameterDesc('--tx-attr',
-                           'a list of transaction attributes to attach to the transaction\n\n'
-                           f"{' ':>17} See: http://docs.neo.org/en-us/network/network-protocol.html section 4 for a description of possible attributes\n\n"
-                           f"{' ':>17} Example\n"
-                           f"{' ':>20} --tx-attr=[{{\"usage\": <value>,\"data\":\"<remark>\"}}, ...]\n"
-                           f"{' ':>20} --tx-attr=[{{\"usage\": 0x90,\"data\":\"my brief description\"}}]\n\n"
-                           f"{' ':>17} For more information about parameter types see\n"
-                           f"{' ':>17} https://neo-python.readthedocs.io/en/latest/data-types.html#contractparametertypes\n", optional=True)
+        p9 = ParameterDesc('--return-type', 'override the return parameter type e.g. --return-type=02', optional=True) 
+        p10 = ParameterDesc('--tx-attr',
+                            'a list of transaction attributes to attach to the transaction\n\n'
+                            f"{' ':>17} See: http://docs.neo.org/en-us/network/network-protocol.html section 4 for a description of possible attributes\n\n"
+                            f"{' ':>17} Example\n"
+                            f"{' ':>20} --tx-attr=[{{\"usage\": <value>,\"data\":\"<remark>\"}}, ...]\n"
+                            f"{' ':>20} --tx-attr=[{{\"usage\": 0x90,\"data\":\"my brief description\"}}]\n\n"
+                            f"{' ':>17} For more information about parameter types see\n"
+                            f"{' ':>17} https://neo-python.readthedocs.io/en/latest/data-types.html#contractparametertypes\n", optional=True)
 
-        params = [p1, p2, p3, p4, p5, p6, p7, p8, p9]
+        params = [p1, p2, p3, p4, p5, p6, p7, p8, p9, p10]
         return CommandDesc('invoke', 'Call functions on the smart contract. Will prompt before sending to the network', params=params)
 
 

--- a/neo/Prompt/Commands/SC.py
+++ b/neo/Prompt/Commands/SC.py
@@ -191,7 +191,7 @@ class CommandSCTestInvoke(CommandBase):
             if return_type is not None:
                 try:
                     parameterized_results = [ContractParameter.AsParameterType(ContractParameterType.FromString(return_type), item).ToJson() for item in results]
-                except:
+                except ValueError:
                     logger.debug("invalid return type")
                     return False
             else:

--- a/neo/Prompt/Commands/tests/test_sc_commands.py
+++ b/neo/Prompt/Commands/tests/test_sc_commands.py
@@ -421,32 +421,32 @@ class CommandSCTestCase(WalletFixtureTestCase):
                 self.assertIn("Incorrect password", mock_print.getvalue())
 
         # test with no return-type override
-        with patch ('sys.stdout', new=StringIO()) as mock_print:
-            with patch ('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            with patch('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
                 args = ['invoke', token_hash_str, 'totalSupply', '[]', '']
                 res = CommandSC().execute(args)
                 a = mock_print.getvalue()
-                self.assertIn ("ByteArray", mock_print.getvalue())
+                self.assertIn("ByteArray", mock_print.getvalue())
 
         # test with bad return-type override
-        with patch ('sys.stdout', new=StringIO()) as mock_print:
-            with patch ('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            with patch('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
                 args = ['invoke', token_hash_str, 'totalSupply', '[]', '--return-type=99']
                 res = CommandSC().execute(args)
                 self.assertFalse(res)
 
         # test with hex return-type override
-        with patch ('sys.stdout', new=StringIO()) as mock_print:
-            with patch ('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            with patch('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
                 args = ['invoke', token_hash_str, 'totalSupply', '[]', '--return-type=02']
                 res = CommandSC().execute(args)
                 self.assertIn("Integer", mock_print.getvalue())
 
         # test with named return-type override
-        with patch ('sys.stdout', new=StringIO()) as mock_print:
-            with patch ('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            with patch('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
                 args = ['invoke', token_hash_str, 'totalSupply', '[]', '--return-type=Integer']
-                res = CommandSC().execute (args)
+                res = CommandSC().execute(args)
                 self.assertIn("Integer", mock_print.getvalue())
 
         # test ok

--- a/neo/Prompt/Commands/tests/test_sc_commands.py
+++ b/neo/Prompt/Commands/tests/test_sc_commands.py
@@ -420,6 +420,35 @@ class CommandSCTestCase(WalletFixtureTestCase):
                 self.assertFalse(res)
                 self.assertIn("Incorrect password", mock_print.getvalue())
 
+        # test with no return-type override
+        with patch ('sys.stdout', new=StringIO()) as mock_print:
+            with patch ('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
+                args = ['invoke', token_hash_str, 'totalSupply', '[]', '']
+                res = CommandSC().execute(args)
+                a = mock_print.getvalue()
+                self.assertIn ("ByteArray", mock_print.getvalue())
+
+        # test with bad return-type override
+        with patch ('sys.stdout', new=StringIO()) as mock_print:
+            with patch ('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
+                args = ['invoke', token_hash_str, 'totalSupply', '[]', '--return-type=99']
+                res = CommandSC().execute(args)
+                self.assertFalse(res)
+
+        # test with hex return-type override
+        with patch ('sys.stdout', new=StringIO()) as mock_print:
+            with patch ('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
+                args = ['invoke', token_hash_str, 'totalSupply', '[]', '--return-type=02']
+                res = CommandSC().execute(args)
+                self.assertIn("Integer", mock_print.getvalue())
+
+        # test with named return-type override
+        with patch ('sys.stdout', new=StringIO()) as mock_print:
+            with patch ('neo.Prompt.Commands.SC.prompt', side_effect=[KeyboardInterrupt]):
+                args = ['invoke', token_hash_str, 'totalSupply', '[]', '--return-type=Integer']
+                res = CommandSC().execute (args)
+                self.assertIn("Integer", mock_print.getvalue())
+
         # test ok
         with patch('sys.stdout', new=StringIO()) as mock_print:
             with patch('neo.Prompt.Commands.SC.prompt', side_effect=[self.wallet_3_pass()]):

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -148,6 +148,15 @@ def get_to_addr(params):
     return params, to_addr
 
 
+def get_return_type_from_args(params):
+    return_type = None
+    for item in params:
+        if '--return-type' in item:
+            params.remove(item)
+            return_type = item.replace('--return-type=', '')
+    return params, return_type
+
+
 def get_fee(params):
     fee = None
     for item in params:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Contract invocation results are displayed using the default return type of the contract, even though some operations will return different types than the default, requiring the user to manually convert results, e.g. from bytearray to integer

**How did you solve this problem?**
Added a --return-type argument to the `sc invoke` command to allow the user to override the contract's default return type during a test invoke

**How did you make sure your solution works?**
Manual testing

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
