### PR TITLE
Speedup np-import when appending blocks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ All notable changes to this project are documented in this file.
 - Fix error while parsing list arguments from prompt for smart contract test invocations
 - Fix ``Runtime.GetTrigger`` and ``Transaction.GetType`` syscalls pushing wrong StackItem type
 - Update handling of default cause for ``PICKITEM`` instruction
+- Speed up `np-import` when appending blocks
 
 
 [0.8.4] 2019-02-14

--- a/neo/bin/import_blocks.py
+++ b/neo/bin/import_blocks.py
@@ -94,13 +94,25 @@ async def _main():
         target_dir = os.path.join(settings.DATA_DIR_PATH, settings.LEVELDB_PATH)
         notif_target_dir = os.path.join(settings.DATA_DIR_PATH, settings.NOTIFICATION_DB_PATH)
 
+        stream = MemoryStream()
+        reader = BinaryReader(stream)
+        block = Block()
+        length_ba = bytearray(4)
+        ctr = 0
+
         if append:
-            blockchain = LevelDBBlockchain(settings.chain_leveldb_path, skip_header_check=True)
+            blockchain = LevelDBBlockchain(settings.chain_leveldb_path, skip_header_check=False)
             Blockchain.DeregisterBlockchain()
             Blockchain.RegisterBlockchain(blockchain)
 
             start_block = Blockchain.Default().Height
             print("Starting import at %s " % start_block)
+
+            for _ in trange(start_block + 1, desc='Skipping blocks', unit='Block'):
+                file_input.readinto(length_ba)
+                block_len = int.from_bytes(length_ba, 'little')
+                file_input.seek(block_len, 1)
+                ctr += 1
         else:
             print("Will import %s of %s blocks to %s" % (total_blocks, total_blocks_available, target_dir))
             print("This will overwrite any data currently in %s and %s.\nType 'confirm' to continue" % (target_dir, notif_target_dir))
@@ -132,12 +144,7 @@ async def _main():
         if store_notifications:
             NotificationDB.instance().start()
 
-        stream = MemoryStream()
-        reader = BinaryReader(stream)
-        block = Block()
-        length_ba = bytearray(4)
-
-        for index in trange(total_blocks, desc='Importing Blocks', unit=' Block'):
+        for index in trange(total_blocks, desc='Importing Blocks', unit=' Block', initial=ctr):
             # set stream data
             file_input.readinto(length_ba)
             block_len = int.from_bytes(length_ba, 'little')


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
when we supplied the `-a` flag for appending blocks, the code would still deserialise all data

**How did you solve this problem?**
skip block deserialization and move the file pointer directly to the next block until we've reached the current height

**How did you make sure your solution works?**
manual testing

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
