### PR TITLE
limit cli maxpeers

### DIFF
--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -99,7 +99,7 @@ async def setup_and_start(loop):
     group_logging = parser.add_argument_group(title="Logging options")
     group_logging.add_argument("--logfile", action="store", type=str, help="Logfile")
     group_logging.add_argument("--syslog", action="store_true", help="Log to syslog instead of to log file ('user' is the default facility)")
-    group_logging.add_argument("--syslog-local", action="store", type=int, choices=range(0, 7), metavar="[0-7]",
+    group_logging.add_argument("--syslog-local", action="store", type=int, choices=range(0, 7 + 1), metavar="[0-7]",
                                help="Log to a local syslog facility instead of 'user'. Value must be between 0 and 7 (e.g. 0 for 'local0').")
     group_logging.add_argument("--disable-stderr", action="store_true", help="Disable stderr logger")
 
@@ -107,10 +107,10 @@ async def setup_and_start(loop):
     parser.add_argument("--datadir", action="store",
                         help="Absolute path to use for database directories")
     # peers
-    parser.add_argument("--minpeers", action="store", type=int,
+    parser.add_argument("--minpeers", action="store", type=int, choices=range(1, 10 + 1), metavar="[1-10]",
                         help="Min peers to use for P2P Joining")
 
-    parser.add_argument("--maxpeers", action="store", type=int,
+    parser.add_argument("--maxpeers", action="store", type=int, choices=range(1, 10 + 1), metavar="[1-10]",
                         help="Max peers to use for P2P Joining")
 
     # If a wallet should be opened

--- a/neo/bin/prompt.py
+++ b/neo/bin/prompt.py
@@ -31,7 +31,6 @@ from neo.Network.nodemanager import NodeManager
 
 import neo.Storage.Implementation.DBFactory as DBFactory
 
-
 logger = log_manager.getLogger()
 
 from prompt_toolkit.eventloop import use_asyncio_event_loop
@@ -265,10 +264,10 @@ def main():
                         help="Absolute path to use for database directories")
 
     # peers
-    parser.add_argument("--minpeers", action="store", type=int,
+    parser.add_argument("--minpeers", action="store", type=int, choices=range(1, 10 + 1), metavar="[1-10]",
                         help="Min peers to use for P2P Joining")
 
-    parser.add_argument("--maxpeers", action="store", type=int, default=5,
+    parser.add_argument("--maxpeers", action="store", type=int, default=5, choices=range(1, 10 + 1), metavar="[1-10]",
                         help="Max peers to use for P2P Joining")
 
     # Show the neo-python version


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
the `sc config maxpeers/minpeers` command already has a 10 peers max limit imposed. The cli arguments did not. 

**How did you solve this problem?**
add argument choices limit

**How did you make sure your solution works?**
manual testing. now gives the following error if a wrong argument is given
```
np-api-server: error: argument --maxpeers: invalid choice: 12 (choose from 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
```

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
