### PR TITLE
Fix InteropService.Getinterface not validating types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ All notable changes to this project are documented in this file.
 - Fix error while parsing list arguments from prompt for smart contract test invocations
 - Fix ``Runtime.GetTrigger`` and ``Transaction.GetType`` syscalls pushing wrong StackItem type
 - Update handling of default cause for ``PICKITEM`` instruction
+- Fix ``InteropService.GetInterface`` not validating types correctly
 
 
 [0.8.4] 2019-02-14

--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -1,4 +1,13 @@
 import sys
+from neo.Core.BlockBase import BlockBase
+from neo.Core.TX.Transaction import Transaction, TransactionOutput
+from neo.Core.TX.TransactionAttribute import TransactionAttribute
+from neo.Core.TX.InvocationTransaction import InvocationTransaction
+from neo.Core.CoinReference import CoinReference
+from neo.SmartContract.Iterable import Enumerator, Iterator
+
+import neo.Core.State
+
 from neo.Core.State.ContractState import ContractState
 from neo.Core.State.AssetState import AssetState
 from neo.Core.Blockchain import Blockchain
@@ -269,35 +278,35 @@ class StateMachine(StateReader):
         return True
 
     def Header_GetVersion(self, engine: ExecutionEngine):
-        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface(BlockBase)
         if header is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(header.Version)
         return True
 
     def Header_GetMerkleRoot(self, engine: ExecutionEngine):
-        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface(BlockBase)
         if header is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(header.MerkleRoot.ToArray())
         return True
 
     def Header_GetConsensusData(self, engine: ExecutionEngine):
-        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface(BlockBase)
         if header is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(header.ConsensusData)
         return True
 
     def Header_GetNextConsensus(self, engine: ExecutionEngine):
-        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface(BlockBase)
         if header is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(header.NextConsensus.ToArray())
         return True
 
     def Transaction_GetType(self, engine: ExecutionEngine):
-        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Transaction)
         if tx is None:
             return False
 
@@ -308,7 +317,7 @@ class StateMachine(StateReader):
         return True
 
     def Transaction_GetAttributes(self, engine: ExecutionEngine):
-        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Transaction)
         if tx is None:
             return False
 
@@ -320,7 +329,7 @@ class StateMachine(StateReader):
         return True
 
     def Transaction_GetInputs(self, engine: ExecutionEngine):
-        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Transaction)
         if tx is None:
             return False
 
@@ -332,7 +341,7 @@ class StateMachine(StateReader):
         return True
 
     def Transaction_GetOutputs(self, engine: ExecutionEngine):
-        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Transaction)
 
         if tx is None:
             return False
@@ -349,7 +358,7 @@ class StateMachine(StateReader):
         return True
 
     def Transaction_GetReferences(self, engine: ExecutionEngine):
-        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Transaction)
 
         if tx is None:
             return False
@@ -363,7 +372,7 @@ class StateMachine(StateReader):
         return True
 
     def Transaction_GetUnspentCoins(self, engine: ExecutionEngine):
-        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Transaction)
 
         if tx is None:
             return False
@@ -377,7 +386,7 @@ class StateMachine(StateReader):
         return True
 
     def Transaction_GetWitnesses(self, engine: ExecutionEngine):
-        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Transaction)
 
         if tx is None:
             return False
@@ -390,13 +399,14 @@ class StateMachine(StateReader):
         return True
 
     def InvocationTransaction_GetScript(self, engine: ExecutionEngine):
-        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface(InvocationTransaction)
         if tx is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(tx.Script)
         return True
 
     def Witness_GetVerificationScript(self, engine: ExecutionEngine):
+        # TODO: create witness wrapper
         witness = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
         if witness is None:
             return False
@@ -404,28 +414,28 @@ class StateMachine(StateReader):
         return True
 
     def Attribute_GetUsage(self, engine: ExecutionEngine):
-        attr = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        attr = engine.CurrentContext.EvaluationStack.Pop().GetInterface(TransactionAttribute)
         if attr is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(attr.Usage)
         return True
 
     def Attribute_GetData(self, engine: ExecutionEngine):
