### PR TITLE
Improve parameter parsing

### DIFF
--- a/neo/Prompt/Utils.py
+++ b/neo/Prompt/Utils.py
@@ -328,9 +328,8 @@ def verify_params(ptype, param):
         return res, False
 
     elif ptype == ContractParameterType.Array:
-        res = eval(param)
-        if isinstance(res, list):
-            return res, False
+        if isinstance(param, list):
+            return param, False
         raise Exception("Please provide a list")
     else:
         raise Exception("Unknown param type %s " % ptype.name)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
When manually testing contract invocation and `build_run`, I noticed that parameters entered via the command line were not parsed identically to those entered with the `--i` flag. This is because the `--i` flag used the `gather_params` helper function and the regular command line parsing did not.

**How did you solve this problem?**
I split out the parameter verification into a separate function: `verify_params`
- verifies parameters input via command line and --i flag
- ensures parameter input is identical

**How did you make sure your solution works?**
manual testing

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [ ] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
