### PR TITLE
Auto-Delete Bootstrap File

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,7 @@ All notable changes to this project are documented in this file.
 - Fix ``BigInteger`` division for negative dividend values
 - Add functionality for RawTransaction class
 - Fix ``GetPriceForSysCall()`` for a ``Neo.Contract.Create`` syscall with invalid contract properties
+- Updated ``np-bootstrap`` to delete the downloaded bootstrap file by default
 
 
 [0.8.4] 2019-02-14

--- a/README.rst
+++ b/README.rst
@@ -272,7 +272,9 @@ np-bootstrap Usage
       -c CONFIG, --config CONFIG
                             Use a specific config file
       -n, --notifications   Bootstrap notification database
-      -s, --skipconfirm     Bypass warning about overwritting data in Chains/SC234
+      -s, --skipconfirm     Bypass warning about overwriting data in Chains
+      -k, --keep-bootstrap-file
+                            Keep the downloaded bootstrap file
       --datadir DATADIR     Absolute path to use for database directories
 
 Bootrapping Testnet

--- a/neo/Prompt/Commands/Bootstrap.py
+++ b/neo/Prompt/Commands/Bootstrap.py
@@ -8,7 +8,7 @@ import shutil
 import os
 
 
-def BootstrapBlockchainFile(target_dir, download_location, bootstrap_name, require_confirm=True):
+def BootstrapBlockchainFile(target_dir, download_location, bootstrap_name, require_confirm=True, delete_bootstrap_file=True):
     if download_location is None:
         print("no bootstrap location file specified. Please update your configuration file.")
         sys.exit(0)
@@ -20,20 +20,21 @@ def BootstrapBlockchainFile(target_dir, download_location, bootstrap_name, requi
         except KeyboardInterrupt:
             confirm = False
         if confirm == 'confirm':
-            return do_bootstrap(download_location, bootstrap_name, target_dir)
+            return do_bootstrap(download_location, bootstrap_name, target_dir, delete_bootstrap_file=delete_bootstrap_file)
     else:
 
         return do_bootstrap(download_location,
                             bootstrap_name,
                             target_dir,
                             tmp_file_name=os.path.join(settings.DATA_DIR_PATH, 'btest.tar.gz'),
-                            tmp_chain_name='btestchain')
+                            tmp_chain_name='btestchain',
+                            delete_bootstrap_file=delete_bootstrap_file)
 
     print("bootstrap cancelled")
     sys.exit(0)
 
 
-def do_bootstrap(download_location, bootstrap_name, destination_dir, tmp_file_name=None, tmp_chain_name='tmpchain'):
+def do_bootstrap(download_location, bootstrap_name, destination_dir, tmp_file_name=None, tmp_chain_name='tmpchain', delete_bootstrap_file=True):
     if tmp_file_name is None:
         tmp_file_name = os.path.join(settings.DATA_DIR_PATH, 'bootstrap.tar.gz')
 
@@ -99,6 +100,10 @@ def do_bootstrap(download_location, bootstrap_name, destination_dir, tmp_file_na
         print("cleaning up %s " % tmp_chain_name)
         if os.path.exists(tmp_chain_name):
             shutil.rmtree(tmp_chain_name)
+
+        if delete_bootstrap_file and os.path.exists(tmp_file_name):
+            print("removing temp bootstrap file %s " % tmp_file_name)
+            os.remove(tmp_file_name)
 
     if success:
         print("Successfully downloaded bootstrap chain!")

--- a/neo/bin/bootstrap.py
+++ b/neo/bin/bootstrap.py
@@ -15,7 +15,10 @@ def main():
                         help="Bootstrap notification database")
 
     parser.add_argument("-s", "--skipconfirm", action="store_true", default=False,
-                        help="Bypass warning about overwritting data in {}".format(settings.LEVELDB_PATH))
+                        help="Bypass warning about overwriting data in {}".format(settings.LEVELDB_PATH))
+
+    parser.add_argument("-k", "--keep-bootstrap-file", action="store_true", default=False,
+                        help="Keep the downloaded bootstrap file when finished")
 
     # Where to store stuff
     parser.add_argument("--datadir", action="store",
@@ -31,6 +34,11 @@ def main():
         require_confirm = False
     else:
         require_confirm = True
+
+    if args.keep_bootstrap_file:
+        keep_bootstrap_file = True
+    else:
+        keep_bootstrap_file = False
 
     # Setting the datadir must come before setting the network, else the wrong path is checked at net setup.
     if args.datadir:
@@ -48,7 +56,7 @@ def main():
         bootstrap_name += "_notif"
         destination_path = settings.notification_leveldb_path
 
-    BootstrapBlockchainFile(destination_path, settings.BOOTSTRAP_LOCATIONS, bootstrap_name, require_confirm)
+    BootstrapBlockchainFile(destination_path, settings.BOOTSTRAP_LOCATIONS, bootstrap_name, require_confirm, not keep_bootstrap_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Auto-delete the downloaded bootstrap file after running `np-bootstrap`.

**How did you solve this problem?**

* Updated the `np-bootstrap` process so that it will delete the downloaded bootstrap file by default when it's done.
* Added a `-k`/`--keep-bootstrap-file` flag to `np-bootstrap` to allow you to keep the bootstrap file in case you need to re-use the file after download.

**How did you make sure your solution works?**

Tested it with both configurations.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)