### PR TITLE
fix NEP-5 query eventhub exception

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ All notable changes to this project are documented in this file.
 -------------------
 - Fix shutdown operations when initializing np-api-server and setting minpeers/maxpeers, opening a wallet, or changing databases
 - Minor improvement to network recovery logic when running out of good node addresses
+- Fix NEP-5 contract detection causing an EventHub exception due to wrong ApplicationEngine initialization
 
 [0.9.1] 2019-09-16 
 ------------------

--- a/neo/Wallets/NEP5Token.py
+++ b/neo/Wallets/NEP5Token.py
@@ -7,6 +7,7 @@ from neo.Core.Fixed8 import Fixed8
 from neo.Prompt.Commands.Invoke import TestInvokeContract, test_invoke
 from neo.Prompt import Utils as PromptUtils
 from neo.Core.UInt160 import UInt160
+from neo.Core.TX import Transaction
 from neo.VM.ScriptBuilder import ScriptBuilder
 from neo.SmartContract.ApplicationEngine import ApplicationEngine
 from neo.Core.Mixins import SerializableMixin
@@ -97,8 +98,9 @@ class NEP5Token(VerificationCode, SerializableMixin):
 
         snapshot = GetBlockchain().Default()._db.createSnapshot().Clone()
         engine = None
+        fake_tx = Transaction.Transaction()
         try:
-            engine = ApplicationEngine.Run(snapshot, sb.ToArray(), exit_on_error=True, gas=Fixed8.FromDecimal(10.0), test_mode=False)
+            engine = ApplicationEngine.Run(snapshot, sb.ToArray(), container=fake_tx, exit_on_error=True, gas=Fixed8.FromDecimal(10.0), test_mode=False)
         except Exception as e:
             traceback.print_exc()
             pass


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
Discord user Marcello#6271 reported an error where an exception is thrown upon contract deployment. Specifically
```python
Traceback (most recent call last):
  File "/home/marcello/neoproject/venv/lib/python3.7/site-packages/neo/Wallets/NEP5Token.py", line 101, in Query
    engine = ApplicationEngine.Run(snapshot, sb.ToArray(), exit_on_error=True, gas=Fixed8.FromDecimal(10.0), test_mode=False)
  File "/home/marcello/neoproject/venv/lib/python3.7/site-packages/neo/SmartContract/ApplicationEngine.py", line 201, in Run
    events.emit(event.event_type, event)
  File "/home/marcello/neoproject/venv/lib/python3.7/site-packages/pymitter/init.py", line 282, in emit
    remove = [l for l in listeners if not l(args, **kwargs)]
  File "/home/marcello/neoproject/venv/lib/python3.7/site-packages/pymitter/init.py", line 282, in <listcomp>
    remove = [l for l in listeners if not l(args, kwargs)]
  File "/home/marcello/neoproject/venv/lib/python3.7/site-packages/pymitter/init.py", line 310, in call
    self.func(*args, kwargs)
  File "/home/marcello/neoproject/venv/lib/python3.7/site-packages/neo/EventHub.py", line 62, in on_sc_event
    logger.info("[%s][%s] [%s] [tx %s] %s" % (sc_event.event_type, sc_event.block_number, sc_event.contract_hash, sc_event.tx_hash.ToString(), payload.ToJson(auto_hex=False)))
AttributeError: 'NoneType' object has no attribute 'ToString'
```

Upon investigation I found that when a contract is deployed, neo-python tries to determine if the contract is a NEP-5 contract. It does this by running the VM and trying to query known methods of a nep-5 contract. This query mechanism runs the VM without setting up a container (Transaction) that the query is ran from. In a normal case VM execution is always triggered from a invocation transaction so this error would not occur.

**How did you solve this problem?**
fix initialization of the VM for NEP-5 queries by using a fake/empty TX as container

**How did you make sure your solution works?**
manually reproduced the issue before and after the fix

**Are there any special changes in the code that we should be aware of?**

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
