### PR TITLE
fix stack item deserialization for Boolean VM type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,6 +59,7 @@ All notable changes to this project are documented in this file.
 - Add support for compressed syscalls
 - Fix NEP-5 token send operation in ``np-prompt`` to properly handle token ``decimals``/scale `#990 <https://github.com/CityOfZion/neo-python/pull/990>`_
 - Fix ``NOT`` VM instruction
+- Fix StackItem deserialization for ``Boolean`` VM type
 
 
 [0.8.4] 2019-02-14

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -97,7 +97,7 @@ class StackItem(EquatableMixin):
         if stype == StackItemType.ByteArray:
             return ByteArray(reader.ReadVarBytes())
         elif stype == StackItemType.Boolean:
-            return Boolean(ord(reader.ReadByte()))
+            return Boolean(bool(ord(reader.ReadByte())))
         elif stype == StackItemType.Integer:
             return Integer(BigInteger.FromBytes(reader.ReadVarBytes(), signed=True))
         elif stype == StackItemType.Array:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
audit of testnet block `2591458` showed a deviation in storage value due to wrong a deserialization of a Boolean VM type. This was caused by the Boolean type receiving an `integer` as value as opposed to a `bool` type. This resulted in deserializing the value `44` as opposed to `True`, leading to a `0x01 0x2c` instead of  `0x01 0x01`.

**How did you solve this problem?**
convert int to bool for stack item deserialization

**How did you make sure your solution works?**
audit of block passes

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
