### PR TITLE
Fix np-import/export

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,7 +30,7 @@ All notable changes to this project are documented in this file.
 - Various VM performance updates
 - Various code cleaning updates
 - Ensure LevelDB iterators are close, ensure all ``MemoryStream`` usages go through ``StreamManger`` and are closed.
-
+- Fix ``np-import`` not importing headers ahead of block persisting potentially unexpected VM execution results
 
 
 [0.8.4] 2019-02-14

--- a/neo/bin/export_blocks.py
+++ b/neo/bin/export_blocks.py
@@ -46,6 +46,7 @@ def main():
 
     # Instantiate the blockchain and subscribe to notifications
     blockchain = LevelDBBlockchain(settings.chain_leveldb_path)
+    Blockchain.DeregisterBlockchain()
     Blockchain.RegisterBlockchain(blockchain)
 
     chain = Blockchain.Default()

--- a/neo/bin/import_blocks.py
+++ b/neo/bin/import_blocks.py
@@ -18,7 +18,12 @@ from neo.Implementations.Notifications.LevelDB.NotificationDB import Notificatio
 import asyncio
 
 
-async def main():
+def main():
+    # needed for console scripts
+    asyncio.run(_main())
+
+
+async def _main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-m", "--mainnet", action="store_true", default=False,
                         help="use MainNet instead of the default TestNet")
@@ -58,7 +63,8 @@ async def main():
         settings.log_smart_contract_events = True
 
     if not args.input:
-        raise Exception("Please specify an input path")
+        print("Please specify an input path")
+        return
     file_path = args.input
 
     append = False
@@ -90,6 +96,7 @@ async def main():
 
         if append:
             blockchain = LevelDBBlockchain(settings.chain_leveldb_path, skip_header_check=True)
+            Blockchain.DeregisterBlockchain()
             Blockchain.RegisterBlockchain(blockchain)
 
             start_block = Blockchain.Default().Height
@@ -117,6 +124,7 @@ async def main():
 
             # Instantiate the blockchain and subscribe to notifications
             blockchain = LevelDBBlockchain(settings.chain_leveldb_path)
+            Blockchain.DeregisterBlockchain()
             Blockchain.RegisterBlockchain(blockchain)
 
         chain = Blockchain.Default()
@@ -143,6 +151,7 @@ async def main():
 
             # add
             if block.Index > start_block:
+                chain.AddHeaders([block.Header])
                 await chain.TryPersist(block)
 
             # reset blockheader
@@ -184,4 +193,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- Both `np-import` and `np-export` could try to register a blockchain without properly deregistering the existing one.
- the `np-import` script was setup to call 
https://github.com/CityOfZion/neo-python/blob/e7e57e5d3d9b3e859dfe39140361343a8f3b94e8/neo/bin/import_blocks.py#L21
but because that is a co-routine it would fail. This fixes that issue such that `np-import` can be run again, along side `python neo/bin/import_blocks`
- `np-import` was modified for speed to persist blocks directly and once done update the header list. This actually causes issues with smart contract execution. Specifically smart contracts that request block data (e.g. to get the timestamp) will fail. Reason being is that the code will call
https://github.com/CityOfZion/neo-python/blob/fe90f62e123d720d4281c79af0598d9df9e776fb/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py#L521-L532

where 
https://github.com/CityOfZion/neo-python/blob/fe90f62e123d720d4281c79af0598d9df9e776fb/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py#L530
will fail, because 
https://github.com/CityOfZion/neo-python/blob/fe90f62e123d720d4281c79af0598d9df9e776fb/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py#L43
is not filled with headers as expected because we skipped the `AddHeaders` call. This PR fixes that


**How did you solve this problem?**

**How did you make sure your solution works?**
manual testing

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
