### PR TITLE
Fix simple policy implementation for outgoing transactions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,7 +57,7 @@ All notable changes to this project are documented in this file.
 - Updated ``np-bootstrap`` to delete the downloaded bootstrap file by default `#986 <https://github.com/CityOfZion/neo-python/pull/986>`_
 - Fix ``Remove()`` behaviour for ``Map`` and ``Array`` types to be inline with C#
 - Add support for compressed syscalls
-- Fix SimplePolicyPlugin implementation when relaying a tx
+- Validate SimplePolicy for signed transactions
 
 
 [0.8.4] 2019-02-14

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,6 +57,7 @@ All notable changes to this project are documented in this file.
 - Updated ``np-bootstrap`` to delete the downloaded bootstrap file by default `#986 <https://github.com/CityOfZion/neo-python/pull/986>`_
 - Fix ``Remove()`` behaviour for ``Map`` and ``Array`` types to be inline with C#
 - Add support for compressed syscalls
+- Fix SimplePolicyPlugin implementation when relaying a tx
 
 
 [0.8.4] 2019-02-14

--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -775,6 +775,6 @@ class ContractTransaction(Transaction):
         self.Type = TransactionType.ContractTransaction
 
 
-class TXFeeError(Exception):
-    """Provide user-friendly feedback for transaction fee errors."""
+class TXError(Exception):
+    """Provide user-friendly feedback for transaction errors."""
     pass