-        attr = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        attr = engine.CurrentContext.EvaluationStack.Pop().GetInterface(TransactionAttribute)
         if attr is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(attr.Data)
         return True
 
     def Input_GetHash(self, engine: ExecutionEngine):
-        input = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        input = engine.CurrentContext.EvaluationStack.Pop().GetInterface(CoinReference)
         if input is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(input.PrevHash.ToArray())
         return True
 
     def Input_GetIndex(self, engine: ExecutionEngine):
-        input = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        input = engine.CurrentContext.EvaluationStack.Pop().GetInterface(CoinReference)
         if input is None:
             return False
 
@@ -433,7 +443,7 @@ class StateMachine(StateReader):
         return True
 
     def Output_GetAssetId(self, engine: ExecutionEngine):
-        output = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        output = engine.CurrentContext.EvaluationStack.Pop().GetInterface(TransactionOutput)
 
         if output is None:
             return False
@@ -442,7 +452,7 @@ class StateMachine(StateReader):
         return True
 
     def Output_GetValue(self, engine: ExecutionEngine):
-        output = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        output = engine.CurrentContext.EvaluationStack.Pop().GetInterface(TransactionOutput)
         if output is None:
             return False
 
@@ -450,7 +460,7 @@ class StateMachine(StateReader):
         return True
 
     def Output_GetScriptHash(self, engine: ExecutionEngine):
-        output = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        output = engine.CurrentContext.EvaluationStack.Pop().GetInterface(TransactionOutput)
 
         if output is None:
             return False
@@ -459,14 +469,14 @@ class StateMachine(StateReader):
         return True
 
     def Account_GetScriptHash(self, engine: ExecutionEngine):
-        account = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        account = engine.CurrentContext.EvaluationStack.Pop().GetInterface(AccountState)
         if account is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(account.ScriptHash.ToArray())
         return True
 
     def Account_GetVotes(self, engine: ExecutionEngine):
-        account = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        account = engine.CurrentContext.EvaluationStack.Pop().GetInterface(AccountState)
         if account is None:
             return False
 
@@ -475,7 +485,7 @@ class StateMachine(StateReader):
         return True
 
     def Account_GetBalance(self, engine: ExecutionEngine):
-        account = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        account = engine.CurrentContext.EvaluationStack.Pop().GetInterface(AccountState)
         assetId = UInt256(data=engine.CurrentContext.EvaluationStack.Pop().GetByteArray())
 
         if account is None:
@@ -568,7 +578,7 @@ class StateMachine(StateReader):
 
     def Asset_Renew(self, engine: ExecutionEngine):
 
-        current_asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        current_asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface(neo.Core.State.AssetState.AssetState)
 
         if current_asset is None:
             return False
@@ -597,56 +607,56 @@ class StateMachine(StateReader):
         return True
 
     def Asset_GetAssetId(self, engine: ExecutionEngine):
-        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface(neo.Core.State.AssetState.AssetState)
         if asset is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(asset.AssetId.ToArray())
         return True
 
     def Asset_GetAssetType(self, engine: ExecutionEngine):
-        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface(neo.Core.State.AssetState.AssetState)
         if asset is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(asset.AssetType)
         return True
 
     def Asset_GetAmount(self, engine: ExecutionEngine):
-        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface(neo.Core.State.AssetState.AssetState)
         if asset is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(asset.Amount.GetData())
         return True
 
     def Asset_GetAvailable(self, engine: ExecutionEngine):
-        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface(neo.Core.State.AssetState.AssetState)
         if asset is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(asset.Available.GetData())
         return True
 
     def Asset_GetPrecision(self, engine: ExecutionEngine):
-        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface(neo.Core.State.AssetState.AssetState)
         if asset is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(asset.Precision)
         return True
 
     def Asset_GetOwner(self, engine: ExecutionEngine):
-        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface(neo.Core.State.AssetState.AssetState)
         if asset is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(asset.Owner.EncodePoint(True))
         return True
 
     def Asset_GetAdmin(self, engine: ExecutionEngine):
-        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface(neo.Core.State.AssetState.AssetState)
         if asset is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(asset.Admin.ToArray())
         return True
 
     def Asset_GetIssuer(self, engine: ExecutionEngine):
