### PR TITLE
Fix Prompt Bug with Sending NEP-5 Tokens

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,6 +57,7 @@ All notable changes to this project are documented in this file.
 - Updated ``np-bootstrap`` to delete the downloaded bootstrap file by default `#986 <https://github.com/CityOfZion/neo-python/pull/986>`_
 - Fix ``Remove()`` behaviour for ``Map`` and ``Array`` types to be inline with C#
 - Add support for compressed syscalls
+- Fix NEP-5 token send operation in ``np-prompt`` to properly handle token ``decimals``/scale
 
 
 [0.8.4] 2019-02-14

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,7 +57,7 @@ All notable changes to this project are documented in this file.
 - Updated ``np-bootstrap`` to delete the downloaded bootstrap file by default `#986 <https://github.com/CityOfZion/neo-python/pull/986>`_
 - Fix ``Remove()`` behaviour for ``Map`` and ``Array`` types to be inline with C#
 - Add support for compressed syscalls
-- Fix NEP-5 token send operation in ``np-prompt`` to properly handle token ``decimals``/scale
+- Fix NEP-5 token send operation in ``np-prompt`` to properly handle token ``decimals``/scale `#990 <https://github.com/CityOfZion/neo-python/pull/990>`_
 
 
 [0.8.4] 2019-02-14

--- a/neo/Prompt/Commands/Tokens.py
+++ b/neo/Prompt/Commands/Tokens.py
@@ -609,7 +609,9 @@ def token_send(wallet, token_str, from_addr, to_addr, amount, fee=Fixed8.Zero(),
         if not isinstance(attr, TransactionAttribute):
             raise ValueError(f"{attr} is not a valid transaction attribute")
 
-    return do_token_transfer(token, wallet, from_addr, to_addr, amount, fee=fee, tx_attributes=user_tx_attributes)
+    decimal_amount = amount_from_string(token, amount)
+
+    return do_token_transfer(token, wallet, from_addr, to_addr, decimal_amount, fee=fee, tx_attributes=user_tx_attributes)
 
 
 def test_token_send_from(wallet, token_str, from_addr, to_addr, amount):


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

* Fixed a bug where sending NEP-5 tokens via the Prompt CLI did not properly handle the NEP-5 decimal conversion. Thus, previously, you'd have to enter the amount as a "raw" value without a decimal in order for the proper amount of tokens to be sent.

**How did you solve this problem?**

Added the proper conversion of the user-entered decimal amount to the raw value based on the NEP-5 token's `decimals`. This fix is mirrored off of the `approve` command, which was already handling the conversion properly.

**How did you make sure your solution works?**

Tested it.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