--- a/neo/Core/TX/Transaction.py
+++ b/neo/Core/TX/Transaction.py
@@ -773,8 +773,3 @@ class ContractTransaction(Transaction):
         """
         super(ContractTransaction, self).__init__(*args, **kwargs)
         self.Type = TransactionType.ContractTransaction
-
-
-class TXError(Exception):
-    """Provide user-friendly feedback for transaction errors."""
-    pass

--- a/neo/Core/Utils.py
+++ b/neo/Core/Utils.py
@@ -1,4 +1,7 @@
 import base58
+from neo.Settings import settings
+from neo.Core.Fixed8 import Fixed8
+from typing import Tuple
 
 
 def isValidPublicAddress(address: str) -> bool:
@@ -14,3 +17,30 @@ def isValidPublicAddress(address: str) -> bool:
             valid = False
 
     return valid
+
+
+def validate_simple_policy(tx) -> Tuple[bool, str]:
+    """
+    Validate transaction policies
+
+    Args:
+        tx: Transaction object
+
+    Returns:
+        tuple:
+            result: True if it passes the policy checks. False otherwise.
+            error_msg: empty str if policy passes, otherwise reason for failure.
+    """
+    # verify the maximum tx size is not exceeded
+    if tx.Size() > tx.MAX_TX_SIZE:
+        return False, f"Transaction cancelled. The tx size ({tx.Size()}) exceeds the maximum tx size ({tx.MAX_TX_SIZE})."
+
+    # calculate and verify the required network fee for the tx
+    fee = tx.NetworkFee()
+    if tx.Size() > settings.MAX_FREE_TX_SIZE and not tx.Type == b'\x02':  # Claim Transactions are High Priority
+        req_fee = Fixed8.FromDecimal(settings.FEE_PER_EXTRA_BYTE * (tx.Size() - settings.MAX_FREE_TX_SIZE))
+        if req_fee < settings.LOW_PRIORITY_THRESHOLD:
+            req_fee = settings.LOW_PRIORITY_THRESHOLD
+        if fee < req_fee:
+            return False, f'Transaction cancelled. The tx size ({tx.Size()}) exceeds the max free tx size ({settings.MAX_FREE_TX_SIZE}).\nA network fee of {req_fee.ToString()} GAS is required.'
+    return True, ""

--- a/neo/Implementations/Wallets/peewee/test_user_wallet.py
+++ b/neo/Implementations/Wallets/peewee/test_user_wallet.py
@@ -10,7 +10,7 @@ from neo.Core.Fixed8 import Fixed8
 from neo.Core.KeyPair import KeyPair
 from neo.Wallets.NEP5Token import NEP5Token
 from neo.SmartContract.ContractParameterContext import ContractParametersContext
-from neo.Core.TX.Transaction import ContractTransaction, TransactionOutput, TXFeeError
+from neo.Core.TX.Transaction import ContractTransaction, TransactionOutput
 from mock import patch
 import binascii
 from neo.Network.nodemanager import NodeManager
@@ -197,7 +197,7 @@ class UserWalletTestCase(WalletFixtureTestCase):
 
             try:
                 tx = wallet.MakeTransaction(tx)
-            except (ValueError, TXFeeError):
+            except (ValueError):
                 pass
 
             cpc = ContractParametersContext(tx)

--- a/neo/Network/nodemanager.py
+++ b/neo/Network/nodemanager.py
@@ -8,8 +8,7 @@ from functools import partial
 from socket import AF_INET as IP4_FAMILY
 from typing import Optional, List
 
-from neo.Core.TX.Transaction import Transaction as OrigTransaction, TXError
-from neo.Core.Fixed8 import Fixed8
+from neo.Core.TX.Transaction import Transaction as OrigTransaction
 from neo.Network.common import msgrouter, wait_for
 from neo.Network.common.singleton import Singleton
 from neo.Network import utils as networkutils
@@ -21,9 +20,7 @@ from neo.Network.requestinfo import RequestInfo
 from neo.Settings import settings
 from neo.logging import log_manager
 
-
 logger = log_manager.getLogger('network')
-# log_manager.config_stdio([('network', 10)])
 
 
 class NodeManager(Singleton):
@@ -295,19 +292,6 @@ class NodeManager(Singleton):
 
     def relay(self, inventory) -> bool:
         if type(inventory) is OrigTransaction or issubclass(type(inventory), OrigTransaction):
-            # verify the maximum tx size is not exceeded
-            if inventory.Size() > OrigTransaction.MAX_TX_SIZE:
-                raise TXError(f"Transaction cancelled. The tx size ({inventory.Size()}) exceeds the maximum tx size ({OrigTransaction.MAX_TX_SIZE}).") 
-
-            # calculate and verify the required network fee for the tx
-            fee = inventory.NetworkFee()
-            if inventory.Size() > settings.MAX_FREE_TX_SIZE and not inventory.Type == b'\x02':  # Claim Transactions are High Priority
-                req_fee = Fixed8.FromDecimal(settings.FEE_PER_EXTRA_BYTE * (inventory.Size() - settings.MAX_FREE_TX_SIZE))
-                if req_fee < settings.LOW_PRIORITY_THRESHOLD:
-                    req_fee = settings.LOW_PRIORITY_THRESHOLD
-                if fee < req_fee:
-                    raise TXError(f'Transaction cancelled. The tx size ({inventory.Size()}) exceeds the max free tx size ({settings.MAX_FREE_TX_SIZE}).\nA network fee of {req_fee.ToString()} GAS is required.')
-
             success = self.mempool.add_transaction(inventory)
             if not success:
                 return False

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -36,6 +36,7 @@ from copy import deepcopy
 from neo.logging import log_manager
 from neo.Prompt.PromptPrinter import prompt_print as print
 from neo.Network.nodemanager import NodeManager
+from neo.Core.Utils import validate_simple_policy
 
 logger = log_manager.getLogger()
 
@@ -74,14 +75,13 @@ def InvokeContract(wallet, tx, fee=Fixed8.Zero(), from_addr=None, owners=None):
 
             wallet_tx.scripts = context.GetScripts()
 
-            relayed = False
+            passed, reason = validate_simple_policy(wallet_tx)
+            if not passed:
+                print(reason)
+                return False
 
             nodemgr = NodeManager()
-            try:
-                relayed = nodemgr.relay(wallet_tx)
-            except TXError as e:
-                print(e)
-                return False
+            relayed = nodemgr.relay(wallet_tx)
 
             if relayed:
                 print("Relayed Tx: %s " % wallet_tx.Hash.ToString())

--- a/neo/Prompt/Commands/Invoke.py
+++ b/neo/Prompt/Commands/Invoke.py
@@ -18,7 +18,7 @@ from neo.Core.State.StorageItem import StorageItem
 
 from neo.Core.TX.InvocationTransaction import InvocationTransaction
 from neo.Core.TX.TransactionAttribute import TransactionAttribute, TransactionAttributeUsage
-from neo.Core.TX.Transaction import TransactionOutput, TXError
+from neo.Core.TX.Transaction import TransactionOutput
 
 from neo.SmartContract.ApplicationEngine import ApplicationEngine
 from neo.SmartContract import TriggerType

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -1,4 +1,4 @@
-from neo.Core.TX.Transaction import TransactionOutput, ContractTransaction, TXError
+from neo.Core.TX.Transaction import TransactionOutput, ContractTransaction
 from neo.Core.TX.TransactionAttribute import TransactionAttribute, TransactionAttributeUsage
 from neo.SmartContract.ContractParameterContext import ContractParametersContext
 from neo.Prompt.Utils import get_arg, get_from_addr, get_asset_id, lookup_addr_str, get_tx_attr_from_args, \

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -1,4 +1,4 @@
-from neo.Core.TX.Transaction import TransactionOutput, ContractTransaction, TXFeeError
+from neo.Core.TX.Transaction import TransactionOutput, ContractTransaction, TXError
 from neo.Core.TX.TransactionAttribute import TransactionAttribute, TransactionAttributeUsage
 from neo.SmartContract.ContractParameterContext import ContractParametersContext
 from neo.Prompt.Utils import get_arg, get_from_addr, get_asset_id, lookup_addr_str, get_tx_attr_from_args, \
@@ -254,9 +254,6 @@ def process_transaction(wallet, contract_tx, scripthash_from=None, scripthash_ch
               "If you are trying to sent multiple transactions in 1 block, then make sure you have enough 'vouts'\n."
               "Use `wallet unspent` and `wallet address split`, or wait until the first transaction is processed before sending another.")
         return
-    except TXFeeError as e:
-        print(e)
-        return
 
     if tx is None:
         logger.debug("insufficient funds")
@@ -323,7 +320,12 @@ def process_transaction(wallet, contract_tx, scripthash_from=None, scripthash_ch
 
             tx.scripts = context.GetScripts()
             nodemgr = NodeManager()
-            relayed = nodemgr.relay(tx)
+            try:
+                relayed = nodemgr.relay(tx)
+            except TXError as e:
+                print(e)
+                return
+
             if relayed:
                 wallet.SaveTransaction(tx)
 

--- a/neo/Prompt/Commands/Send.py
+++ b/neo/Prompt/Commands/Send.py
@@ -7,6 +7,7 @@ from neo.Prompt.Commands.Tokens import do_token_transfer, amount_from_string
 from neo.Prompt.Commands.Invoke import gather_signatures
 from neo.Wallets.NEP5Token import NEP5Token
 from neo.Core.Fixed8 import Fixed8
+from neo.Core.Utils import validate_simple_policy
 import json
 import traceback
 from neo.Prompt.PromptData import PromptData
@@ -319,12 +320,14 @@ def process_transaction(wallet, contract_tx, scripthash_from=None, scripthash_ch
         if context.Completed:
 
             tx.scripts = context.GetScripts()
-            nodemgr = NodeManager()
-            try:
-                relayed = nodemgr.relay(tx)
-            except TXError as e:
-                print(e)
+
+            passed, reason = validate_simple_policy(tx)
+            if not passed:
+                print(reason)
                 return
+
+            nodemgr = NodeManager()
+            relayed = nodemgr.relay(tx)
 
             if relayed:
                 wallet.SaveTransaction(tx)

--- a/neo/Prompt/Commands/tests/test_sc_commands.py
+++ b/neo/Prompt/Commands/tests/test_sc_commands.py
@@ -345,29 +345,6 @@ class CommandSCTestCase(WalletFixtureTestCase):
                     self.assertIn("Priority Fee (0.001) + Deploy Invoke TX Fee (0.0) = 0.001", mock_print.getvalue())
                     self.assertTrue(mock_print.getvalue().endswith('Insufficient funds\n'))
 
-        # test with ok contract parameter gathering, and tx is too large for low priority (e.g. >1024), just insufficient funds to deploy
-        with patch('sys.stdout', new=StringIO()) as mock_print:
-            with patch('neo.Prompt.Commands.LoadSmartContract.prompt', side_effect=prompt_entries):
-                with patch('neo.Prompt.Commands.SC.prompt', side_effect=[self.wallet_1_pass()]):
-                    with patch('neo.Core.TX.InvocationTransaction.InvocationTransaction.Size', return_value=1026):  # returns a size of 1026
-                        args = ['deploy', path_dir + 'SampleSC.avm', 'True', 'False', 'False', '070502', '02']
-                        res = CommandSC().execute(args)
-                        self.assertFalse(res)
-                        self.assertIn("Deploy Invoke TX Fee: 0.001", mock_print.getvalue())  # notice the required fee is equal to the low priority threshold
-                        self.assertTrue(mock_print.getvalue().endswith('Insufficient funds\n'))
-
-        # test with ok contract parameter gathering, but tx size exceeds the size covered by the high priority fee (e.g. >1124), just insufficient funds to deploy
-        with patch('sys.stdout', new=StringIO()) as mock_print:
-            with patch('neo.Prompt.Commands.LoadSmartContract.prompt', side_effect=prompt_entries):
-                with patch('neo.Prompt.Commands.SC.prompt', side_effect=[self.wallet_1_pass()]):
-                    with patch('neo.Core.TX.InvocationTransaction.InvocationTransaction.Size', return_value=1411):  # returns a size of 1411
-                        args = ['deploy', path_dir + 'SampleSC.avm', 'True', 'False', 'False', '070502', '02']
-                        res = CommandSC().execute(args)
-                        self.assertFalse(res)
-                        self.assertIn("Deploy Invoke TX Fee: 0.00387",
-                                      mock_print.getvalue())  # notice the required fee is now greater than the low priority threshold
-                        self.assertTrue(mock_print.getvalue().endswith('Insufficient funds\n'))
-
     def test_sc_invoke(self):
         token_hash_str = '31730cc9a1844891a3bafd1aa929a4142860d8d3'
 

--- a/neo/Prompt/Commands/tests/test_send_commands.py
+++ b/neo/Prompt/Commands/tests/test_send_commands.py
@@ -243,28 +243,55 @@ class UserWalletTestCase(WalletFixtureTestCase):
             self.assertIn("Insufficient funds", mock_print.getvalue())
 
     def test_transaction_size_1(self):
+        nodemgr = NodeManager()
+        nodemgr.reset_for_test()
+        nodemgr.nodes = [NeoNode(object, object)]
+
         with patch('sys.stdout', new=StringIO()) as mock_print:
-            with patch('neo.Core.TX.Transaction.Transaction.Size', return_value=1026):  # returns a size of 1026
-                PromptData.Wallet = self.GetWallet1(recreate=True)
-                args = ['send', 'gas', self.watch_addr_str, '5']
+            with patch('neo.Prompt.Commands.Send.prompt', side_effect=[UserWalletTestCase.wallet_1_pass()]):
+                with patch('neo.Core.TX.Transaction.Transaction.Size', return_value=1026):  # returns a size of 1026
+                    PromptData.Wallet = self.GetWallet1(recreate=True)
+                    args = ['send', 'gas', self.watch_addr_str, '5']
 
-                res = Wallet.CommandWallet().execute(args)
+                    res = Wallet.CommandWallet().execute(args)
 
-                self.assertFalse(res)
-                self.assertIn('Transaction cancelled. The tx size (1026) exceeds the max free tx size (1024).\nA network fee of 0.001 GAS is required.',
-                              mock_print.getvalue())  # notice the required fee is equal to the low priority threshold
+                    self.assertFalse(res)
+                    self.assertIn('Transaction cancelled. The tx size (1026) exceeds the max free tx size (1024).\nA network fee of 0.001 GAS is required.',
+                                  mock_print.getvalue())  # notice the required fee is equal to the low priority threshold
 
     def test_transaction_size_2(self):
+        nodemgr = NodeManager()
+        nodemgr.reset_for_test()
+        nodemgr.nodes = [NeoNode(object, object)]
+
         with patch('sys.stdout', new=StringIO()) as mock_print:
-            with patch('neo.Core.TX.Transaction.Transaction.Size', return_value=1411):  # returns a size of 1411
-                PromptData.Wallet = self.GetWallet1(recreate=True)
-                args = ['send', 'gas', self.watch_addr_str, '5', '--fee=0.001']
+            with patch('neo.Prompt.Commands.Send.prompt', side_effect=[UserWalletTestCase.wallet_1_pass()]):
+                with patch('neo.Core.TX.Transaction.Transaction.Size', return_value=1411):  # returns a size of 1411
+                    PromptData.Wallet = self.GetWallet1(recreate=True)
+                    args = ['send', 'gas', self.watch_addr_str, '5', '--fee=0.001']
 
-                res = Wallet.CommandWallet().execute(args)
+                    res = Wallet.CommandWallet().execute(args)
 
-                self.assertFalse(res)
-                self.assertIn('Transaction cancelled. The tx size (1411) exceeds the max free tx size (1024).\nA network fee of 0.00387 GAS is required.',
-                              mock_print.getvalue())  # the required fee is equal to (1411-1024) * 0.0001 (FEE_PER_EXTRA_BYTE) = 0.00387
+                    self.assertFalse(res)
+                    self.assertIn('Transaction cancelled. The tx size (1411) exceeds the max free tx size (1024).\nA network fee of 0.00387 GAS is required.',
+                                  mock_print.getvalue())  # the required fee is equal to (1411-1024) * 0.0001 (FEE_PER_EXTRA_BYTE) = 0.00387
+
+    def test_transaction_size_3(self):
+        nodemgr = NodeManager()
+        nodemgr.reset_for_test()
+        nodemgr.nodes = [NeoNode(object, object)]
+
+        with patch('sys.stdout', new=StringIO()) as mock_print:
+            with patch('neo.Prompt.Commands.Send.prompt', side_effect=[UserWalletTestCase.wallet_1_pass()]):
+                with patch('neo.Core.TX.Transaction.Transaction.Size', return_value=102401):  # returns a size of 102401
+                    PromptData.Wallet = self.GetWallet1(recreate=True)
+                    args = ['send', 'gas', self.watch_addr_str, '5', '--fee=0.5']
+
+                    res = Wallet.CommandWallet().execute(args)
+
+                    self.assertFalse(res)
+                    self.assertIn('Transaction cancelled. The tx size (102401) exceeds the maximum tx size (102400).',
+                                  mock_print.getvalue())  # the maximum tx size is 102400
 
     def test_bad_password(self):
         with patch('neo.Prompt.Commands.Send.prompt', side_effect=['blah']):

--- a/neo/Prompt/Commands/tests/test_send_commands.py
+++ b/neo/Prompt/Commands/tests/test_send_commands.py
@@ -260,10 +260,6 @@ class UserWalletTestCase(WalletFixtureTestCase):
                                   mock_print.getvalue())  # notice the required fee is equal to the low priority threshold
 
     def test_transaction_size_2(self):
-        nodemgr = NodeManager()
-        nodemgr.reset_for_test()
-        nodemgr.nodes = [NeoNode(object, object)]
-
         with patch('sys.stdout', new=StringIO()) as mock_print:
             with patch('neo.Prompt.Commands.Send.prompt', side_effect=[UserWalletTestCase.wallet_1_pass()]):
                 with patch('neo.Core.TX.Transaction.Transaction.Size', return_value=1411):  # returns a size of 1411
@@ -277,10 +273,6 @@ class UserWalletTestCase(WalletFixtureTestCase):
                                   mock_print.getvalue())  # the required fee is equal to (1411-1024) * 0.0001 (FEE_PER_EXTRA_BYTE) = 0.00387
 
     def test_transaction_size_3(self):
-        nodemgr = NodeManager()
-        nodemgr.reset_for_test()
-        nodemgr.nodes = [NeoNode(object, object)]
-
         with patch('sys.stdout', new=StringIO()) as mock_print:
             with patch('neo.Prompt.Commands.Send.prompt', side_effect=[UserWalletTestCase.wallet_1_pass()]):
                 with patch('neo.Core.TX.Transaction.Transaction.Size', return_value=102401):  # returns a size of 102401

--- a/neo/Wallets/Wallet.py
+++ b/neo/Wallets/Wallet.py
@@ -13,7 +13,7 @@ from decimal import Decimal
 from Crypto import Random
 from Crypto.Cipher import AES
 from threading import RLock
-from neo.Core.TX.Transaction import TransactionType, TransactionOutput, TXFeeError
+from neo.Core.TX.Transaction import TransactionType, TransactionOutput
 from neo.Core.State.CoinState import CoinState
 from neo.Core.Blockchain import Blockchain
 from neo.Core.CoinReference import CoinReference
@@ -986,8 +986,7 @@ class Wallet:
                         use_standard=False,
                         watch_only_val=0,
                         exclude_vin=None,
-                        use_vins_for_asset=None,
-                        skip_fee_calc=False):
+                        use_vins_for_asset=None):
         """
         This method is used to to calculate the necessary TransactionInputs (CoinReferences) and TransactionOutputs to
         be used when creating a transaction that involves an exchange of system assets, ( NEO, Gas, etc ).