-        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        asset = engine.CurrentContext.EvaluationStack.Pop().GetInterface(neo.Core.State.AssetState.AssetState)
         if asset is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(asset.Issuer.ToArray())
@@ -778,21 +788,21 @@ class StateMachine(StateReader):
         return self.Contract_Destroy(engine)
 
     def Contract_GetScript(self, engine: ExecutionEngine):
-        contract = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        contract = engine.CurrentContext.EvaluationStack.Pop().GetInterface(ContractState)
         if contract is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(contract.Code.Script)
         return True
 
     def Contract_IsPayable(self, engine: ExecutionEngine):
-        contract = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        contract = engine.CurrentContext.EvaluationStack.Pop().GetInterface(ContractState)
         if contract is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(contract.Payable)
         return True
 
     def Storage_Find(self, engine: ExecutionEngine):
-        context = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        context = engine.CurrentContext.EvaluationStack.Pop().GetInterface(StorageContext)
         if context is None:
             return False
 
@@ -816,14 +826,14 @@ class StateMachine(StateReader):
         return False
 
     def Enumerator_Next(self, engine: ExecutionEngine):
-        item = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        item = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Enumerator)
         if item is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(item.Next())
         return True
 
     def Enumerator_Value(self, engine: ExecutionEngine):
-        item = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        item = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Enumerator)
         if item is None:
             return False
 
@@ -831,11 +841,11 @@ class StateMachine(StateReader):
         return True
 
     def Enumerator_Concat(self, engine: ExecutionEngine):
-        item1 = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        item1 = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Enumerator)
         if item1 is None:
             return False
 
-        item2 = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        item2 = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Enumerator)
         if item2 is None:
             return False
 
@@ -852,7 +862,11 @@ class StateMachine(StateReader):
         return False
 
     def Iterator_Key(self, engine: ExecutionEngine):
-        iterator = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        try:
+            iterator = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Iterator)
+        except TypeError:
+            return False
+
         if iterator is None:
             return False
 
@@ -860,7 +874,11 @@ class StateMachine(StateReader):
         return True
 
     def Iterator_Keys(self, engine: ExecutionEngine):
-        iterator = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        try:
+            iterator = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Iterator)
+        except TypeError:
+            return False
+
         if iterator is None:
             return False
         wrapper = StackItem.FromInterface(KeysWrapper(iterator))
@@ -868,7 +886,11 @@ class StateMachine(StateReader):
         return True
 
     def Iterator_Values(self, engine: ExecutionEngine):
-        iterator = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        try:
+            iterator = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Iterator)
+        except TypeError:
+            return False
+        
         if iterator is None:
             return False
 
@@ -877,11 +899,11 @@ class StateMachine(StateReader):
         return True
 
     def Iterator_Concat(self, engine: ExecutionEngine):
-        item1 = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        item1 = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Iterator)
         if item1 is None:
             return False
 
-        item2 = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        item2 = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Iterator)
         if item2 is None:
             return False
 

--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -890,7 +890,7 @@ class StateMachine(StateReader):
             iterator = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Iterator)
         except TypeError:
             return False
-        
+
         if iterator is None:
             return False
 

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -3,6 +3,9 @@ from neo.SmartContract.Contract import Contract
 from neo.SmartContract.NotifyEventArgs import NotifyEventArgs
 from neo.SmartContract.StorageContext import StorageContext
 from neo.Core.State.StorageKey import StorageKey
+from neo.Core.BlockBase import BlockBase
+from neo.Core.Block import Block
+from neo.Core.TX.Transaction import Transaction
 from neo.Core.Blockchain import Blockchain
 from neo.Core.Cryptography.Crypto import Crypto
 from neo.Core.BigInteger import BigInteger
@@ -432,28 +435,28 @@ class StateReader(InteropService):
         return True
 
     def Header_GetIndex(self, engine: ExecutionEngine):
-        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface(BlockBase)
         if header is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(header.Index)
         return True
 
     def Header_GetHash(self, engine: ExecutionEngine):
-        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface(BlockBase)
         if header is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(header.Hash.ToArray())
         return True
 
     def Header_GetPrevHash(self, engine: ExecutionEngine):
