### PR TITLE
fix DataCache duplicate results + invalid Contract return type handling

### DIFF
--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -639,6 +639,11 @@ class StateMachine(StateReader):
         if len(param_list) > 252:
             return False
         return_type = int(engine.CurrentContext.EvaluationStack.Pop().GetBigInteger())
+        try:
+            ContractParameterType(return_type)
+        except ValueError:
+            raise ValueError("Invalid return type data popped from stack")
+
         contract_properties = int(engine.CurrentContext.EvaluationStack.Pop().GetBigInteger())
 
         if len(engine.CurrentContext.EvaluationStack.Peek().GetByteArray()) > 252:

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -278,7 +278,7 @@ class StateReader(InteropService):
             stack_item.Serialize(writer)
         except Exception as e:
             StreamManager.ReleaseStream(ms)
-            logger.error("Cannot serialize item %s: %s " % (stack_item, e))
+            logger.debug("Cannot serialize item %s: %s " % (stack_item, e))
             return False
 
         ms.flush()
@@ -303,7 +303,7 @@ class StateReader(InteropService):
             engine.CurrentContext.EvaluationStack.PushT(stack_item)
         except ValueError as e:
             # can't deserialize type
-            logger.error("%s " % e)
+            logger.debug("%s " % e)
             return False
         finally:
             StreamManager.ReleaseStream(ms)

--- a/neo/Storage/Common/DataCache.py
+++ b/neo/Storage/Common/DataCache.py
@@ -88,7 +88,7 @@ class DataCache:
             key_prefix = b''
 
         for k, v in self.FindInternal(key_prefix):
-            if k not in self.dictionary:
+            if bytes(key_prefix + k) not in self.dictionary:
                 yield k, v
 
         for k, v in self.dictionary.items():


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
- audit of testnet block `1546918` showed a deviation in VMState due to incorrect handling of duplicate results from the DataCache + Internal storage. Internal storage only returns the actual `key` value, whereas the DataCache holds `contract_hash + key` values for looking up. 
- various testnet blocks showed error logs regarding various Serialization/Deserialization issues. I investigated 2 cases (Runtime_Serialize and Runtime_Deserialize) of respectively blocks `1552947` and `1553029` and concluded that the behaviour is inline with C# neo-cli. The error message is too aggressive possible leading to user confusion whether it's a real problem or not
- audit of testnet block `1575282` showed a deviation in VMState and Storage due to incorrect handling of an invalid Contract return type. neo-python accepted this, whereas neo-cli throws an exception. 

**How did you solve this problem?**
- fix key lookup check by adding the necessary prefix 
- lower debug level from `error` to `debug`
- tighten contract return type validation

**How did you make sure your solution works?**
audit passes, make test passes

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
