### PR TITLE
Align Fixed8 string output representation with C#

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ All notable changes to this project are documented in this file.
 - Add PICKITEM for ByteArray into VM `#923 <https://github.com/CityOfZion/neo-python/pull/923>`_
 - Improve Connection Failure Handling in NodeLeader `#915 <https://github.com/CityOfZion/neo-python/issues/915>`_
 - Improve transaction coverage and fix `PublishTransaction.Size()` `#929 <https://github.com/CityOfZion/neo-python/issues/929>`_
+- Align ``Fixed8`` ``ToString()`` output with C# `#941 <https://github.com/CityOfZion/neo-python/pull/941>`_
 
 
 [0.8.4] 2019-02-14

--- a/neo/Core/Fixed8.py
+++ b/neo/Core/Fixed8.py
@@ -133,7 +133,14 @@ class Fixed8:
         return int(self.value / Fixed8.D)
 
     def ToString(self):
-        return str(self.value / Fixed8.D)
+        value = self.value / Fixed8.D
+        if value < 0:
+            return f"{value:.08g}"
+        else:
+            res = f"{value:.08f}".rstrip("0")
+            if res.endswith("."):
+                res = res.rstrip(".")
+            return res
 
     def ToNeoJsonString(self):
         strval = self.ToString()

--- a/neo/Core/tests/test_io.py
+++ b/neo/Core/tests/test_io.py
@@ -87,7 +87,7 @@ class BinaryReaderTestCase(TestCase):
         self.assertEqual(str(x), "3237383139333738323933373839313738333231")
 
         x = get_br(b"\x01\x02\x0345678").ReadFixed8()
-        self.assertEqual(str(x), "40507659919.768295")
+        self.assertEqual(str(x), "40507659919.76829529")
 
         self.assertEqual(get_br(b"\x0212345567898765434567890987").ReadHashes(), ['3738393039383736353433343536373839383736353534333231', ''])
 

--- a/neo/Core/tests/test_numbers.py
+++ b/neo/Core/tests/test_numbers.py
@@ -9,6 +9,7 @@ from neo.Core.BigInteger import BigInteger
 from neo.Core.UIntBase import UIntBase
 from neo.Core.UInt160 import UInt160
 from neo.Core.UInt256 import UInt256
+from decimal import Decimal
 
 
 class Fixed8TestCase(TestCase):
@@ -178,7 +179,7 @@ class Fixed8TestCase(TestCase):
 
         f8 = Fixed8.One()
         self.assertEqual(f8.ToInt(), 1)
-        self.assertEqual(f8.ToString(), "1.0")
+        self.assertEqual(f8.ToString(), "1")
         self.assertTrue(isinstance(f8.ToString(), str))
 
     def test_fixed8_tojsonstring(self):
@@ -191,8 +192,17 @@ class Fixed8TestCase(TestCase):
         f8 = Fixed8.FromDecimal(100)
         self.assertEqual("100", f8.ToNeoJsonString())
 
+        f8 = Fixed8.FromDecimal(100.00000001)
+        self.assertEqual("100.00000001", f8.ToNeoJsonString())
+
+        f8 = Fixed8.FromDecimal(100.000000001)
+        self.assertEqual("100", f8.ToNeoJsonString())
+
         f8 = Fixed8.FromDecimal(2609.997813)
         self.assertEqual("2609.997813", f8.ToNeoJsonString())
+
+        f8 = Fixed8.FromDecimal(Decimal("1e-08"))
+        self.assertEqual(f8.ToNeoJsonString(), "0.00000001")
 
 
 class BigIntegerTestCase(TestCase):

--- a/neo/Prompt/Commands/tests/test_send_commands.py
+++ b/neo/Prompt/Commands/tests/test_send_commands.py
@@ -44,7 +44,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
                 res = Wallet.CommandWallet().execute(args)
 
                 self.assertTrue(res)
-                self.assertIn("Sending with fee: 0.0", mock_print.getvalue())
+                self.assertIn("Sending with fee: 0", mock_print.getvalue())
 
     def test_send_gas(self):
         with patch('sys.stdout', new=StringIO()) as mock_print:
@@ -55,7 +55,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
                 res = Wallet.CommandWallet().execute(args)
 
                 self.assertTrue(res)
-                self.assertIn("Sending with fee: 0.0", mock_print.getvalue())
+                self.assertIn("Sending with fee: 0", mock_print.getvalue())
 
     def test_send_with_fee_and_from_addr(self):
         with patch('sys.stdout', new=StringIO()) as mock_print:
@@ -382,7 +382,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
                 res = Wallet.CommandWallet().execute(args)
 
                 self.assertTrue(res)  # verify successful tx
-                self.assertIn("Sending with fee: 0.0", mock_print.getvalue())
+                self.assertIn("Sending with fee: 0", mock_print.getvalue())
                 json_res = res.ToJson()
 
                 # check for 2 transfers

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -205,7 +205,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         req = self._gen_post_rpc_req("getaccountstate", params=[addr_str])
         mock_req = mock_post_request(json.dumps(req).encode("utf-8"))
         res = json.loads(self.app.home(mock_req))
-        self.assertEqual(res['result']['balances'][0]['value'], '99989900.0')
+        self.assertEqual(res['result']['balances'][0]['value'], '99989900')
         self.assertEqual(res['result']['balances'][0]['asset'], '0xc56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'),
         self.assertEqual(res['result']['address'], addr_str)
 
@@ -660,7 +660,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase):
         res = json.loads(self.app.home(mock_req))
 
         self.assertIn('Balance', res.get('result').keys())
-        self.assertEqual(res['result']['Balance'], "150.0")
+        self.assertEqual(res['result']['Balance'], "150")
         self.assertIn('Confirmed', res.get('result').keys())
         self.assertEqual(res['result']['Confirmed'], "50.0")
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
fix #940
**How did you solve this problem?**
change `ToString()`

**How did you make sure your solution works?**
make test

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