@@ -1001,7 +1000,6 @@ class Wallet:
             watch_only_val (int): 0 or CoinState.WATCH_ONLY, if present only choose coins that are in a WatchOnly address.
             exclude_vin (list): A list of CoinReferences to NOT use in the making of this tx.
             use_vins_for_asset (list): A list of CoinReferences to use.
-            skip_fee_calc (bool): If true, the network fee calculation and verification will be skipped.
 
         Returns:
             tx: (Transaction) Returns the transaction with updated inputs and outputs.
@@ -1092,15 +1090,6 @@ class Wallet:
 
         tx.inputs = inputs
         tx.outputs = tx.outputs + new_outputs
-
-        # calculate and verify the required network fee for the tx
-        if tx.Size() > settings.MAX_FREE_TX_SIZE and not skip_fee_calc:
-            req_fee = Fixed8.FromDecimal(settings.FEE_PER_EXTRA_BYTE * (tx.Size() - settings.MAX_FREE_TX_SIZE))
-            if req_fee < settings.LOW_PRIORITY_THRESHOLD:
-                req_fee = settings.LOW_PRIORITY_THRESHOLD
-            if fee < req_fee:
-                raise TXFeeError(
-                    f'Transaction cancelled. The tx size ({tx.Size()}) exceeds the max free tx size ({settings.MAX_FREE_TX_SIZE}).\nA network fee of {req_fee.ToString()} GAS is required.')
 
         return tx
 

