### PR TITLE
fix storage find iterator when facing cached data

### DIFF
--- a/neo/SmartContract/Iterable/StorageIterator.py
+++ b/neo/SmartContract/Iterable/StorageIterator.py
@@ -14,6 +14,7 @@ class StorageIterator(Iterator):
     def Next(self):
         try:
             self.key, self.value = next(self.enumerator)
+            self.key = self.key[20:]
         except StopIteration:
             return False
         return True

--- a/neo/SmartContract/StateMachine.py
+++ b/neo/SmartContract/StateMachine.py
@@ -751,7 +751,7 @@ class StateMachine(StateReader):
             if contract.HasStorage:
                 to_add = []
                 for key, item in self.Snapshot.Storages.Find(cur_hash.ToArray()):
-                    key = StorageKey(script_hash=hash, key=key)
+                    key = StorageKey(script_hash=hash, key=key[20:])
                     to_add.append((key.ToArray(), item))
 
                 for k, v in to_add:

--- a/neo/Storage/Common/DataCache.py
+++ b/neo/Storage/Common/DataCache.py
@@ -88,12 +88,12 @@ class DataCache:
             key_prefix = b''
 
         for k, v in self.FindInternal(key_prefix):
-            if bytes(key_prefix + k) not in self.dictionary:
+            if k not in self.dictionary:
                 yield k, v
 
         for k, v in self.dictionary.items():
             if v.State != TrackState.DELETED and (key_prefix is None or key_prefix in k):
-                yield k[20:], v.Item
+                yield k, v.Item
 
     def FindInternal(self, key_prefix) -> dict:
         # should be equal to DBInterface.Find

--- a/neo/Storage/Implementation/LevelDB/LevelDBCache.py
+++ b/neo/Storage/Implementation/LevelDB/LevelDBCache.py
@@ -41,7 +41,7 @@ class LevelDBCache(DataCache):
                 # we want the storage item, not the raw bytes
                 item = self.ClassRef.DeserializeFromDB(binascii.unhexlify(val))
                 # also here we need to skip the 1 byte storage prefix
-                res_key = key[21:]
+                res_key = key[1:]
                 res[res_key] = item
 
         # yielding outside of iterator to make sure the db iterator is closed


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
`Storage.Find` did not work properly when called after storage was altered in the current snapshot. This would cause it to not find data in it's cache and return duplicate results and also in the wrong order.

**How did you solve this problem?**

**How did you make sure your solution works?**

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
