### PR TITLE
Improve parameter parsing [02]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ All notable changes to this project are documented in this file.
 - Add workaround for ``Neo.Contract.Create`` SYSCALl accepting invalid ``ContractParameterType``'s until neo-cli fixes it to keep same state
 - Fix parsing nested lists `#954 <https://github.com/CityOfZion/neo-python/issues/954>`_
 - Fix clearing storage manipulations on failed invocation transaction execution
+- Fix param parsing input from command line
 
 
 [0.8.4] 2019-02-14

--- a/neo/Prompt/Commands/BuildNRun.py
+++ b/neo/Prompt/Commands/BuildNRun.py
@@ -90,9 +90,10 @@ def DoRun(contract_script, arguments, wallet, path, verbose=True,
     except Exception:
         raise TypeError
 
-    tx, result, total_ops, engine = test_deploy_and_invoke(script, i_args, wallet, from_addr,
-                                                           min_fee, invocation_test_mode, debug_map=debug_map,
-                                                           invoke_attrs=invoke_attrs, owners=owners, enable_debugger=enable_debugger)
+    tx, result, total_ops, engine = test_deploy_and_invoke(script, i_args, wallet, from_addr, min_fee,
+                                                           invocation_test_mode, debug_map=debug_map,
+                                                           invoke_attrs=invoke_attrs, owners=owners,
+                                                           enable_debugger=enable_debugger, user_entry=True)
     i_args.reverse()
 
     return_type_results = []

--- a/neo/Prompt/Commands/SC.py
+++ b/neo/Prompt/Commands/SC.py
@@ -185,7 +185,8 @@ class CommandSCTestInvoke(CommandBase):
                 logger.debug("invalid fee")
                 return False
 
-        tx, fee, results, num_ops, engine_success = TestInvokeContract(wallet, arguments, from_addr=from_addr, invoke_attrs=invoke_attrs, owners=owners)
+        tx, fee, results, num_ops, engine_success = TestInvokeContract(wallet, arguments, from_addr=from_addr, invoke_attrs=invoke_attrs,
+                                                                       owners=owners, user_entry=True)
         if tx is not None and results is not None:
 
             if return_type is not None:

--- a/neo/Prompt/Commands/tests/test_sc_commands.py
+++ b/neo/Prompt/Commands/tests/test_sc_commands.py
@@ -128,6 +128,15 @@ class CommandSCTestCase(WalletFixtureTestCase):
             self.assertFalse(tx)
             self.assertIn("run `sc build_run help` to see supported queries", mock_print.getvalue())
 
+        # test too few args
+        PromptData.Wallet = self.GetWallet1(recreate=True)
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['build_run', 'neo/Prompt/Commands/tests/SampleSC.py', 'True', 'False', 'False', '070502', '02', 'add', 'AG4GfwjnvydAZodm4xEDivguCtjCFzLcJy',
+                    ]  # missing third param
+            tx, result, total_ops, engine = CommandSC().execute(args)
+            self.assertFalse(tx)
+            self.assertIn("Check params. 3 params specified and only 2 given.", mock_print.getvalue())
+
         # test successful build and run
         PromptData.Wallet = self.GetWallet1(recreate=True)
         with patch('sys.stdout', new=StringIO()) as mock_print:
@@ -401,6 +410,13 @@ class CommandSCTestCase(WalletFixtureTestCase):
             res = CommandSC().execute(args)
             self.assertFalse(res)
             self.assertIn("Error testing contract invoke", mock_print.getvalue())
+
+        # test too few args
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            args = ['invoke', token_hash_str, 'name']  # missing second arg
+            res = CommandSC().execute(args)
+            self.assertFalse(res)
+            self.assertIn("Check params. 2 params specified and only 1 given.", mock_print.getvalue())
 
         # test with keyboard interrupt
         with patch('sys.stdout', new=StringIO()) as mock_print:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
**NOTE:** This PR is a continuation of #972 
When manually testing contract invocation and `build_run`, I noticed that parameters entered via the command line were not parsed identically to those entered with the `--i` flag. This is because the `--i` flag used the `gather_params` helper function and the regular command line parsing did not.

**How did you solve this problem?**
I split out the parameter verification into a separate function: `verify_params` and added a `user_entry` flag to limit verification to user entered params.
- verifies parameters input via command line and --i flag
- ensures parameter input is identical
- does not disrupt existing logic which had previously caused many errors in #972

**How did you make sure your solution works?**
manual testing

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [ ] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
