### PR TITLE
use snapshot for ED/EDT validation

### DIFF
--- a/neo/SmartContract/ApplicationEngine.py
+++ b/neo/SmartContract/ApplicationEngine.py
@@ -79,7 +79,7 @@ class ApplicationEngine(ExecutionEngine):
             return current_contract_state.HasDynamicInvoke
         elif opcode in [OpCode.CALL_ED, OpCode.CALL_EDT]:
             current = UInt160(data=cx.ScriptHash())
-            current_contract_state = self._Table.GetContractState(current.ToBytes())
+            current_contract_state = self.snapshot.Contracts[current.ToBytes()]
             return current_contract_state.HasDynamicInvoke
 
         else:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
audit of testnet block `2842737` showed a deviation in VM state due to not using snapshots for CALL_ED/EDT dynamic invoke validation. This should have been part of #995 

**How did you solve this problem?**
use same logic as #995

**How did you make sure your solution works?**
audit of block passes

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
