### PR TITLE
update contract return type verification

### DIFF
--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -639,9 +639,7 @@ class StateMachine(StateReader):
         if len(param_list) > 252:
             return False
         return_type = int(engine.CurrentContext.EvaluationStack.Pop().GetBigInteger())
-        try:
-            ContractParameterType(return_type)
-        except ValueError:
+        if return_type > 0xff:
             raise ValueError("Invalid return type data popped from stack")
 
         contract_properties = int(engine.CurrentContext.EvaluationStack.Pop().GetBigInteger())


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
while https://github.com/CityOfZion/neo-python/pull/978 fixed Contract return type validation for the block at hand, it broke a historical validation. When using Python enums a ValueError is thrown when trying to create an enum from an invalid value
e.g.
```python
class MyEnum(Enum):
   bla = 0x1

t1 = MyEnum(1) # OK
t2 = MyEnum(2) # raises ValueError
```
In C# it actually doesn't care as long as the value you're trying to cast fits in the datatype (in the case of ContractParameter a `byte`). In #978 the return_type value was 2 bytes and failed to cast to a 1 byte enum in C#. The solution used for that block was ok, but fails for block `846536`. This PR resolves that.
 
**How did you solve this problem?**
change validation logic

**How did you make sure your solution works?**
audit now also passes for block `846536`


**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
