### PR TITLE
Fix bigint3 modulo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,7 @@ All notable changes to this project are documented in this file.
 - Fix clearing storage manipulations on failed invocation transaction execution
 - Port caching layer from neo-cli
 - Fix ``Contract_Migrate`` sycall
+- Fix ``BigInteger`` modulo for negative divisor values
 
 
 [0.8.4] 2019-02-14

--- a/neo/Core/BigInteger.py
+++ b/neo/Core/BigInteger.py
@@ -1,3 +1,6 @@
+from math import fmod
+
+
 class BigInteger(int):
     @property
     def Sign(self):
@@ -46,7 +49,11 @@ class BigInteger(int):
         return BigInteger(super(BigInteger, self).__add__(*args, **kwargs))
 
     def __mod__(self, *args, **kwargs):  # real signature unknown
-        return BigInteger(super(BigInteger, self).__mod__(*args, **kwargs))
+        # C# uses different logic from Python
+        if args[0] < 0:
+            return fmod(self, args[0])
+        else:
+            return BigInteger(super(BigInteger, self).__mod__(*args, **kwargs))
 
     def __mul__(self, *args, **kwargs):  # real signature unknown
         return BigInteger(super(BigInteger, self).__mul__(*args, **kwargs))

--- a/neo/Core/tests/test_numbers.py
+++ b/neo/Core/tests/test_numbers.py
@@ -317,6 +317,15 @@ class BigIntegerTestCase(TestCase):
         c2_unsigned = BigInteger.FromBytes(c1_bytes, signed=False)
         self.assertEqual(c2_unsigned.Sign, 1)
 
+    def test_big_integer_modulo(self):
+        b1 = BigInteger(860593)
+        b2 = BigInteger(-201)
+        self.assertEqual(112, b1 % b2)
+
+        b1 = BigInteger(20195283520469175757)
+        b2 = BigInteger(1048576)
+        self.assertEqual(888269, b1 % b2)
+
     def test_dunder_methods(self):
         b1 = BigInteger(1)
         b2 = BigInteger(2)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Audit of testnet blocks `1474198`  and `1474514` showed a deviation in gas consumption. After backtracking this was caused by pushing a different result by the `MOD` instruction. This then led to a `LT` comparison between a negative vs positive value, whereas C# compared a positive + positive value which happened to be `false` in the C# case and `true` in Python's case. That resulted in deviating behaviour for the `JMPIFNOT` that followed and the rest is self-explanatory.

The deviation occurs due to Python's different way of handling negative divisor values.

**How did you solve this problem?**
handle negative case different

**How did you make sure your solution works?**
audit now passes

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
