### PR TITLE
fix BigInteger divide

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ All notable changes to this project are documented in this file.
 - Fix ``Contract_Migrate`` sycall
 - Fix ``BigInteger`` modulo for negative divisor values
 - Fix ``GetBoolean()`` for ``Array`` stackitem
+- Fix ``BigInteger`` division for negative dividend values
 
 
 [0.8.4] 2019-02-14

--- a/neo/Core/BigInteger.py
+++ b/neo/Core/BigInteger.py
@@ -71,7 +71,10 @@ class BigInteger(int):
         return BigInteger(super(BigInteger, self).__floordiv__(*args, **kwargs))
 
     def __truediv__(self, *args, **kwargs):  # real signature unknown
-        return BigInteger(super(BigInteger, self).__floordiv__(*args, **kwargs))
+        if self < 0:
+            return BigInteger(super(BigInteger, self).__truediv__(*args, **kwargs))
+        else:
+            return BigInteger(super(BigInteger, self).__floordiv__(*args, **kwargs))
 
     def __rshift__(self, *args, **kwargs):
         shift = args[0]

--- a/neo/Core/tests/test_numbers.py
+++ b/neo/Core/tests/test_numbers.py
@@ -251,6 +251,37 @@ class BigIntegerTestCase(TestCase):
         self.assertEqual(b3, 99975899)
         self.assertEqual(b4, b3)
 
+    def test_big_integer_div_rounding(self):
+        b1 = BigInteger(1)
+        b2 = BigInteger(2)
+        self.assertEqual(0, b1 / b2)  # 0.5 -> 0
+
+        b1 = BigInteger(2)
+        b2 = BigInteger(3)
+        self.assertEqual(0, b1 / b2)  # 0.66 -> 0
+
+        b1 = BigInteger(5)
+        b2 = BigInteger(4)
+        self.assertEqual(1, b1 / b2)  # 1.25 -> 1
+
+        b1 = BigInteger(5)
+        b2 = BigInteger(3)
+        self.assertEqual(1, b1 / b2)  # 1.66 -> 1
+
+        b1 = BigInteger(-1)
+        b2 = BigInteger(3)
+        self.assertEqual(0, b1 / b2)  # -0.33 -> 0
+
+        b1 = BigInteger(-5)
+        b2 = BigInteger(3)
+        self.assertEqual(-1, b1 / b2)  # -1.66 -> -1
+
+    def test_big_integer_div_block1473972(self):
+        b1 = BigInteger(-11001000000)
+        b2 = BigInteger(86400)
+        result = b1 / b2
+        self.assertEqual(-127326, result)
+
     def test_big_integer_float(self):
         b1 = BigInteger(5505.001)
         b2 = BigInteger(55055.999)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
audit of testnet block `1473972` showed a deviation in storage due to a different rounding used for C# compared to neo-python when dividing 2 BigIntegers where the dividend is negative. Specifically `-11001000000` / `86400` should result in `-127326` but resulted in `-127327`.

**How did you solve this problem?**
change divide logic

**How did you make sure your solution works?**
audit for the block passes, other tests still pass, added a couple more tests for which I took the expected values from a C# program.

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [X] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
