### PR TITLE
Fix `config maxpeers`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ All notable changes to this project are documented in this file.
 - Fix ``np-import`` not importing headers ahead of block persisting potentially unexpected VM execution results
 - Fix undesired debug statement printing
 - Add negative bitwise shifting support for ``BigInteger`` to match C#
+- Fix ``config maxpeers`` and update tests
 
 
 [0.8.4] 2019-02-14

--- a/neo/Prompt/Commands/Config.py
+++ b/neo/Prompt/Commands/Config.py
@@ -1,4 +1,3 @@
-import asyncio
 from neo.Network.common import blocking_prompt as prompt
 from neo.logging import log_manager
 from neo.Prompt.CommandBase import CommandBase, CommandDesc, ParameterDesc
@@ -8,6 +7,7 @@ from neo.Prompt.PromptPrinter import prompt_print as print
 from distutils import util
 from neo.Network.nodemanager import NodeManager
 import logging
+from neo.Network.common import wait_for
 
 
 class CommandConfig(CommandBase):
@@ -201,13 +201,9 @@ class CommandConfigMaxpeers(CommandBase):
             connected_count = len(nodemgr.nodes)
             if current_max < connected_count:
                 to_remove = connected_count - c1
-                r_list = []
-                i = 1
                 for _ in range(to_remove):
-                    r_list.append(nodemgr.nodes[-i])
-                    i += 1
-                for node in r_list:
-                    asyncio.run_coroutine_threadsafe(node.disconnect(), nodemgr.loop)  # need to avoid it being labelled as dead/bad
+                    last_connected_node = nodemgr.nodes[-1]
+                    wait_for(last_connected_node.disconnect())  # need to avoid it being labelled as dead/bad
 
             print(f"Maxpeers set to {c1}")
             return c1

--- a/neo/Prompt/Commands/tests/test_config_commands.py
+++ b/neo/Prompt/Commands/tests/test_config_commands.py
@@ -2,6 +2,8 @@ import os
 from neo.Settings import settings
 from neo.Utils.BlockchainFixtureTestCase import BlockchainFixtureTestCase
 from neo.Prompt.Commands.Config import CommandConfig
+from neo.Network.nodemanager import NodeManager
+from neo.Network.node import NeoNode
 from mock import patch
 from io import StringIO
 from neo.Prompt.PromptPrinter import pp
@@ -114,11 +116,15 @@ class CommandConfigTestCase(BlockchainFixtureTestCase):
         self.assertFalse(res)
 
     def test_config_maxpeers(self):
+        nodemgr = NodeManager()
+        nodemgr.reset_for_test()
+
         # test no input and verify output confirming current maxpeers
         with patch('sys.stdout', new=StringIO()) as mock_print:
             args = ['maxpeers']
             res = CommandConfig().execute(args)
             self.assertFalse(res)
+            self.assertEqual(settings.CONNECTED_PEER_MAX, 10)
             self.assertIn(f"Maintaining maxpeers at {settings.CONNECTED_PEER_MAX}", mock_print.getvalue())
 
         # test changing the number of maxpeers
@@ -126,8 +132,16 @@ class CommandConfigTestCase(BlockchainFixtureTestCase):
             args = ['maxpeers', "6"]
             res = CommandConfig().execute(args)
             self.assertTrue(res)
+            self.assertEqual(settings.CONNECTED_PEER_MAX, 6)
             self.assertEqual(int(res), settings.CONNECTED_PEER_MAX)
             self.assertIn(f"Maxpeers set to {settings.CONNECTED_PEER_MAX}", mock_print.getvalue())
+
+        # test trying to set maxpeers > 10
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['maxpeers', "12"]
+            res = CommandConfig().execute(args)
+            self.assertFalse(res)
+            self.assertIn("Max peers is limited to 10", mock_print.getvalue())
 
         # test bad input
         with patch('sys.stdout', new=StringIO()) as mock_print:
@@ -142,6 +156,48 @@ class CommandConfigTestCase(BlockchainFixtureTestCase):
             res = CommandConfig().execute(args)
             self.assertFalse(res)
             self.assertIn("Please supply a positive integer for maxpeers", mock_print.getvalue())