--- a/neo/api/JSONRPC/JsonRpcApi.py
+++ b/neo/api/JSONRPC/JsonRpcApi.py
@@ -22,7 +22,7 @@ from neo.Core.State.AccountState import AccountState
 from neo.Core.State.CoinState import CoinState
 from neo.Core.State.StorageKey import StorageKey
 from neo.Core.TX.Transaction import Transaction, TransactionOutput, \
-    ContractTransaction, TXError
+    ContractTransaction
 from neo.Core.TX.TransactionAttribute import TransactionAttribute, \
     TransactionAttributeUsage
 from neo.Core.UInt160 import UInt160

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -771,6 +771,8 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         os.remove(test_wallet_path)
 
     def test_send_to_address_simple(self):
+        self.api_server.nodemgr.reset_for_test()
+        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -781,8 +783,9 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         )
         address = 'AXjaFSP23Jkbe6Pk9pPGT6NBDs1HVdqaXK'
 
-        req = self._gen_post_rpc_req("sendtoaddress", params=['gas', address, 1])
-        res = json.loads(self.do_test_post("/", json=req))
+        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+            req = self._gen_post_rpc_req("sendtoaddress", params=['gas', address, 1])
+            res = json.loads(self.do_test_post("/", json=req))
 
         self.assertEqual(res.get('jsonrpc', None), '2.0')
         self.assertIn('txid', res.get('result', {}).keys())
