### PR TITLE
fix NOT VM instruction

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,7 @@ All notable changes to this project are documented in this file.
 - Fix ``Remove()`` behaviour for ``Map`` and ``Array`` types to be inline with C#
 - Add support for compressed syscalls
 - Fix NEP-5 token send operation in ``np-prompt`` to properly handle token ``decimals``/scale `#990 <https://github.com/CityOfZion/neo-python/pull/990>`_
+- Fix ``NOT`` VM instruction
 
 
 [0.8.4] 2019-02-14

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -537,7 +537,7 @@ class ExecutionEngine:
 
             elif opcode == NOT:
 
-                x = estack.Pop().GetBigInteger()
+                x = estack.Pop().GetBoolean()
                 estack.PushT(not x)
                 self.CheckStackSize(False, 0)
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Audit of testnet block `2431844` showed a deviation in gas consumption due to a difference in the `NOT`  VM instruction. The faulty implementation would throw an exception because we tried to get a `BitInteger` from a `Map` VM type, which isn't possible. 

**How did you solve this problem?**
align implementation

**How did you make sure your solution works?**
audit of block now passes

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
