### PR TITLE
Fixed AccountState Sync Issue

### DIFF
--- a/neo/Core/Blockchain.py
+++ b/neo/Core/Blockchain.py
@@ -1018,7 +1018,7 @@ class Blockchain:
                                 sc.Items.append(SpentCoinItem(input.PrevIndex, block.Index))
 
                             output = prevTx.outputs[input.PrevIndex]
-                            acct = snapshot.Accounts.GetAndChange(prevTx.outputs[input.PrevIndex].AddressBytes, AccountState(output.ScriptHash))
+                            acct = snapshot.Accounts.GetAndChange(prevTx.outputs[input.PrevIndex].AddressBytes, lambda: AccountState(output.ScriptHash))
                             assetid = prevTx.outputs[input.PrevIndex].AssetId
                             acct.SubtractFromBalance(assetid, prevTx.outputs[input.PrevIndex].Value)
 

--- a/neo/Utils/BlockchainFixtureTestCase.py
+++ b/neo/Utils/BlockchainFixtureTestCase.py
@@ -78,7 +78,7 @@ def MonkeyPatchPersist(self, block, snapshot=None):
                         sc.Items.append(SpentCoinItem(input.PrevIndex, block.Index))
 
                     output = prevTx.outputs[input.PrevIndex]
-                    acct = snapshot.Accounts.GetAndChange(prevTx.outputs[input.PrevIndex].AddressBytes, AccountState(output.ScriptHash))
+                    acct = snapshot.Accounts.GetAndChange(prevTx.outputs[input.PrevIndex].AddressBytes, lambda: AccountState(output.ScriptHash))
                     assetid = prevTx.outputs[input.PrevIndex].AssetId
                     acct.SubtractFromBalance(assetid, prevTx.outputs[input.PrevIndex].Value)
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Explicitly defining `lambda` for account syncing to fix `TypeError: 'AccountState' object is not callable` errors.

**How did you solve this problem?**

Added `lambda`, per @ixje.

**How did you make sure your solution works?**

Tested before and after. Errors happening before; syncing works after.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)