@@ -793,6 +796,8 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         os.remove(WalletFixtureTestCase.wallet_1_dest())
 
     def test_send_to_address_with_fee(self):
+        self.api_server.nodemgr.reset_for_test()
+        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -803,8 +808,9 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         )
         address = 'AXjaFSP23Jkbe6Pk9pPGT6NBDs1HVdqaXK'
 
-        req = self._gen_post_rpc_req("sendtoaddress", params=['neo', address, 1, 0.005])
-        res = json.loads(self.do_test_post("/", json=req))
+        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+            req = self._gen_post_rpc_req("sendtoaddress", params=['neo', address, 1, 0.005])
+            res = json.loads(self.do_test_post("/", json=req))
 
         self.assertEqual(res.get('jsonrpc', None), '2.0')
         self.assertIn('txid', res.get('result', {}).keys())
@@ -990,6 +996,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
 
     def test_send_from_simple(self):
         self.api_server.nodemgr.reset_for_test()
+        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -1000,8 +1007,11 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         )
         address_to = 'AXjaFSP23Jkbe6Pk9pPGT6NBDs1HVdqaXK'
         address_from = 'AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3'
-        req = self._gen_post_rpc_req("sendfrom", params=['neo', address_from, address_to, 1])
-        res = json.loads(self.do_test_post("/", json=req))
+
+        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+            req = self._gen_post_rpc_req("sendfrom", params=['neo', address_from, address_to, 1])
+            res = json.loads(self.do_test_post("/", json=req))
+
         self.assertEqual(res.get('jsonrpc', None), '2.0')
         self.assertIn('txid', res.get('result', {}).keys())
         self.assertIn('vin', res.get('result', {}).keys())
