### PR TITLE
Fix Runtime.Trigger and Transaction.GetType syscalls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ All notable changes to this project are documented in this file.
 - Include address aliases in ``wallet`` command output
 - Fix ``config maxpeers`` and update tests
 - Fix error while parsing list arguments from prompt for smart contract test invocations
+- Fix ``Runtime.GetTrigger`` and ``Transaction.GetType`` syscalls pushing wrong StackItem type
 
 
 [0.8.4] 2019-02-14

--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -302,9 +302,9 @@ class StateMachine(StateReader):
             return False
 
         if isinstance(tx.Type, bytes):
-            engine.CurrentContext.EvaluationStack.PushT(tx.Type)
+            engine.CurrentContext.EvaluationStack.PushT(int.from_bytes(tx.Type, 'little'))
         else:
-            engine.CurrentContext.EvaluationStack.PushT(tx.Type.to_bytes(1, 'little'))
+            engine.CurrentContext.EvaluationStack.PushT(tx.Type)
         return True
 
     def Transaction_GetAttributes(self, engine: ExecutionEngine):

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -193,7 +193,7 @@ class StateReader(InteropService):
 
     def Runtime_GetTrigger(self, engine):
 
-        engine.CurrentContext.EvaluationStack.PushT(engine.Trigger)
+        engine.CurrentContext.EvaluationStack.PushT(int.from_bytes(engine.Trigger, 'little'))
 
         return True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ mmh3==2.5.1
 mock==2.0.0
 mpmath==1.1.0
 multidict==4.5.2
-git+https://github.com/ixje/neo-boa@01ea0207250c8ee96bca673e6e587796888e58d1#egg=neo-boa
+git+https://github.com/ixje/neo-boa@6bc33703b80e687d5fb9eed2e1f5e6708221c13d#egg=neo-boa
 neo-python-rpc==0.2.1
 pbr==5.1.3
 peewee==3.9.2


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
The ongoing audit showed a deviation in gas consumption for Testnet block 449841. 
Both `RunTime.Trigger` and `Transaction.GetType` are supposed to push integers to the stack, neo-python pushed bytes. For the majority of time this worked well, but the mentioned block showed a contract where a `NUMEQUAL` instruction would fail the comparison in `neo-python` whereas `neo-cli` passed. This caused the next instruction `JMPIFNOT` to take a different branch and the rest is history. 

**How did you solve this problem?**
pushing int's instead of bytes.

**How did you make sure your solution works?**
audit of the block now passes (=gas consumption equals neo-cli)

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