-        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface(BlockBase)
         if header is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(header.PrevHash.ToArray())
         return True
 
     def Header_GetTimestamp(self, engine: ExecutionEngine):
-        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        header = engine.CurrentContext.EvaluationStack.Pop().GetInterface(BlockBase)
         if header is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(header.Timestamp)
@@ -461,14 +464,14 @@ class StateReader(InteropService):
         return True
 
     def Block_GetTransactionCount(self, engine: ExecutionEngine):
-        block = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        block = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Block)
         if block is None:
             return False
         engine.CurrentContext.EvaluationStack.PushT(len(block.Transactions))
         return True
 
     def Block_GetTransactions(self, engine: ExecutionEngine):
-        block = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        block = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Block)
         if block is None:
             return False
 
@@ -480,7 +483,7 @@ class StateReader(InteropService):
         return True
 
     def Block_GetTransaction(self, engine: ExecutionEngine):
-        block = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        block = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Block)
         index = engine.CurrentContext.EvaluationStack.Pop().GetBigInteger()
 
         if block is None or index < 0 or index > len(block.Transactions):
@@ -491,7 +494,7 @@ class StateReader(InteropService):
         return True
 
     def Transaction_GetHash(self, engine: ExecutionEngine):
-        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        tx = engine.CurrentContext.EvaluationStack.Pop().GetInterface(Transaction)
         if tx is None:
             return False
 
@@ -515,7 +518,7 @@ class StateReader(InteropService):
         return True
 
     def StorageContext_AsReadOnly(self, engine: ExecutionEngine):
-        context = engine.CurrentContext.EvaluationStack.Pop.GetInterface()
+        context = engine.CurrentContext.EvaluationStack.Pop.GetInterface(StorageContext)
 
         if context is None:
             return False
@@ -530,9 +533,8 @@ class StateReader(InteropService):
         context = None
         try:
             item = engine.CurrentContext.EvaluationStack.Pop()
-            context = item.GetInterface()
+            context = item.GetInterface(StorageContext)
         except Exception as e:
-            logger.error("could not get storage context %s " % e)
             return False
 
         if not self.CheckStorageContext(context):
@@ -569,9 +571,8 @@ class StateReader(InteropService):
 
         context = None
         try:
-            context = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+            context = engine.CurrentContext.EvaluationStack.Pop().GetInterface(StorageContext)
         except Exception as e:
-            logger.error("Storage Context Not found on stack")
             return False
 
         if not self.CheckStorageContext(context):
@@ -605,7 +606,7 @@ class StateReader(InteropService):
 
     def Contract_GetStorageContext(self, engine):
 
-        contract = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        contract = engine.CurrentContext.EvaluationStack.Pop().GetInterface(ContractState)
 
         shash = contract.Code.ScriptHash()
 
@@ -648,7 +649,7 @@ class StateReader(InteropService):
 
     def Storage_Delete(self, engine: ExecutionEngine):
 
-        context = engine.CurrentContext.EvaluationStack.Pop().GetInterface()
+        context = engine.CurrentContext.EvaluationStack.Pop().GetInterface(StorageContext)
 
         if not self.CheckStorageContext(context):
             return False

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -399,8 +399,14 @@ class InteropInterface(StackItem):
     def GetByteArray(self):
         raise Exception("Not supported- Cant get byte array for item %s %s " % (type(self), self._object))
 
-    def GetInterface(self):
-        return self._object
+    def GetInterface(self, interface_type=None):
+        if interface_type is None:
+            return self._object
+        else:
+            if issubclass(type(self._object), interface_type):
+                return self._object
+            else:
+                return None
 
     def Serialize(self, writer):
         raise Exception('Not supported- Cannot serialize Interop Interface %s %s ' % (type(self), self._object))


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
The audit of testnet block `620999` showed that the `GetInterface()` method of `InteropService` didn't do anything when it comes to checking subclassing of the specified type. This caused some interop methods to pass validation where they should have failed resulting in deviating VM behaviour.

**How did you solve this problem?**
Update the method to use type information

**How did you make sure your solution works?**
audit of the above block now passes

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
