### PR TITLE
fix Array.GetBoolean()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,7 @@ All notable changes to this project are documented in this file.
 - Port caching layer from neo-cli
 - Fix ``Contract_Migrate`` sycall
 - Fix ``BigInteger`` modulo for negative divisor values
+- Fix ``GetBoolean()`` for ``Array`` stackitem
 
 
 [0.8.4] 2019-02-14

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -213,7 +213,7 @@ class Array(StackItem, CollectionMixin):
         raise Exception("Not Supported")
 
     def GetBoolean(self):
-        return len(self._array) > 0
+        return True
 
     def GetByteArray(self):
         logger.debug("Trying to get bytearray integer %s " % self)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
audit of testnet block `1532382` showed a deviation in gas consumption due to a different return value for the `GetBoolean()` call of the `Array` stack item.

**How did you solve this problem?**
bring inline with changes to C#

**How did you make sure your solution works?**
audit passes, make test

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