@@ -1013,6 +1023,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
 
     def test_send_from_complex(self):
         self.api_server.nodemgr.reset_for_test()
+        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -1031,8 +1042,9 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
                                        address_from_account_state['balances']))
         address_from_gas_bal = address_from_gas['value']
 
-        req = self._gen_post_rpc_req("sendfrom", params=['gas', address_from, address_to, amount, net_fee, change_addr])
-        res = json.loads(self.do_test_post("/", json=req))
+        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+            req = self._gen_post_rpc_req("sendfrom", params=['gas', address_from, address_to, amount, net_fee, change_addr])
+            res = json.loads(self.do_test_post("/", json=req))
 
         self.assertEqual(res.get('jsonrpc', None), '2.0')
         self.assertIn('txid', res.get('result', {}).keys())
@@ -1237,6 +1249,8 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
 
     def test_sendmany_complex_post(self):
         # test POST requests
+        self.api_server.nodemgr.reset_for_test()
+        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -1252,8 +1266,9 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
                   {"asset": 'neo',
                    "value": 1,
                    "address": address_to}]
-        req = self._gen_post_rpc_req("sendmany", params=[output, 1, "APRgMZHZubii29UXF9uFa6sohrsYupNAvx"])
-        res = json.loads(self.do_test_post("/", json=req))
+        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+            req = self._gen_post_rpc_req("sendmany", params=[output, 1, "APRgMZHZubii29UXF9uFa6sohrsYupNAvx"])
+            res = json.loads(self.do_test_post("/", json=req))
 
         self.assertEqual(res.get('jsonrpc', None), '2.0')
         self.assertIn('txid', res.get('result', {}).keys())
