### PR TITLE
np-api-server auto exit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog
 
 All notable changes to this project are documented in this file.
 
+[0.9.2] In progress
+-------------------
+- Fix automatic shutdown when initializing np-api-server and setting minpeers/maxpeers or opening a wallet
+
+
 [0.9.1] 2019-09-16 
 ------------------
 - Reformat wallet verbose output to include big-endian scripthash
@@ -10,7 +15,6 @@ All notable changes to this project are documented in this file.
 - Update Python requirements
 - Fix Docker configuration pip issue
 - Fix parsing prompt command arguments that include spaces (e.g. `description` tx attributes)
-- Fix automatic shutdown when initializing np-api-server and setting minpeers/maxpeers and opening a wallet
 
 
 [0.9.0] 2019-08-21

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 
 [0.9.2] In progress
 -------------------
-- Fix automatic shutdown when initializing np-api-server and setting minpeers/maxpeers or opening a wallet
+- Fix shutdown operations when initializing np-api-server and setting minpeers/maxpeers, opening a wallet, or changing databases
 
 
 [0.9.1] 2019-09-16 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 - Update Python requirements
 - Fix Docker configuration pip issue
 - Fix parsing prompt command arguments that include spaces (e.g. `description` tx attributes)
+- Fix automatic shutdown when initializing np-api-server and setting minpeers/maxpeers and opening a wallet
 
 
 [0.9.0] 2019-08-21

--- a/neo/Prompt/PromptData.py
+++ b/neo/Prompt/PromptData.py
@@ -14,5 +14,5 @@ class PromptData:
         Blockchain.Default().PersistCompleted.on_change -= PromptData.Wallet.ProcessNewBlock
         PromptData.Wallet.Close()
         PromptData.Wallet = None
-        print("Closed wallet %s" % path)
+        print(f"Closed wallet {path}")
         return True

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -327,7 +327,9 @@ def main():
 
     wallet = main_task.result()
     if wallet:
+        path = wallet._path
         wallet.Close()
+        logger.info(f"Closed wallet {path}")
 
 
 if __name__ == "__main__":

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -44,7 +44,7 @@ from neo.Implementations.Notifications.NotificationDB import NotificationDB
 from neo.Wallets.utils import to_aes_key
 from neo.Implementations.Wallets.peewee.UserWallet import UserWallet
 from neo.Network.p2pservice import NetworkService
-from neo.Settings import settings
+from neo.Settings import settings, PrivnetConnectionError
 from neo.Utils.plugin import load_class_from_path
 from neo.Wallets.utils import to_aes_key
 from contextlib import suppress
@@ -152,7 +152,11 @@ async def setup_and_start(loop):
     elif args.testnet:
         settings.setup_testnet()
     elif args.privnet:
-        settings.setup_privnet()
+        try:
+            settings.setup_privnet()
+        except PrivnetConnectionError as e:
+            print(e)
+            raise SystemExit
     elif args.coznet:
         settings.setup_coznet()
 

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -269,7 +269,7 @@ async def setup_and_start(loop):
             sys.exit()
         api_server_rpc = rpc_class(wallet=wallet)
 
-        runner = web.AppRunner(api_server_rpc.app)
+        runner = web.AppRunner(api_server_rpc.app, handle_signals=True)
         await runner.setup()
         site = web.TCPSite(runner, args.host, args.port_rpc)
         await site.start()
@@ -282,7 +282,7 @@ async def setup_and_start(loop):
             logger.error(err)
             sys.exit()
         api_server_rest = rest_api()
-        runner = web.AppRunner(api_server_rest.app)
+        runner = web.AppRunner(api_server_rpc.app, handle_signals=True)
         await runner.setup()
         site = web.TCPSite(runner, args.host, args.port_rpc)
         await site.start()

--- a/neo/bin/api_server.py
+++ b/neo/bin/api_server.py
@@ -180,21 +180,21 @@ async def setup_and_start(loop):
     if minpeers and maxpeers:
         if minpeers > maxpeers:
             print("minpeers setting cannot be bigger than maxpeers setting")
-            return
+            raise SystemExit
         if not set_min_peers(minpeers) or not set_max_peers(maxpeers):
-            return
+            raise SystemExit
     elif minpeers:
         if not set_min_peers(minpeers):
-            return
+            raise SystemExit
         if minpeers > settings.CONNECTED_PEER_MAX:
             if not set_max_peers(minpeers):
-                return
+                raise SystemExit
     elif maxpeers:
         if not set_max_peers(maxpeers):
-            return
+            raise SystemExit
         if maxpeers < settings.CONNECTED_PEER_MIN:
             if not set_min_peers(maxpeers):
-                return
+                raise SystemExit
 
     if args.syslog or args.syslog_local is not None:
         # Setup the syslog facility
@@ -223,7 +223,7 @@ async def setup_and_start(loop):
     if args.wallet:
         if not os.path.exists(args.wallet):
             print("Wallet file not found")
-            return
+            raise SystemExit
 
         passwd = os.environ.get('NEO_PYTHON_JSONRPC_WALLET_PASSWORD', None)
         if not passwd:
@@ -231,7 +231,7 @@ async def setup_and_start(loop):
                 passwd = prompt("[password]> ", is_password=True)
             except KeyboardInterrupt:
                 print("Wallet opening cancelled")
-                return
+                raise SystemExit
 
         password_key = to_aes_key(passwd)
         try:
@@ -240,7 +240,7 @@ async def setup_and_start(loop):
 
         except Exception as e:
             print(f"Could not open wallet {e}")
-            return
+            raise SystemExit
     else:
         wallet = None
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Partially addresses https://github.com/CityOfZion/neo-python/issues/1020, specifically issues 1-3. Now, the program will automatically exit whenever an issue arises when opening a wallet or setting minpeers/maxpeers.

I haven't figured out how to solve issue 4 from https://github.com/CityOfZion/neo-python/issues/1020.

(-edit-) All issues from https://github.com/CityOfZion/neo-python/issues/1020 have been addressed thanks to input from @ixje 

**How did you solve this problem?**
I replaced applicable instances of `return` with `raise SystemExit` which had precedence for issues setting `port-rpc` and `port-rest`.

**How did you make sure your solution works?**
Manual testing

**Are there any special changes in the code that we should be aware of?**
No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
