### PR TITLE
Fix prompt list parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ All notable changes to this project are documented in this file.
 - Add negative bitwise shifting support for ``BigInteger`` to match C#
 - Include address aliases in ``wallet`` command output
 - Fix ``config maxpeers`` and update tests
+- Fix error while parsing list arguments from prompt for smart contract test invocations
 
 
 [0.8.4] 2019-02-14

--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -217,12 +217,7 @@ def parse_param(p, wallet=None, ignore_int=False, prefer_hex=True, parse_addr=Tr
     # first, we'll try to parse an array
     try:
         items = eval(p, {"__builtins__": {'list': list}}, {})
-        if len(items) > 0 and type(items) is list:
-
-            parsed = []
-            for item in items:
-                parsed.append(parse_param(item, wallet, parse_addr=parse_addr))
-            return parsed
+        return items
 
     except Exception as e:
         #        print("Could not eval items as array %s " % e)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
when running sc invocations via e.g. the `build_run` command we parse the smart contract parameters from the console. Specifically list arguments were trouble some. Take
```
sc build_run sc.py False False False 0210 01 1 ['aa']
```
The old logic would parse `['aa']` into a BigInteger because 
https://github.com/CityOfZion/neo-python/blob/d2362d4de3e278da7fe7dd68a07d798053a1f7bd/neo/Prompt/Commands/Invoke.py#L509
would turn `['aa']` into `[b'6161']` because it uses recursion internally.
Then when we continue we parse the items again in which 

https://github.com/CityOfZion/neo-python/blob/d2362d4de3e278da7fe7dd68a07d798053a1f7bd/neo/Prompt/Commands/Invoke.py#L510-L514

which now tries to parse `[b'6161']` and that will happily be picked up at https://github.com/CityOfZion/neo-python/blob/d2362d4de3e278da7fe7dd68a07d798053a1f7bd/neo/Prompt/Utils.py#L232-L235
and now we have a `BigInteger` we do not want.

**How did you solve this problem?**
the quick fix was to remove the recursion from list parsing. The downside this limits how many lists can be nested. The upside is it is fast. We should redo the whole prompt parsing and script builder for neo-python 3.0

**How did you make sure your solution works?**
manual testing

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