@@ -1272,6 +1287,8 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         os.remove(WalletFixtureTestCase.wallet_1_dest())
 
         # test GET requests
+        self.api_server.nodemgr.reset_for_test()
+        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -1280,8 +1297,9 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
             test_wallet_path,
             to_aes_key(WalletFixtureTestCase.wallet_1_pass())
         )
-        req = self._gen_get_rpc_req("sendmany", params=[output, 0.005, "APRgMZHZubii29UXF9uFa6sohrsYupNAvx"])
-        res = json.loads(self.do_test_get(req))
+        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+            req = self._gen_get_rpc_req("sendmany", params=[output, 0.005, "APRgMZHZubii29UXF9uFa6sohrsYupNAvx"])
+            res = json.loads(self.do_test_get(req))
 
         self.assertEqual(res.get('jsonrpc', None), '2.0')
         self.assertIn('txid', res.get('result', {}).keys())
@@ -1300,6 +1318,8 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         os.remove(WalletFixtureTestCase.wallet_1_dest())
 
     def test_sendmany_min_params(self):
+        self.api_server.nodemgr.reset_for_test()
+        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -1315,8 +1335,10 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
                   {"asset": 'neo',
                    "value": 1,
                    "address": address_to}]
-        req = self._gen_post_rpc_req("sendmany", params=[output])
-        res = json.loads(self.do_test_post("/", json=req))
+        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+            req = self._gen_post_rpc_req("sendmany", params=[output])
+            res = json.loads(self.do_test_post("/", json=req))
+
         self.assertEqual(res.get('jsonrpc', None), '2.0')
         self.assertIn('txid', res.get('result', {}).keys())
         self.assertIn('vin', res.get('result', {}).keys())

--- a/neo/api/JSONRPC/test_json_rpc_api.py
+++ b/neo/api/JSONRPC/test_json_rpc_api.py
@@ -771,8 +771,6 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         os.remove(test_wallet_path)
 
     def test_send_to_address_simple(self):
-        self.api_server.nodemgr.reset_for_test()
-        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -783,7 +781,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         )
         address = 'AXjaFSP23Jkbe6Pk9pPGT6NBDs1HVdqaXK'
 
-        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+        with patch('neo.Network.nodemanager.NodeManager.relay', return_value=self.async_return(True)):
             req = self._gen_post_rpc_req("sendtoaddress", params=['gas', address, 1])
             res = json.loads(self.do_test_post("/", json=req))
 
@@ -796,8 +794,6 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         os.remove(WalletFixtureTestCase.wallet_1_dest())
 
     def test_send_to_address_with_fee(self):
-        self.api_server.nodemgr.reset_for_test()
-        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -808,7 +804,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         )
         address = 'AXjaFSP23Jkbe6Pk9pPGT6NBDs1HVdqaXK'
 
