### PR TITLE
Lock contract deserialize to old ReadVarBytes implementation

### DIFF
--- a/neo/SmartContract/Contract.py
+++ b/neo/SmartContract/Contract.py
@@ -158,7 +158,14 @@ class Contract(SerializableMixin, VerificationCode):
     def Deserialize(self, reader):
         self.PublicKeyHash = reader.ReadUInt160()
         self.ParameterList = reader.ReadVarBytes()
-        script = bytearray(reader.ReadVarBytes())
+        # TODO: fix this. This is supposed to be `reader.ReadVarBytes`,
+        #  however that no longer works after the internal implementation changed to verify the length of data to read.
+        #  There has always been a bug that went unnoticed because previously we'd ask e.g. 70 bytes and it could return 35 without problems.
+        #  Now that will fail. The test `neo.Wallets.test_wallet.test_privnet_wallet` thinks it should read 70 bytes because it expects b'AABB' data
+        #  while in reality it gets b'\xAA\xBB` data and is thus only half the size. It's spread in so many places that I don't want to fix it in this already
+        #  huge VM update PR. We work around it by manually reconstructing the old `ReadVarBytes``
+        length = reader.ReadVarInt()
+        script = bytearray(reader.ReadBytes(length))
         self.Script = script
 
     def Serialize(self, writer):


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
In order to update the VM we had to change the implementation of `ReadVarBytes` to use [SafeReadBytes](https://github.com/CityOfZion/neo-python-core/blob/0e27b796d962385e52451ee20c2258c47d9e6e8c/neocore/IO/BinaryReader.py#L70) in this [PR](https://github.com/CityOfZion/neo-python-core/pull/178) on neo-python-core . This however breaks tests like (being one of)
https://github.com/CityOfZion/neo-python/blob/fe90f62e123d720d4281c79af0598d9df9e776fb/neo/Wallets/test_wallet.py#L124-L126

Because a `Contract()` is created and saved in the DB where the `script` member length is determined by a `b'aabbcc'` data `script` member whereas reading back data for `script` (during deserialization) gives `b'\xaa\xbb\cc` data therefore having a wrong length (in the example 6 vs 3). The old `ReadVarBytes` ignored this difference and just returned whatever it could read which made the bug go unnoticed for a long time. The new version raises an error that not enough data can be read. Because the upcoming PR for VM updates is already so big I don't want to address this issue that's seems to touch many places right now.   

**How did you solve this problem?**
I've hardcoded the old `ReadVarBytes` implementation into the `Contract.Deserialize` method such that the `neo-python-core` PR can pass building and we can start PR'ing other stuff. Travis-ci now fails on this stuff.

**How did you make sure your solution works?**

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
