### PR TITLE
Fix to the syntax warnings caused by comparing literals

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ All notable changes to this project are documented in this file.
 - Fix shutdown operations when initializing np-api-server and setting minpeers/maxpeers, opening a wallet, or changing databases
 - Minor improvement to network recovery logic when running out of good node addresses
 - Fix NEP-5 contract detection causing an EventHub exception due to wrong ApplicationEngine initialization
+- Fix syntax warnings caused by comparing literals with ``is not``, instead of ``!=``
 
 [0.9.1] 2019-09-16 
 ------------------

--- a/neo/Core/Cryptography/ECCurve.py
+++ b/neo/Core/Cryptography/ECCurve.py
@@ -707,7 +707,7 @@ class EllipticCurve:
             ysquare_root = None
 
         bit0 = 0
-        if ysquare_root % 2 is not 0:
+        if ysquare_root % 2 != 0:
             bit0 = 1
 
         if bit0 != flag:

--- a/neo/Core/KeyPair.py
+++ b/neo/Core/KeyPair.py
@@ -96,14 +96,14 @@ class KeyPair(object):
                 if the input `wif` has an invalid format
                 if the input `wif` has an invalid checksum
         """
-        if wif is None or len(wif) is not 52:
+        if wif is None or len(wif) != 52:
             raise ValueError('Please provide a wif with a length of 52 bytes (LEN: {0:d})'.format(len(wif)))
 
         data = base58.b58decode(wif)
 
         length = len(data)
 
-        if length is not 38 or data[0] is not 0x80 or data[33] is not 0x01:
+        if length != 38 or data[0] != 0x80 or data[33] != 0x01:
             raise ValueError("Invalid format!")
 
         checksum = Crypto.Hash256(data[0:34])[0:4]


### PR DESCRIPTION
**What current issue(s) does this address, or what feature is it adding?**
There are 5 syntax warnings in 2 files in the current code. Warnings appear when neo-python is installed as a library in a separate project.

`SyntaxWarning: "is not" with a literal. Did you mean "!="?`

**How did you solve this problem?**
Replaced them with `!=` which is the proper way to compare literals.

**How did you make sure your solution works?**
It doesn't raise syntax warning anymore. 

**Are there any special changes in the code that we should be aware of?**
no

**Please check the following, if applicable:**

- [ ] Did you add any tests?  n/a
- [x] Did you run `make lint`?
- [x] Did you run `make test`?
- [x] Are you making a PR to a feature branch or development rather than master?
- [x] Did you add an entry to `CHANGELOG.rst`? (if not, please do)
