### PR TITLE
Minor update to network recovery

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ All notable changes to this project are documented in this file.
 [0.9.2] In progress
 -------------------
 - Fix shutdown operations when initializing np-api-server and setting minpeers/maxpeers, opening a wallet, or changing databases
-
+- Minor improvement to network recovery logic when running out of good node addresses
 
 [0.9.1] 2019-09-16 
 ------------------

--- a/neo/Network/nodemanager.py
+++ b/neo/Network/nodemanager.py
@@ -2,6 +2,7 @@ import asyncio
 import socket
 import traceback
 import errno
+import random
 from contextlib import suppress
 from datetime import datetime
 from functools import partial
@@ -140,6 +141,7 @@ class NodeManager(Singleton):
                             # we have no other option then to retry any address we know
                             logger.debug("Recycling old addresses")
                             self.known_addresses = self.bad_addresses
+                            random.shuffle(self.known_addresses)
                             self.bad_addresses = []
                             self.MAX_NODE_POOL_ERROR_COUNT = 0
 


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
A recent discussion on slack showed that an edge case can exist in which `neo-python` runs out of node address to fill our desired connection slots and cannot recover. In such a scenario `neo-python` recycles all addresses it ever learned over the network (both bad and good) and tries to find a working node. There is a threshold on how long it tries before recycling again. This threshold is time based, not address list exhaustive. The recycling logic always produces the same list, therefore if the first `n` addresses in the list are bad, we can hit the time threshold and recycle before finding a good node.   

**How did you solve this problem?**
We randomize the addresses just after recycling them. This should eventually result in being able to restore.

**How did you make sure your solution works?**

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [ ] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
