### PR TITLE
Fix dbcollection not properly clearing state for faulty TXs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ All notable changes to this project are documented in this file.
 - Fix ``GetBigInteger()`` return value of ``Boolean`` ``StackItem`` to return correct type
 - Add workaround for ``Neo.Contract.Create`` SYSCALl accepting invalid ``ContractParameterType``'s until neo-cli fixes it to keep same state
 - Fix parsing nested lists `#954 <https://github.com/CityOfZion/neo-python/issues/954>`_
+- Fix clearing storage manipulations on failed invocation transaction execution
 
 
 [0.8.4] 2019-02-14

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -282,9 +282,7 @@ class StateReader(InteropService):
 
     def Runtime_GetCurrentTime(self, engine: ExecutionEngine):
         BC = GetBlockchain()
-        print(BC)
         header = BC.GetHeaderByHeight(BC.Height)
-        print(header, GetBlockchain().SECONDS_PER_BLOCK)
         if header is None:
             header = GetBlockchain().GenesisBlock()
 

--- a/neo/Storage/Interface/DBInterface.py
+++ b/neo/Storage/Interface/DBInterface.py
@@ -18,7 +18,6 @@ class DBProperties:
     """
 
     def __init__(self, prefix=None, include_value=True, include_key=True):
-
         if not include_value and not include_key:
             raise Exception('Either key or value have to be true')
 
@@ -43,8 +42,8 @@ class DBInterface(object):
         self.Changed = []
         self.Deleted = []
 
-        self._ChangedResetState = None
-        self._DeletedResetState = None
+        self._ChangedResetState = []
+        self._DeletedResetState = []
 
         self._batch_changed = {}
 
@@ -94,15 +93,15 @@ class DBInterface(object):
         else:
             self.Changed = []
             self.Deleted = []
-            self._ChangedResetState = None
-            self._DeletedResetState = None
+            self._ChangedResetState = []
+            self._DeletedResetState = []
 
     def Reset(self):
-        self.Changed = self._ChangedResetState
-        self.Deleted = self._DeletedResetState
+        self.Changed = []
+        self.Deleted = []
 
-        self._ChangedResetState = None
-        self._DeletedResetState = None
+        self._ChangedResetState = []
+        self._DeletedResetState = []
 
     def GetAndChange(self, keyval, new_instance=None, debug_item=False):
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Audit of TestNet block `936671` showed a deviating in storage due to incorrect state being committed in the previous block while the TX failed. It was not committed in the actual run of the faulty TX, but because the DBInterface was not properly cleared from its state the next successful commit included the changes from the faulty TX.

**How did you solve this problem?**
DBCollection/DBInterface now properly resets all state when the TX failed.

**How did you make sure your solution works?**
audit now passes for the block and all blocks leading up to it

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
