### PR TITLE
Fix tx deserialization class for ContractTransaction

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ All notable changes to this project are documented in this file.
 - Fix ``InteropService.GetInterface`` not validating types correctly
 - Speed up `np-import` when appending blocks
 - Fix ``BigInteger.ToByteArray()`` for some negative values to return too many bytes
+- Fix transaction deserialization not setting correct type for ``ContractTransaction``
 
 
 [0.8.4] 2019-02-14

--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -445,6 +445,7 @@ class Transaction(InventoryMixin):
         from neo.Core.TX.InvocationTransaction import InvocationTransaction
         from neo.Core.TX.EnrollmentTransaction import EnrollmentTransaction
         from neo.Core.TX.StateTransaction import StateTransaction
+        from neo.Core.TX.Transaction import ContractTransaction
 
         if ttype == int.from_bytes(TransactionType.RegisterTransaction, 'little'):
             tx = RegisterTransaction()
@@ -462,6 +463,8 @@ class Transaction(InventoryMixin):
             tx = EnrollmentTransaction()
         elif ttype == int.from_bytes(TransactionType.StateTransaction, 'little'):
             tx = StateTransaction()
+        elif ttype == int.from_bytes(TransactionType.ContractTransaction, 'little'):
+            tx = ContractTransaction()
         else:
             tx = Transaction()
             tx.Type = ttype

--- a/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
+++ b/neo/Implementations/Blockchains/LevelDB/LevelDBBlockchain.py
@@ -784,7 +784,7 @@ class LevelDBBlockchain(Blockchain):
                     await asyncio.sleep(0.001)
                 else:
 
-                    if tx.Type != b'\x00' and tx.Type != 128:
+                    if tx.Type != b'\x00' and tx.Type != b'\x80':
                         logger.info("TX Not Found %s " % tx.Type)
 
             # do save all the accounts, unspent, coins, validators, assets, etc


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Audit of testnet block `697324` showed a deviation in VM result stack return value due to an incomplete TX deserialization routine. 
The stack item reported a 
```
{"type: "Interop", "value": "Transaction"}
```
Instead of
```
{"type: "Interop", "value": "ContractTransaction"}
```

**How did you solve this problem?**
fix deserialization to use correct TX class for ContractTransaction

**How did you make sure your solution works?**
audit now passes for block

**Are there any special changes in the code that we should be aware of?**
n/a

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