-        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+        with patch('neo.Network.nodemanager.NodeManager.relay', return_value=self.async_return(True)):
             req = self._gen_post_rpc_req("sendtoaddress", params=['neo', address, 1, 0.005])
             res = json.loads(self.do_test_post("/", json=req))
 
@@ -995,8 +991,6 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         os.remove(test_wallet_path)
 
     def test_send_from_simple(self):
-        self.api_server.nodemgr.reset_for_test()
-        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -1008,7 +1002,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         address_to = 'AXjaFSP23Jkbe6Pk9pPGT6NBDs1HVdqaXK'
         address_from = 'AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3'
 
-        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+        with patch('neo.Network.nodemanager.NodeManager.relay', return_value=self.async_return(True)):
             req = self._gen_post_rpc_req("sendfrom", params=['neo', address_from, address_to, 1])
             res = json.loads(self.do_test_post("/", json=req))
 
@@ -1022,8 +1016,6 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         os.remove(WalletFixtureTestCase.wallet_1_dest())
 
     def test_send_from_complex(self):
-        self.api_server.nodemgr.reset_for_test()
-        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -1042,7 +1034,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
                                        address_from_account_state['balances']))
         address_from_gas_bal = address_from_gas['value']
 
-        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+        with patch('neo.Network.nodemanager.NodeManager.relay', return_value=self.async_return(True)):
             req = self._gen_post_rpc_req("sendfrom", params=['gas', address_from, address_to, amount, net_fee, change_addr])
             res = json.loads(self.do_test_post("/", json=req))
 
@@ -1249,8 +1241,6 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
 
     def test_sendmany_complex_post(self):
         # test POST requests
-        self.api_server.nodemgr.reset_for_test()
-        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -1266,7 +1256,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
                   {"asset": 'neo',
                    "value": 1,
                    "address": address_to}]
-        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+        with patch('neo.Network.nodemanager.NodeManager.relay', return_value=self.async_return(True)):
             req = self._gen_post_rpc_req("sendmany", params=[output, 1, "APRgMZHZubii29UXF9uFa6sohrsYupNAvx"])
             res = json.loads(self.do_test_post("/", json=req))
 
@@ -1287,8 +1277,6 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         os.remove(WalletFixtureTestCase.wallet_1_dest())
 
         # test GET requests
-        self.api_server.nodemgr.reset_for_test()
-        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -1297,7 +1285,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
             test_wallet_path,
             to_aes_key(WalletFixtureTestCase.wallet_1_pass())
         )
-        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+        with patch('neo.Network.nodemanager.NodeManager.relay', return_value=self.async_return(True)):
             req = self._gen_get_rpc_req("sendmany", params=[output, 0.005, "APRgMZHZubii29UXF9uFa6sohrsYupNAvx"])
             res = json.loads(self.do_test_get(req))
 
@@ -1318,8 +1306,6 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
         os.remove(WalletFixtureTestCase.wallet_1_dest())
 
     def test_sendmany_min_params(self):
-        self.api_server.nodemgr.reset_for_test()
-        self.api_server.nodemgr.nodes = [NeoNode(object, object)]
         test_wallet_path = shutil.copyfile(
             WalletFixtureTestCase.wallet_1_path(),
             WalletFixtureTestCase.wallet_1_dest()
@@ -1335,7 +1321,7 @@ class JsonRpcApiTestCase(BlockchainFixtureTestCase, AioHTTPTestCase):
                   {"asset": 'neo',
                    "value": 1,
                    "address": address_to}]
-        with patch('neo.Network.node.NeoNode.relay', return_value=self.async_return(True)):
+        with patch('neo.Network.nodemanager.NodeManager.relay', return_value=self.async_return(True)):
             req = self._gen_post_rpc_req("sendmany", params=[output])
             res = json.loads(self.do_test_post("/", json=req))
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Addresses #960; specifically, https://github.com/CityOfZion/neo-python/issues/960#issuecomment-512248474

**How did you solve this problem?**
implement SimplePolicy check when relaying any tx
- results in a cancelled tx and a required fee recommendation if SimplePolicy requirements are not met
- addresses https://github.com/CityOfZion/neo-python/issues/960#issuecomment-512248474 by checking each tx after it is signed

**How did you make sure your solution works?**
`make test` with unittests

**Are there any special changes in the code that we should be aware of?**
Replaced `TXFeeError` with `TXError` to incorporate a check for violating the tx maximum size

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
