### PR TITLE
Fix parsing spaces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,6 +66,7 @@ All notable changes to this project are documented in this file.
 - Fix ``Equals()`` of ``ByteArray``
 - Fix max recursion depth exception when counting certain VM StackItems that point to themselves
 - Fix ``RIGHT`` opcode for 0 count edge case
+- Fix parsing spaces
 
 
 [0.8.4] 2019-02-14

--- a/neo/Implementations/Wallets/peewee/UserWallet.py
+++ b/neo/Implementations/Wallets/peewee/UserWallet.py
@@ -539,7 +539,7 @@ class UserWallet(Wallet):
             print(f"Address    : {addr_str}")
             if verbose:
                 scripthash_le = binascii.hexlify(data['script_hash']).decode()
-                scripthash_be = UInt160(data=data['script_hash']).To0xString();
+                scripthash_be = UInt160(data=data['script_hash']).To0xString()
                 print(f"Public key : {data['public_key']}")
                 print(f"Script hash: {data['script_hash']}")
                 print(f"               little endian: {scripthash_le}")

--- a/neo/Prompt/InputParser.py
+++ b/neo/Prompt/InputParser.py
@@ -11,6 +11,7 @@ class InputParser:
             return command_parts[0], command_parts[1:]
         return None, None
 
+
 def merge_items(command_parts):
     s = 0
     f = 0

--- a/neo/Prompt/InputParser.py
+++ b/neo/Prompt/InputParser.py
@@ -7,12 +7,24 @@ class InputParser:
     def parse_input(self, user_input):
         if len(user_input):
             command_parts = self.parser.parseString(user_input)
-            for n, i in enumerate(command_parts):
-                for x in i:
-                    if x != ']':
-                        break
-                    command_parts[n - 1] = command_parts[n - 1] + i
-                    command_parts.pop(n)
-                    break
+            command_parts = merge_items(command_parts)
             return command_parts[0], command_parts[1:]
         return None, None
+
+def merge_items(command_parts):
+    s = 0
+    f = 0
+    for n, i in enumerate(command_parts):
+        for x in i:
+            if x == '[':
+                s += 1
+            if x == ']':
+                f += 1
+        if s != f:
+            try:
+                command_parts[n] = command_parts[n] + " " + command_parts[n + 1]
+                command_parts.pop(n + 1)
+                merge_items(command_parts)
+            except IndexError:
+                pass
+    return command_parts

--- a/neo/Prompt/test_input_parser.py
+++ b/neo/Prompt/test_input_parser.py
@@ -33,7 +33,7 @@ class TestInputParser(TestCase):
     def test_unmatched_brackets(self):
         command, arguments = self.input_parser.parse_input("this [is \"a simple\" test")
         self.assertEqual(command, "this")
-        self.assertEqual(arguments, ["[is", "\"a simple\"", "test"])
+        self.assertEqual(arguments, ["[is \"a simple\" test"])
 
     def test_unmatched_single_quotes(self):
         command, arguments = self.input_parser.parse_input("this is 'a simple test")
@@ -48,12 +48,12 @@ class TestInputParser(TestCase):
     def test_nested_lists(self):
         command, arguments = self.input_parser.parse_input('sc build_run sc.py False False False 0210 01 2 ["notused",["helloworld"]]')
         self.assertEqual(command, "sc")
-        self.assertEqual(arguments, ['build_run', 'sc.py', 'False', 'False', 'False', '0210', '01', '2', '["notused",["helloworld"]]'])
+        self.assertEqual(arguments, ['build_run', 'sc.py', 'False', 'False', 'False', '0210', '01', '2', '["notused",["helloworld"] ]'])
 
     def test_nested_lists_2(self):
         command, arguments = self.input_parser.parse_input('test ["notused",["helloworld", 1, ["a", 1]]]')
         self.assertEqual(command, "test")
-        self.assertEqual(arguments, ['["notused",["helloworld", 1, ["a", 1]]]'])
+        self.assertEqual(arguments, ['["notused",["helloworld", 1, ["a", 1] ]]'])
 
     def test_python_bytearrays(self):
         command, arguments = self.input_parser.parse_input("testinvoke bytearray(b'S\xefB\xc8\xdf!^\xbeZ|z\xe8\x01\xcb\xc3\xac/\xacI)') b'\xaf\x12\xa8h{\x14\x94\x8b\xc4\xa0\x08\x12\x8aU\nci[\xc1\xa5'")
@@ -64,3 +64,8 @@ class TestInputParser(TestCase):
         command, arguments = self.input_parser.parse_input("testinvoke f8d448b227991cf07cb96a6f9c0322437f1599b9 transfer [bytearray(b'S\xefB\xc8\xdf!^\xbeZ|z\xe8\x01\xcb\xc3\xac/\xacI)'), bytearray(b'\xaf\x12\xa8h{\x14\x94\x8b\xc4\xa0\x08\x12\x8aU\nci[\xc1\xa5'), 1000]")
         self.assertEqual(command, "testinvoke")
         self.assertEqual(arguments, ["f8d448b227991cf07cb96a6f9c0322437f1599b9", "transfer", "[bytearray(b'S\xefB\xc8\xdf!^\xbeZ|z\xe8\x01\xcb\xc3\xac/\xacI)'), bytearray(b'\xaf\x12\xa8h{\x14\x94\x8b\xc4\xa0\x08\x12\x8aU\nci[\xc1\xa5'), 1000]"])
+
+    def test_attribute_spacing(self):
+        command, arguments = self.input_parser.parse_input('wallet send neo Ae7bSUtT5Qvpkh7473q9FsxT4tSv5KK6dt 100 --tx-attr=[{"usage": 0x90,"data":"my brief description"}]')
+        self.assertEqual(command, "wallet")
+        self.assertEqual(arguments, ['send', 'neo', 'Ae7bSUtT5Qvpkh7473q9FsxT4tSv5KK6dt', '100', '--tx-attr=[{"usage": 0x90,"data":"my brief description"}]'])


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Addresses https://github.com/CityOfZion/neo-python/issues/1009 (see `test_attribute_spacing`)

**How did you solve this problem?**
The input parser now merges strings until the count of "[" matches "]" or there is an `IndexError` (e.g. parsing a bytearray).

NOTE:
- results in an extra space when parsing nested lists (i.e. ] ]]), which is still processed correctly
- results in one string for an unmatched bracket, which is still acceptable

(see tests for examples)

**How did you make sure your solution works?**
unittest and manual testing in privatenet

**Are there any special changes in the code that we should be aware of?**
No

**Please check the following, if applicable:**

- [x] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