+
+        # test if the new maxpeers < settings.CONNECTED_PEER_MAX
+        # first make sure we have a predictable state
+        node1 = NeoNode(object, object)
+        node2 = NeoNode(object, object)
+        node1.address = "127.0.0.1:20333"
+        node2.address = "127.0.0.1:20334"
+
+        nodemgr.nodes = [node1, node2]
+        nodemgr.loop = object
+
+        with patch("neo.Network.node.NeoNode.disconnect") as mock_disconnect:
+            # first test if the number of connected peers !< new maxpeers
+            self.assertEqual(nodemgr.max_clients, 6)  # verifying the current number of maxpeers
+            with patch('sys.stdout', new=StringIO()) as mock_print:
+                args = ['maxpeers', "4"]
+                res = CommandConfig().execute(args)
+                self.assertTrue(res)
+                self.assertEqual(nodemgr.max_clients, 4)
+                self.assertFalse(mock_disconnect.called)
+                self.assertEqual(settings.CONNECTED_PEER_MAX, 4)
+                self.assertIn(f"Maxpeers set to {settings.CONNECTED_PEER_MAX}", mock_print.getvalue())
+
+            # now test if the number of connected peers < new maxpeers and < current minpeers
+            self.assertEqual(settings.CONNECTED_PEER_MIN, 4)  # verifying the current minpeers value
+            with patch('sys.stdout', new=StringIO()) as mock_print:
+                with patch('neo.Prompt.Commands.Config.asyncio'):
+                    args = ['maxpeers', "1"]
+                    res = CommandConfig().execute(args)
+                    self.assertTrue(res)
+                    self.assertEqual(nodemgr.max_clients, 1)
+                    self.assertTrue(mock_disconnect.called)
+                    self.assertEqual(settings.CONNECTED_PEER_MAX, 1)
+                    self.assertIn(f"Maxpeers set to {settings.CONNECTED_PEER_MAX}", mock_print.getvalue())
+
+                    self.assertEqual(settings.CONNECTED_PEER_MIN, 1)
+                    self.assertIn(f"Minpeers set to {settings.CONNECTED_PEER_MIN}", mock_print.getvalue())
+
+        # reset for future tests
+        nodemgr.reset_for_test()
+        nodemgr.loop = None
+        settings.set_max_peers(10)
 
     def test_config_minpeers(self):
         # test no input and verify output confirming current minpeers

--- a/neo/Prompt/Commands/tests/test_config_commands.py
+++ b/neo/Prompt/Commands/tests/test_config_commands.py
@@ -182,7 +182,7 @@ class CommandConfigTestCase(BlockchainFixtureTestCase):
             # now test if the number of connected peers < new maxpeers and < current minpeers
             self.assertEqual(settings.CONNECTED_PEER_MIN, 4)  # verifying the current minpeers value
             with patch('sys.stdout', new=StringIO()) as mock_print:
-                with patch('neo.Prompt.Commands.Config.asyncio'):
+                with patch('neo.Prompt.Commands.Config.wait_for'):
                     args = ['maxpeers', "1"]
                     res = CommandConfig().execute(args)
                     self.assertTrue(res)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
**NOTE**: updated re-submission of https://github.com/ixje/neo-python/pull/12

- update for `minpeers`
- update for errors when the new `maxpeers` < connected peers
- update tests

**How did you solve this problem?**
- update to set `minpeers` equal to `maxpeers` if `maxpeers` < `minpeers`
- specifically, when new `maxpeers` < connected peers
  - fixes a RuntimeError caused by calling a coro in another loop
    - see https://github.com/ixje/neo-python/pull/12#pullrequestreview-231447541
  - fixes an error where the same node was disconnected multiple times
    - see https://github.com/ixje/neo-python/pull/12/files/7292761e76ac3a983dbbfc85b41b0b9ef406cbb7..be1307860d274b0db82b3eaf06ff6cb37037350b
- updates tests


**How did you make sure your solution works?**
manual testing and `make test`

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
