### PR TITLE
Fix ByteArray equals

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,7 @@ All notable changes to this project are documented in this file.
 - Fix StackItem deserialization for ``Boolean`` VM type
 - Update ``CheckDynamicInvoke`` to operate on snapshots
 - Fix ``Contract.Destroy`` not always deleting storage
+- Fix ``Equals()`` of ``ByteArray``
 
 
 [0.8.4] 2019-02-14

--- a/neo/VM/InteropService.py
+++ b/neo/VM/InteropService.py
@@ -300,7 +300,10 @@ class ByteArray(StackItem):
         if other is self:
             return True
 
-        return self._value == other._value
+        try:
+            return self._value == other.GetByteArray()
+        except Exception:
+            return False
 
     def GetBigInteger(self):
         try:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Audit of Testnet block `2728887` showed a deviation in gas consumption due to failed comparison between a single element `ByteArray` and an integer. 

**How did you solve this problem?**
ensure that the `Equals` method of `ByteArray` tries to compare against another `ByteArray` type instead of whatever type it might be.

**How did you make sure your solution works?**
audit of the block now passes

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
