### PR TITLE
include alias in pretty print

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,7 +31,7 @@ All notable changes to this project are documented in this file.
 - Various code cleaning updates
 - Ensure LevelDB iterators are close, ensure all ``MemoryStream`` usages go through ``StreamManger`` and are closed.
 - Fix ``np-import`` not importing headers ahead of block persisting potentially unexpected VM execution results
-
+- Extend ``pretty_print`` to include address aliases
 
 [0.8.4] 2019-02-14
 ------------------

--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -525,8 +525,17 @@ class UserWallet(Wallet):
                 'tokens': self._get_token_balances(addr_str)
             }})
 
+        aliases = dict()
+        alia = NamedAddress.select()
+        if len(alia):
+            for n in alia:
+                aliases[n.Title] = n.ToString()
+
         # pretty print
         for address, data in addresses.items():
+            for title, addr in aliases.items():
+                if address == addr:
+                    print(f"Alias      : {title}")
             addr_str = address + " (watch only)" if data['watchonly'] else address
             print(f"Address    : {addr_str}")
             if verbose:

--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -527,9 +527,8 @@ class UserWallet(Wallet):
 
         aliases = dict()
         alia = NamedAddress.select()
-        if len(alia):
-            for n in alia:
-                aliases[n.Title] = n.ToString()
+        for n in alia:
+            aliases[n.Title] = n.ToString()
 
         # pretty print
         for address, data in addresses.items():

--- a/neo/Prompt/Commands/tests/test_address_commands.py
+++ b/neo/Prompt/Commands/tests/test_address_commands.py
@@ -97,6 +97,14 @@ class UserWalletTestCase(UserWalletTestCaseBase):
         res = CommandWallet().execute(args)
         self.assertFalse(res)
 
+        # verify wallet has no aliases
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = [""]
+            res = CommandWallet().execute(args)
+            self.assertTrue(res)
+            self.assertEqual(len(PromptData.Wallet.NamedAddr), 0)
+            self.assertNotIn("Alias", mock_print.getvalue())
+
         # test wallet alias successful
         self.assertNotIn('mine', [n.Title for n in PromptData.Wallet.NamedAddr])
 
@@ -104,6 +112,12 @@ class UserWalletTestCase(UserWalletTestCaseBase):
         res = CommandWallet().execute(args)
         self.assertTrue(res)
         self.assertIn('mine', [n.Title for n in PromptData.Wallet.NamedAddr])
+
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = [""]
+            res = CommandWallet().execute(args)
+            self.assertTrue(res)
+            self.assertIn("Alias      : mine", mock_print.getvalue())
 
     def test_6_split_unspent(self):
         wallet = self.GetWallet1(recreate=True)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- resubmitting https://github.com/ixje/neo-python/pull/18
- addresses https://github.com/CityOfZion/neo-python/pull/934#issuecomment-496112560

**How did you solve this problem?**
- if an alias exists for the address, print the alias
- updated tests

**NOTE:** Right now there is no ability within neo-python to update/delete the alias once it is set. I think this should be a future feature update.

**How did you make sure your solution works?**
manual testing initially and `make test` after tests were updated

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [x] Did you add any tests? (updated)
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
