### PR TITLE
Hide contract script in search results for compactness/easier reading

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Fix shutdown operations when initializing np-api-server and setting minpeers/maxpeers, opening a wallet, or changing databases
 - Minor improvement to network recovery logic when running out of good node addresses
 - Fix NEP-5 contract detection causing an EventHub exception due to wrong ApplicationEngine initialization
+- Hide contract script in `search contract` output for easier reading of search results
 
 [0.9.1] 2019-09-16 
 ------------------

--- a/neo/Core/FunctionCode.py
+++ b/neo/Core/FunctionCode.py
@@ -89,7 +89,7 @@ class FunctionCode(SerializableMixin):
         writer.WriteVarBytes(self.ParameterList)
         writer.WriteByte(self.ReturnType)
 
-    def ToJson(self):
+    def ToJson(self, verbose=True):
         """
         Convert object members to a dictionary that can be parsed as JSON.
 
@@ -98,9 +98,14 @@ class FunctionCode(SerializableMixin):
         """
         parameters = self.ParameterList.hex()
         paramlist = [ToName(ContractParameterType.FromString(parameters[i:i + 2]).value) for i in range(0, len(parameters), 2)]
+        if verbose:
+            return {
+                'hash': self.ScriptHash().To0xString(),
+                'script': self.Script.hex(),
+                'parameters': paramlist,
+                'returntype': ToName(self.ReturnType) if type(self.ReturnType) is int else ToName(int(self.ReturnType))
+            }
         return {
             'hash': self.ScriptHash().To0xString(),
-            'script': self.Script.hex(),
-            'parameters': paramlist,
-            'returntype': ToName(self.ReturnType) if type(self.ReturnType) is int else ToName(int(self.ReturnType))
         }
+

--- a/neo/Core/FunctionCode.py
+++ b/neo/Core/FunctionCode.py
@@ -108,4 +108,3 @@ class FunctionCode(SerializableMixin):
         return {
             'hash': self.ScriptHash().To0xString(),
         }
-

--- a/neo/Core/State/ContractState.py
+++ b/neo/Core/State/ContractState.py
@@ -169,7 +169,7 @@ class ContractState(StateBase):
             self._is_nep5 = True
         return self._is_nep5
 
-    def ToJson(self):
+    def ToJson(self, verbose=True):
         """
         Convert object members to a dictionary that can be parsed as JSON.
 
@@ -185,7 +185,7 @@ class ContractState(StateBase):
 
         jsn = {'version': self.StateVersion}
 
-        jsn_code = self.Code.ToJson()
+        jsn_code = self.Code.ToJson(verbose=verbose)
 
         jsn_contract = {
             'name': name,
@@ -199,7 +199,6 @@ class ContractState(StateBase):
                 'payable': self.Payable
             }
         }
-
         jsn.update(jsn_code)
         jsn.update(jsn_contract)
 

--- a/neo/Prompt/Commands/Search.py
+++ b/neo/Prompt/Commands/Search.py
@@ -64,7 +64,7 @@ class CommandSearchContract(CommandBase):
             contracts = Blockchain.Default().SearchContracts(query=item)
             print("Found %s results for %s" % (len(contracts), item))
             for contract in contracts:
-                print(json.dumps(contract.ToJson(), indent=4))
+                print(json.dumps(contract.ToJson(verbose=False), indent=4))
             return contracts
         else:
             print("run `%s %s help` to see supported queries" % (CommandSearch().command_desc().command, self.command_desc().command))


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**

Searching the chain for contracts is problematic because the hex script for every matching contract is shown in the search output. Generally when searching, the goal is trying to locate a specific scripthash rather than dump every contract's lengthy script in hex.

**How did you solve this problem?**

By hiding the contract script output in the search results. `show contract` can still be used to acquire the script hex of a contract, so no functionality is lost.

**How did you make sure your solution works?**

Manual testing.

**Are there any special changes in the code that we should be aware of?**

No.

**Please check the following, if applicable:**

- [ ] Did you add any tests?
- [X] Did you run `make lint`?
- [X] Did you run `make test`?
- [X] Are you making a PR to a feature branch or development rather than master?
- [X] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
