### PR TITLE
Updating development version 

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -2,37 +2,35 @@
 Overview
 ========
 
-What does it currently do
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Neo-python is an implementation of the Neo protocol using Python. 
 
-- This project aims to be a full port of the original C# `NEO project <https://github.com/neo-project>`_
-- Run a Python based P2P node
-- Interactive CLI for configuring node and inspecting blockchain
-- Compile, test, deploy and run Smart Contracts written in python or any Smart Contract in the ``.avm`` format
-- `NEP2 <https://github.com/neo-project/proposals/blob/master/nep-2.mediawiki>`_ and `NEP5 <https://github.com/neo-project/proposals/blob/master/nep-5.mediawiki>`_ compliant wallet functionality
-- RPC Client
-- RPC server
-- Notification Server ( for viewing transfers of NEP5 tokens )
-- ``Runtime.Log`` and ``Runtime.Notify`` event monitoring
 
-What will it do
-^^^^^^^^^^^^^^^
+What it currently does
+^^^^^^^^^^^^^^^^^^^^^^
 
-- Consensus nodes
-- Full smart contract debugging and inspection
+- A Command Line Interface (CLI) for node configuration and blockchain inspection.
+- Smart Contracts development tool using `neo-boa <https://github.com/CityOfZion/neo-boa>`_, debugging and deployment using the command line.
+- `RPC Client <https://github.com/CityOfZion/neo-python-rpc>`_ and RPC Server.
+- Notification server with optional REST endpoints (for viewing transfers of NEP5 tokens).
+- ``Runtime.Log`` and ``Runtime.Notify`` event monitoring.
+- `NEP2 <https://github.com/neo-project/proposals/blob/master/nep-2.mediawiki>`_ and `NEP5 <https://github.com/neo-project/proposals/blob/master/nep-5.mediawiki>`_ compliant wallet.
+-  This project aimed to be an alternative implementation for the original C# `NEO
+   project <https://github.com/neo-project>`_.
+
+
+Neo 3
+^^^^^
+Our current focus is on Neo 3, with neo-python (Neo 2) only receiving the necessary bug fixes.
 
 
 Getting started
 ^^^^^^^^^^^^^^^
-Please follow directions in `the install section <install.html>`_
+Please follow directions in `the install section <install.html>`_.
 
-The main functionality for this project is contained within the cli application ``np-prompt``.  You can `view usage details here <prompt.html>`_
-
-We have published a Youtube `video <https://youtu.be/oy6Z_zd42-4>`_ to help get you started with this library. There are other videos under the `CityOfZion <(https://www.youtube.com/channel/UCzlQUNLrRa8qJkz40G91iJg>`_ Youtube channel.
+The main functionality for this project is contained within the cli application ``np-prompt``.  You can `view usage details here <prompt.html>`_.
 
 
-Sister projects
-^^^^^^^^^^^^^^^
+Watch this `video <https://youtu.be/oy6Z_zd42-4>`_ to help get you started.  
 
-- `neo-python-rpc <https://github.com/CityOfZion/neo-python-rpc>`_: NEO RPC client in Python
-- `neo-boa <https://github.com/CityOfZion/neo-boa>`_: Write smart contracts with Python
+Visit `CityOfZion <https://www.youtube.com/channel/UCzlQUNLrRa8qJkz40G91iJg>`_ for more video tutorials.
+


### PR DESCRIPTION
Updating development version because the documentation link is pointing to development, not to master branch, where changes were made.

@ixje, the documentation website directs to the information in the development branch. Should we leave it like this? Or should we change it?


**What current issue(s) does this address, or what feature is it adding?**
The documentation is using the development version (branch)

**How did you solve this problem?**
I want to send the changes to the development branch

**How did you make sure your solution works?**

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [ ] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [ ] Did you add an entry to `CHANGELOG.rst`? (if not, please do)

