### PR TITLE
update docker to use python 3.7

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,12 +30,13 @@ FROM ubuntu:18.04
 ARG branch=master
 
 # Install dependencies
+RUN apt-get update && apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update && apt-get install -y \
     wget \
     git-core \
-    python3.6 \
-    python3.6-dev \
-    python3.6-venv \
+    python3.7 \
+    python3.7-dev \
+    python3.7-venv \
     python3-pip \
     libleveldb-dev \
     libssl-dev \


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
docker uses python 3.6, whereas the latest version will only work with 3.7

**How did you solve this problem?**
install 3.7
**How did you make sure your solution works?**
ran
```
docker build --no-cache -f Dockerfile -t neopython .
```
and passed
**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [ ] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
