### PR TITLE
fix BigInteger.ToByteArray() for certain negative values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ All notable changes to this project are documented in this file.
 - Fix error while parsing list arguments from prompt for smart contract test invocations
 - Fix ``Runtime.GetTrigger`` and ``Transaction.GetType`` syscalls pushing wrong StackItem type
 - Update handling of default cause for ``PICKITEM`` instruction
+- Fix ``BigInteger.ToByteArray()`` for some negative values to return too many bytes
 
 
 [0.8.4] 2019-02-14

--- a/neo/Core/BigInteger.py
+++ b/neo/Core/BigInteger.py
@@ -19,7 +19,20 @@ class BigInteger(int):
             return b'\x00'
 
         if self < 0:
-            return self.to_bytes(1 + ((self.bit_length() + 7) // 8), byteorder='little', signed=True)
+            highbyte = 0xff
+            data = self.to_bytes(1 + ((self.bit_length() + 7) // 8), byteorder='little', signed=signed)
+
+            msb = len(data) - 1
+            for i, b in enumerate(data[::-1]):
+                if b != highbyte:
+                    msb = i
+                    break
+
+            needExtraByte = (data[msb] & 0x80) == (highbyte & 0x80)
+            if needExtraByte:
+                return data
+            else:
+                return data[:-1]
 
         try:
             return self.to_bytes((self.bit_length() + 7) // 8, byteorder='little', signed=signed)

--- a/neo/Core/tests/test_numbers.py
+++ b/neo/Core/tests/test_numbers.py
@@ -280,6 +280,14 @@ class BigIntegerTestCase(TestCase):
         b4ba = b4.ToByteArray()
         self.assertEqual(b4ba, b'\x00')
 
+        b5 = BigInteger(-146)
+        b5ba = b5.ToByteArray()
+        self.assertEqual(b'\x6e\xff', b5ba)
+
+        b6 = BigInteger(-48335248028225339427907476932896373492484053930)
+        b6ba = b6.ToByteArray()
+        self.assertEqual(20, len(b6ba))
+
     def test_big_integer_frombytes(self):
         b1 = BigInteger(8972340892734890723)
         ba = b1.ToByteArray()


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
the audit of testnet block `678752` showed a storage deviation caused by a difference in return value for the `BigInteger.ToByteArray()` method for the number `-48335248028225339427907476932896373492484053930`

**How did you solve this problem?**
glanced at the C# source of the `BigInteger` class and applied somewhat similar logic

**How did you make sure your solution works?**
test cases + audit now passes for the block

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
