### PR TITLE
fix price check call for Neo.Contract.Create

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,10 +48,11 @@ All notable changes to this project are documented in this file.
 - Fix parsing nested lists `#954 <https://github.com/CityOfZion/neo-python/issues/954>`_
 - Fix clearing storage manipulations on failed invocation transaction execution
 - Port caching layer from neo-cli
-- Fix ``Contract_Migrate`` sycall
+- Fix ``Contract_Migrate`` syscall
 - Fix ``BigInteger`` modulo for negative divisor values
 - Fix ``GetBoolean()`` for ``Array`` stackitem
 - Fix ``BigInteger`` division for negative dividend values
+- Fix ``GetPriceForSysCall()`` for a ``Neo.Contract.Create`` syscall with invalid contract properties
 
 
 [0.8.4] 2019-02-14

--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -147,6 +147,8 @@ class ApplicationEngine(ExecutionEngine):
             fee = int(100 * 100000000 / self.ratio)  # 100 gas for contract with no storage no dynamic invoke
 
             contract_properties = self.CurrentContext.EvaluationStack.Peek(3).GetBigInteger()
+            if contract_properties < 0 or contract_properties > 0xff:
+                raise ValueError("Invalid contract properties")
 
             if contract_properties & ContractPropertyState.HasStorage > 0:
                 fee += int(400 * 100000000 / self.ratio)  # if contract has storage, we add 400 gas


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
audit of testnet block `1729953` showed a deviation in gas consumption due to a difference in handling invalid contract properties in the  `GetPriceForSysCall()` function compared to neo-cli. Where neo-cli throws an exception when trying to cast the contract property to a `byte`, neo-python did not and happily continued. 

**How did you solve this problem?**
apply similar logic as in #982

**How did you make sure your solution works?**
audit of block now passes

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
