### PR TITLE
update dynamic invoke check to use snapshots

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,6 +60,7 @@ All notable changes to this project are documented in this file.
 - Fix NEP-5 token send operation in ``np-prompt`` to properly handle token ``decimals``/scale `#990 <https://github.com/CityOfZion/neo-python/pull/990>`_
 - Fix ``NOT`` VM instruction
 - Fix StackItem deserialization for ``Boolean`` VM type
+- Update ``CheckDynamicInvoke`` to operate on snapshots
 
 
 [0.8.4] 2019-02-14

--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -73,7 +73,7 @@ class ApplicationEngine(ExecutionEngine):
             # if this is a dynamic app call, we will arrive here
             # get the current executing script hash
             current = UInt160(data=cx.ScriptHash())
-            current_contract_state = self._Table.GetContractState(current.ToBytes())
+            current_contract_state = self.snapshot.Contracts[current.ToBytes()]
 
             # if current contract state cant do dynamic calls, return False
             return current_contract_state.HasDynamicInvoke


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
audit of testnet block `2606285` showed a deviation in VM state due to the `CheckDynamicInvoke` function not using snapshots and accessing the data caching layer. 

**How did you solve this problem?**
make it use snapshots

**How did you make sure your solution works?**
audit of the block now passes

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
