### PR TITLE
changing PICKITEM handling of invalid type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ All notable changes to this project are documented in this file.
 - Fix ``config maxpeers`` and update tests
 - Fix error while parsing list arguments from prompt for smart contract test invocations
 - Fix ``Runtime.GetTrigger`` and ``Transaction.GetType`` syscalls pushing wrong StackItem type
+- Update handling of default cause for ``PICKITEM`` instruction
 
 
 [0.8.4] 2019-02-14

--- a/neo/SmartContract/tests/test_vm_error_output.py
+++ b/neo/SmartContract/tests/test_vm_error_output.py
@@ -37,11 +37,11 @@ class TestVMErrors(BoaTest):
 
     def test_invalid_type_indexing(self):
         with self.assertLogHandler('vm', DEBUG) as log_context:
-            tx, results, total_ops, engine = TestBuild(self.script, [3, ['my_arg0']], self.GetWallet1(), '0210', '07')
+            tx, results, total_ops, engine = TestBuild(self.script, [3, [1]], self.GetWallet1(), '0210', '07')
             self.assertTrue(len(log_context.output) > 0)
             log_msg = log_context.output[0]
             # an index of 1 for an array with length one is out of bounds
-            self.assertTrue("Array index is less than zero or 1 exceeds list length 1" in log_msg)
+            self.assertTrue("Item is not an Array or Map but of type" in log_msg)
 
     def test_invalid_appcall(self):
         with self.assertLogHandler('vm', DEBUG) as log_context:

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -924,13 +924,7 @@ class ExecutionEngine:
                     else:
                         return self.VM_FAULT_and_report(VMFault.DICT_KEY_NOT_FOUND, key, collection.Keys)
                 else:
-                    byte_array = collection.GetByteArray()
-                    index = key.GetBigInteger()
-                    if index < 0 or index >= len(byte_array):
-                        self.VM_FAULT_and_report(VMFault.PICKITEM_INVALID_INDEX, index, len(byte_array))
-                        return
-                    estack.PushT(byte_array[index])
-                    self.CheckStackSize(True, -1)
+                    return False
 
             elif opcode == SETITEM:
                 value = estack.Pop()

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -924,7 +924,7 @@ class ExecutionEngine:
                     else:
                         return self.VM_FAULT_and_report(VMFault.DICT_KEY_NOT_FOUND, key, collection.Keys)
                 else:
-                    return False
+                    return self.VM_FAULT_and_report(VMFault.PICKITEM_INVALID_TYPE, key, collection)
 
             elif opcode == SETITEM:
                 value = estack.Pop()
@@ -1284,7 +1284,7 @@ class ExecutionEngine:
         elif id == VMFault.PICKITEM_INVALID_TYPE:
             index = args[0]
             item = args[1]
-            error_msg = "Cannot access item at index {}. Item is not an array or dict but of type: {}".format(index, type(item))
+            error_msg = "Cannot access item at index {}. Item is not an Array or Map but of type: {}".format(index, type(item))
 
         elif id == VMFault.PICKITEM_NEGATIVE_INDEX:
             error_msg = "Attempting to access an array using a negative index"

--- a/neo/VM/tests/test_interop_map.py
+++ b/neo/VM/tests/test_interop_map.py
@@ -156,21 +156,6 @@ class InteropTest(NeoTestCase):
             self.assertTrue(len(log_context.output) > 0)
             self.assertTrue('VMFault.KEY_IS_COLLECTION' in log_context.output[0])
 
-    def test_op_map8(self):
-        with self.assertLogHandler('vm', logging.DEBUG) as log_context:
-            # pick item out of bounds
-            self.econtext.EvaluationStack.PushT(StackItem.New('a'))
-            self.econtext.EvaluationStack.PushT(StackItem.New('a'))
-            self.econtext.Script._value = OpCode.PICKITEM
-            self.engine.ExecuteInstruction()
-
-            self.assertTrue(len(log_context.output) > 0)
-            log_msg = log_context.output[0]
-            expected_msg = "Array index is less than zero or 97 exceeds list length 1"
-            self.assertTrue(expected_msg in log_msg)
-
-            self.assertEqual(self.engine.State, VMState.FAULT)
-
     def test_op_map9(self):
         with self.assertLogHandler('vm', logging.DEBUG) as log_context:
             # pick item key not found


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
audit of block testnet block 460271 showed a deviation in VMState. The root cause is a difference in handling types that are not of type Array or Map.

**How did you solve this problem?**
fix the default handling to match C#

**How did you make sure your solution works?**
block now passes with the same results as neo-cli

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
