### PR TITLE
Fix BigInteger bitwise shifting behaviour

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ All notable changes to this project are documented in this file.
 - Ensure LevelDB iterators are close, ensure all ``MemoryStream`` usages go through ``StreamManger`` and are closed.
 - Fix ``np-import`` not importing headers ahead of block persisting potentially unexpected VM execution results
 - Fix undesired debug statement printing
+- Add negative bitwise shifting support for ``BigInteger`` to match C#
 
 
 [0.8.4] 2019-02-14

--- a/neo/Core/BigInteger.py
+++ b/neo/Core/BigInteger.py
@@ -54,10 +54,20 @@ class BigInteger(int):
         return BigInteger(super(BigInteger, self).__floordiv__(*args, **kwargs))
 
     def __rshift__(self, *args, **kwargs):
-        return BigInteger(super(BigInteger, self).__rshift__(*args, **kwargs))
+        shift = args[0]
+        if shift < 0:
+            shift = abs(shift)
+            return BigInteger(super(BigInteger, self).__lshift__(shift, **kwargs))
+        else:
+            return BigInteger(super(BigInteger, self).__rshift__(*args, **kwargs))
 
     def __lshift__(self, *args, **kwargs):
-        return BigInteger(super(BigInteger, self).__lshift__(*args, **kwargs))
+        shift = args[0]
+        if shift < 0:
+            shift = abs(shift)
+            return BigInteger(super(BigInteger, self).__rshift__(shift, **kwargs))
+        else:
+            return BigInteger(super(BigInteger, self).__lshift__(*args, **kwargs))
 
 
 ZERO = BigInteger(0)

--- a/neo/Core/tests/test_numbers.py
+++ b/neo/Core/tests/test_numbers.py
@@ -324,6 +324,21 @@ class BigIntegerTestCase(TestCase):
         self.assertEqual(left_shift, 8)
         self.assertIsInstance(left_shift, BigInteger)
 
+    def test_negative_shifting(self):
+        # C#'s BigInteger changes a left shift with a negative shift index,
+        # to a right shift with a positive index.
+
+        b1 = BigInteger(8)
+        b2 = BigInteger(-3)
+        # shift against BigInteger
+        self.assertEqual(1, b1 << b2)
+        # shift against integer
+        self.assertEqual(1, b1 << -3)
+
+        # the same as above but for right shift
+        self.assertEqual(64, b1 >> b2)
+        self.assertEqual(64, b1 >> -3)
+
 
 class UIntBaseTestCase(TestCase):
     def test_initialization(self):


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
fix https://github.com/CityOfZion/neo-python/issues/951

**How did you solve this problem?**
convert negative lshift into positive rshift and negative rshift into positive lshift.

**How did you make sure your solution works?**
added tests cmparing against C# output

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
