### PR TITLE
Fix Remove() for Map/Array VM types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,7 @@ All notable changes to this project are documented in this file.
 - Add functionality for RawTransaction class
 - Fix ``GetPriceForSysCall()`` for a ``Neo.Contract.Create`` syscall with invalid contract properties
 - Updated ``np-bootstrap`` to delete the downloaded bootstrap file by default `#986 <https://github.com/CityOfZion/neo-python/pull/986>`_
+- Fix ``Remove()`` behaviour for ``Map`` and ``Array`` types to be inline with C#
 
 
 [0.8.4] 2019-02-14

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -187,7 +187,11 @@ class Array(StackItem, CollectionMixin):
         return self._array.index(item)
 
     def Remove(self, item):
-        return self._array.remove(item)
+        try:
+            self._array.remove(item)
+            return True
+        except ValueError:
+            return False
 
     def RemoveAt(self, index):
         return self._array.pop(index)
@@ -496,8 +500,11 @@ class Map(StackItem, CollectionMixin):
         self._dict[key] = value
 
     def Remove(self, key):
-        del self._dict[key]
-        return True
+        try:
+            del self._dict[key]
+            return True
+        except KeyError:
+            return False
 
     def Clear(self):
         self._dict = {}


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Audit of testnet block `2053221` showed a deviation in VM execution due to different ways of handling the removal of non-existing items in the `Map` and `Array` types.

C# returns a boolean False if the item is not found in its dictionary/list, Python by default throws KeyError or ValueError respectively. This caused neo-python to fail VM execution, whereas C# would continue
  
**How did you solve this problem?**
add try/catch and return bool for found status

**How did you make sure your solution works?**
audit now passes

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
