### PR TITLE
further tighten return type checking

### DIFF
--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -639,7 +639,7 @@ class StateMachine(StateReader):
         if len(param_list) > 252:
             return False
         return_type = int(engine.CurrentContext.EvaluationStack.Pop().GetBigInteger())
-        if return_type > 0xff:
+        if return_type < 0 or return_type > 0xff:
             raise ValueError("Invalid return type data popped from stack")
 
         contract_properties = int(engine.CurrentContext.EvaluationStack.Pop().GetBigInteger())


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
testnet block `1701573` sets up a `ByteArray` type with `0xF0` as data on the evaluation stack for the return type of a `Contract_Create` call. This should be equal to the `InteropInterface` type, however it seems that neo-cli expects `0x00F0` because they convert to `BigInteger` which is signed. Therefore we're getting `-16` and that should fail. 

**How did you solve this problem?**
don't allow negative numbers for the type

**How did you make sure your solution works?**
audit for the block now passes

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
