### PR TITLE
Update VM

### DIFF
--- a/neo/SmartContract/tests/test_contract_parameters.py
+++ b/neo/SmartContract/tests/test_contract_parameters.py
@@ -10,7 +10,6 @@ from neo.Core.Cryptography.ECCurve import EllipticCurve
 class EventTestCase(TestCase):
 
     def test_from_json(self):
-
         jsn = {
             'type': str(ContractParameterType.String),
             'value': 'hello'
@@ -165,7 +164,6 @@ class EventTestCase(TestCase):
         self.assertEqual(cp.ToJson(), jsn)
 
     def test_to_parameter(self):
-
         stack_item = Integer(BigInteger(14))
 
         cp1 = ContractParameter.AsParameterType(ContractParameterType.Integer, stack_item)
@@ -195,7 +193,7 @@ class EventTestCase(TestCase):
         self.assertEqual(cp1.ToJson(), {'type': 'Boolean', 'value': False})
 
         cp1 = ContractParameter.AsParameterType(ContractParameterType.ByteArray, stack_item)
-        self.assertEqual(cp1.ToJson(), {'type': 'ByteArray', 'value': '00'})
+        self.assertEqual(cp1.ToJson(), {'type': 'ByteArray', 'value': ''})
 
         with self.assertRaises(Exception) as ctx:
             cp1 = ContractParameter.AsParameterType(ContractParameterType.Array, stack_item)

--- a/neo/Utils/VMJSONTestCase.py
+++ b/neo/Utils/VMJSONTestCase.py
@@ -10,7 +10,7 @@ logger = log_manager.getLogger()
 
 
 class VMJSONTestCase(NeoTestCase):
-    NEO_VM_REPO_URL = "https://github.com/neo-project/neo-vm/tarball/e615bf58921db9e1bb6a71ba72e82f05d027c3c7"
+    NEO_VM_REPO_URL = "https://github.com/neo-project/neo-vm/tarball/c45330eee5a0ef47a03a7dad212318a7acaf01b5"
     SOURCE_FILENAME = os.path.join(settings.DATA_DIR_PATH, 'vm-tests/neo-vm.tar.gz')
 
     @classmethod

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -39,6 +39,9 @@ class StackItem(EquatableMixin):
     def GetBigInteger(self):
         return BigInteger(int.from_bytes(self.GetByteArray(), 'little', signed=True))
 
+    def GetByteLength(self):
+        return len(self.GetByteArray())
+
     def GetBoolean(self):
         for p in self.GetByteArray():
             if p > 0:
@@ -224,7 +227,7 @@ class Array(StackItem, CollectionMixin):
 
 class Boolean(StackItem):
     TRUE = bytearray([1])
-    FALSE = bytearray([0])
+    FALSE = bytearray()  # restore once https://github.com/neo-project/neo-vm/pull/132 is approved
 
     _value = None
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- update to match https://github.com/neo-project/neo-vm/pull/95 and https://github.com/neo-project/neo-vm/pull/126
- resolve memory leak when executing invocation transactions

**How did you solve this problem?**

**How did you make sure your solution works?**
- for the VM update I ran the newer JSON test files + `make test`
- for the VM memory leak I ran this test before and after fixing and confirmed the memory usage stays low

```
import unittest
import binascii
from neo.VM.ExecutionEngine import ExecutionEngine
from neo.VM import InteropService
from neo.Core.Cryptography.Crypto import Crypto
from pympler.tracker import SummaryTracker


class VMLeak(unittest.TestCase):
    def test_vm_context_leak(self):
        service = InteropService.InteropService()
        script_container = None
        script_table = None
        tracker = SummaryTracker()
        for _ in range(10000):
            engine = ExecutionEngine(crypto=Crypto.Default(), service=service, container=script_container, table=script_table, exit_on_error=True)
            script_data = binascii.unhexlify('00C57655C86B00C5766AC86A56C86C')
            engine.LoadScript(script_data)
            engine.Execute()
        tracker.print_diff()
```

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
