### PR TITLE
fix contract destroy storage deletion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,7 @@ All notable changes to this project are documented in this file.
 - Fix ``NOT`` VM instruction
 - Fix StackItem deserialization for ``Boolean`` VM type
 - Update ``CheckDynamicInvoke`` to operate on snapshots
+- Fix ``Contract.Destroy`` not always deleting storage
 
 
 [0.8.4] 2019-02-14

--- a/neo/SmartContract/StateReader.py
+++ b/neo/SmartContract/StateReader.py
@@ -617,7 +617,7 @@ class StateReader(InteropService):
 
                 to_del = []
                 for k, v in self.Snapshot.Storages.Find(hash.ToArray()):
-                    storage_key = StorageKey(script_hash=hash, key=k)
+                    storage_key = StorageKey(script_hash=hash, key=k[20:])
                     # Snapshot.Storages.Delete() modifies the underlying dictionary of the cache we'd be iterating
                     # over using Storages.Find. We therefore need to postpone deletion
                     to_del.append(storage_key)


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
audit of testnet block `2644593` showed that the `Contract.Destroy` SYSCALL would under certain conditions not delete all contract storage.

**How did you solve this problem?**
fix key data lookup input for internal storage call of the DataCache

**How did you make sure your solution works?**
audit of the said block now passes

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
