### PR TITLE
revert nodemanager.start.port

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,6 @@ All notable changes to this project are documented in this file.
 - Various code cleaning updates
 - Ensure LevelDB iterators are close, ensure all ``MemoryStream`` usages go through ``StreamManger`` and are closed.
 - Fix ``np-import`` not importing headers ahead of block persisting potentially unexpected VM execution results
-- Fix ``nodemanager`` so the host port points to ``settings.NODE_PORT`` instead of 8888
 
 
 [0.8.4] 2019-02-14

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ All notable changes to this project are documented in this file.
 - Various code cleaning updates
 - Ensure LevelDB iterators are close, ensure all ``MemoryStream`` usages go through ``StreamManger`` and are closed.
 - Fix ``np-import`` not importing headers ahead of block persisting potentially unexpected VM execution results
+- Fix ``nodemanager`` so the host port points to ``settings.NODE_PORT`` instead of 8888
 
 
 [0.8.4] 2019-02-14

--- a/neo/Network/nodemanager.py
+++ b/neo/Network/nodemanager.py
@@ -69,7 +69,7 @@ class NodeManager(Singleton):
 
     async def start(self):
         host = 'localhost'
-        port = 8888  # settings.NODE_PORT
+        port = settings.NODE_PORT
         proto = partial(NeoProtocol, nodemanager=self)
 
         try:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- addresses https://github.com/CityOfZion/neo-python/pull/934#pullrequestreview-231428364 and https://github.com/CityOfZion/neo-python/pull/934#pullrequestreview-243522758

**How did you solve this problem?**
- now points to `settings.NODE_PORT` instead of `8888`

**How did you make sure your solution works?**
manual testing

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
