### PR TITLE
Fix boolean StackItem return type for `GetBigInteger()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ All notable changes to this project are documented in this file.
 - Fix ``BigInteger.ToByteArray()`` for some negative values to return too many bytes
 - Implement SimplePolicyPlugin for transactions sent to a node `#960 <https://github.com/CityOfZion/neo-python/issues/960>`_
 - Fix transaction deserialization not setting correct type for ``ContractTransaction``
+- Fix ``GetBigInteger()`` return value of ``Boolean`` ``StackItem`` to return correct type
 
 
 [0.8.4] 2019-02-14

--- a/neo/Core/IO/BinaryWriter.py
+++ b/neo/Core/IO/BinaryWriter.py
@@ -82,6 +82,11 @@ class BinaryWriter(object):
             self.stream.write(value.encode('utf-8'))
         elif type(value) is int:
             self.stream.write(bytes([value]))
+        elif type(value) is bool:
+            if value:
+                self.stream.write(bytes([1]))
+            else:
+                self.stream.write(bytes([0]))
 
     def WriteBytes(self, value, unhex=True):
         """

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -261,7 +261,7 @@ class Boolean(StackItem):
         return self._value == other._value
 
     def GetBigInteger(self):
-        return 1 if self._value else 0
+        return BigInteger(1) if self._value else BigInteger(0)
 
     def GetBoolean(self):
         return self._value
@@ -274,7 +274,7 @@ class Boolean(StackItem):
 
     def Serialize(self, writer):
         writer.WriteByte(StackItemType.Boolean)
-        writer.WriteByte(self.GetBigInteger())
+        writer.WriteByte(self.GetBoolean())
 
     def __str__(self):
         return str(self._value)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
audit of testnet block `735309` showed a deviating in VMState due to a wrong type returned by `StackItem.Boolean.GetBigInteger()` causing an exception.

**How did you solve this problem?**
fix to actually return a BigInteger instead of an int.

**How did you make sure your solution works?**
audit passes for the block

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
