### PR TITLE
fix RIGHT and LEFT VM opcodes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,6 +65,7 @@ All notable changes to this project are documented in this file.
 - Fix ``Contract.Destroy`` not always deleting storage
 - Fix ``Equals()`` of ``ByteArray``
 - Fix max recursion depth exception when counting certain VM StackItems that point to themselves
+- Fix ``RIGHT`` opcode for 0 count edge case
 
 
 [0.8.4] 2019-02-14

--- a/neo/VM/ExecutionEngine.py
+++ b/neo/VM/ExecutionEngine.py
@@ -456,7 +456,10 @@ class ExecutionEngine:
 
                 x = estack.Pop().GetByteArray()
 
-                estack.PushT(x[:count])
+                if count >= len(x):
+                    estack.PushT(x)
+                else:
+                    estack.PushT(x[:count])
                 self.CheckStackSize(True, -1)
 
             elif opcode == RIGHT:
@@ -469,7 +472,11 @@ class ExecutionEngine:
                 if count > len(x):
                     return self.VM_FAULT_and_report(VMFault.RIGHT_UNKNOWN)
 
-                estack.PushT(x[-count:])
+                if count == len(x):
+                    estack.PushT(x)
+                else:
+                    offset = len(x) - count
+                    estack.PushT(x[offset:offset + count])
                 self.CheckStackSize(True, -1)
 
             elif opcode == SIZE:


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
audit of mainnet block `3602763` showed a deviation in gas consumption due to an incorrect implementation of the `RIGHT` VM opcode. The existing JSON tests also do not cover this.
A `0` count operand should result in an empty buffer, the existing implementation used `buffer[-count:]` which worked fine as long as the count > 0. For the specific case of `0` it would actually return the full buffer instead of an empty buffer as needed. This would return incorrect lenghts, causing an `LT`->`JMPIF` sequence to point the IP to the wrong next instruction.

**How did you solve this problem?**
fix implementation to be explicit. Also addressed possible issue with similar logic for the `LEFT` instruction.

**How did you make sure your solution works?**
audit of the given block now passes. 

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
