### PR TITLE
Fix Contract_Migrate syscall

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,7 @@ All notable changes to this project are documented in this file.
 - Fix parsing nested lists `#954 <https://github.com/CityOfZion/neo-python/issues/954>`_
 - Fix clearing storage manipulations on failed invocation transaction execution
 - Port caching layer from neo-cli
+- Fix ``Contract_Migrate`` sycall
 
 
 [0.8.4] 2019-02-14

--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -742,11 +742,12 @@ class StateMachine(StateReader):
 
             self.Snapshot.Contracts.Add(hash.ToBytes(), contract)
 
-            self._contracts_created[hash.ToBytes()] = UInt160(data=engine.CurrentContext.ScriptHash())
+            cur_hash = UInt160(data=engine.CurrentContext.ScriptHash())
+            self._contracts_created[hash.ToBytes()] = cur_hash
 
             if contract.HasStorage:
                 to_add = []
-                for key, item in self.Snapshot.Storages.Find(engine.CurrentContext.ScriptHash()):
+                for key, item in self.Snapshot.Storages.Find(cur_hash.ToArray()):
                     key = StorageKey(script_hash=hash, key=key)
                     to_add.append((key.ToArray(), item))
 

--- a/neo/Storage/Implementation/LevelDB/LevelDBCache.py
+++ b/neo/Storage/Implementation/LevelDB/LevelDBCache.py
@@ -34,7 +34,6 @@ class LevelDBCache(DataCache):
         except binascii.Error:
             intermediate_prefix = bytearray(key_prefix)
 
-        intermediate_prefix.reverse()
         key_prefix = self.prefix + intermediate_prefix
         res = {}
         with self.db.openIter(DBProperties(key_prefix, include_value=True)) as it:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Audit of testnet block `1303979` shows a deviation in Storage changes. 
- the existing syscall `System.Runtime.GetTime` implementation uses the latest already persisted block to get the timestamp from. C# instead uses the currently being persisted block. This led to a 1 byte difference in the script to be migrated, causing a different script_hash and as a result storages could not be found properly.
- Contract_Migrate and Contract_Destroy operated on the wrong provided key data. The key data was supplied in reversed byte order causing it to not find existing storages.  

**How did you solve this problem?**
fix the above 2 items

**How did you make sure your solution works?**
audit now passes, make test still ok, resynced previous 350K blocks to test for regression

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
