### PR TITLE
Add support for compressed syscall

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,7 @@ All notable changes to this project are documented in this file.
 - Fix ``GetPriceForSysCall()`` for a ``Neo.Contract.Create`` syscall with invalid contract properties
 - Updated ``np-bootstrap`` to delete the downloaded bootstrap file by default `#986 <https://github.com/CityOfZion/neo-python/pull/986>`_
 - Fix ``Remove()`` behaviour for ``Map`` and ``Array`` types to be inline with C#
+- Add support for compressed syscalls
 
 
 [0.8.4] 2019-02-14

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -24,6 +24,7 @@ from neo.IO.MemoryStream import StreamManager
 from neo.Core.State.ContractState import ContractState
 from neo.Core.State.StorageItem import StorageItem
 from neo.logging import log_manager
+import hashlib
 
 logger = log_manager.getLogger('vm')
 
@@ -31,8 +32,9 @@ logger = log_manager.getLogger('vm')
 class StateReader(InteropService):
 
     def RegisterWithPrice(self, method, func, price):
-        self._dictionary[method] = func
-        self.prices.update({hash(method): price})
+        hashed_method = int.from_bytes(hashlib.sha256(method.encode()).digest()[:4], 'little', signed=False)
+        self._dictionary[hashed_method] = func
+        self.prices.update({hashed_method: price})
 
     def __init__(self, trigger_type, snapshot):
 

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -311,9 +311,7 @@ class ExecutionEngine:
                 if len(instruction.Operand) > 252:
                     return False
 
-                call = instruction.Operand.decode('ascii')
-                self.write_log(call)
-                if not self._Service.Invoke(call, self):
+                if not self._Service.Invoke(instruction.Operand, self):
                     return self.VM_FAULT_and_report(VMFault.SYSCALL_ERROR, instruction.Operand)
 
                 if not self.CheckStackSize(False, int_MaxValue):
@@ -1237,6 +1235,14 @@ class ExecutionEngine:
                 instruction = self.CurrentContext.CurrentInstruction
 
                 if self._is_write_log:
+                    if instruction.InstructionName == "SYSCALL":
+                        if len(instruction.Operand) > 4:
+                            call = instruction.Operand.decode('ascii')
+                            self.write_log("{} {} {} {}".format(self.ops_processed, instruction.InstructionName, call, self.CurrentContext.InstructionPointer))
+                        else:
+                            self.write_log("{} {} {} {}".format(self.ops_processed, instruction.InstructionName, instruction.TokenU32,
+                                                                self.CurrentContext.InstructionPointer))
+                else:
                     self.write_log("{} {} {}".format(self.ops_processed, instruction.InstructionName, self.CurrentContext.InstructionPointer))
 
                 if not self.PreExecuteInstruction():


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
audit of testnet block `2105805` showed a deviation in VM state due to no support for compressed syscalls. neo-python would throw an exception on compressed syscall operands

**How did you solve this problem?**
add support for compressed format

**How did you make sure your solution works?**
audit of the block now passes

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
